### PR TITLE
feat(bible): add book_id and chapter_number to highlights

### DIFF
--- a/packages/backend-base/src/bible/dto/highlight/create-highlight.dto.ts
+++ b/packages/backend-base/src/bible/dto/highlight/create-highlight.dto.ts
@@ -4,6 +4,8 @@ import { type Static, t } from "elysia";
 export const CreateHighlightDto = t.Object({
   user_id: t.String(),
   chapter_id: t.Number(),
+  book_id: t.Number(),
+  chapter_number: t.Number(),
   start_verse: t.Number(),
   end_verse: t.Number(),
   color: t.Optional(t.Enum(HighlightColorEnum)),

--- a/packages/backend-base/src/bible/repository/bible.repository.ts
+++ b/packages/backend-base/src/bible/repository/bible.repository.ts
@@ -1064,6 +1064,8 @@ export class BibleRepository {
   async addHighlight({
     user_id,
     chapter_id,
+    book_id,
+    chapter_number,
     start_verse,
     end_verse,
     color = "yellow" as HighlightColorEnum,
@@ -1120,6 +1122,8 @@ export class BibleRepository {
       const newHighlight: NewVerseHighlights = {
         user_id,
         chapter_id,
+        book_id,
+        chapter_number,
         start_verse,
         end_verse,
         color,

--- a/packages/backend-base/src/bible/schemas/bible-response.schema.ts
+++ b/packages/backend-base/src/bible/schemas/bible-response.schema.ts
@@ -287,6 +287,8 @@ const HighlightResponseType = t.Object({
   highlight_id: t.Number(),
   user_id: t.String(), // UUID
   chapter_id: t.Number(),
+  book_id: t.Number(),
+  chapter_number: t.Number(),
   start_verse: t.Number(),
   end_verse: t.Number(),
   color: HighlightColorEnum,

--- a/packages/backend-base/src/bible/services/bible.service.ts
+++ b/packages/backend-base/src/bible/services/bible.service.ts
@@ -551,6 +551,8 @@ export class BibleService {
     const { highlight, success } = await this.bibleRepository.addHighlight({
       user_id,
       chapter_id,
+      book_id,
+      chapter_number,
       start_verse,
       end_verse,
       color,

--- a/packages/database/migrations/20251116232541-new-migration.ts
+++ b/packages/database/migrations/20251116232541-new-migration.ts
@@ -1,0 +1,59 @@
+import { type Kysely, sql } from "kysely";
+
+import type Database from "../src/models/Database";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  // Add book_id and chapter_number columns to verse_highlights table
+  await db.schema
+    .alterTable("verse_highlights")
+    .addColumn("book_id", "integer")
+    .execute();
+
+  await db.schema
+    .alterTable("verse_highlights")
+    .addColumn("chapter_number", "integer")
+    .execute();
+
+  // Backfill book_id and chapter_number from chapters table using chapter_id foreign key
+  await sql`
+    UPDATE verse_highlights vh
+    SET book_id = c.book_id,
+        chapter_number = c.chapter_number
+    FROM chapters c
+    WHERE vh.chapter_id = c.chapter_id
+  `.execute(db);
+
+  // Add NOT NULL constraints after backfill
+  await db.schema
+    .alterTable("verse_highlights")
+    .alterColumn("book_id", (col) => col.setNotNull())
+    .execute();
+
+  await db.schema
+    .alterTable("verse_highlights")
+    .alterColumn("chapter_number", (col) => col.setNotNull())
+    .execute();
+
+  // Add index for efficient querying by book_id and chapter_number
+  await db.schema
+    .createIndex("idx_verse_highlights_book_chapter")
+    .on("verse_highlights")
+    .columns(["book_id", "chapter_number"])
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  // Drop index
+  await db.schema.dropIndex("idx_verse_highlights_book_chapter").execute();
+
+  // Drop columns
+  await db.schema
+    .alterTable("verse_highlights")
+    .dropColumn("book_id")
+    .execute();
+
+  await db.schema
+    .alterTable("verse_highlights")
+    .dropColumn("chapter_number")
+    .execute();
+}

--- a/packages/database/src/models/public/PublicSchema.ts
+++ b/packages/database/src/models/public/PublicSchema.ts
@@ -86,8 +86,6 @@ export default interface PublicSchema {
 
   notes: NotesTable;
 
-  refresh_tokens: RefreshTokensTable;
-
   highlight_themes: HighlightThemesTable;
 
   auto_highlights: AutoHighlightsTable;
@@ -95,4 +93,6 @@ export default interface PublicSchema {
   user_theme_preferences: UserThemePreferencesTable;
 
   auto_highlight_settings: AutoHighlightSettingsTable;
+
+  refresh_tokens: RefreshTokensTable;
 }

--- a/packages/database/src/models/public/VerseHighlights.ts
+++ b/packages/database/src/models/public/VerseHighlights.ts
@@ -51,6 +51,10 @@ export default interface VerseHighlightsTable {
     Date | string | null,
     Date | string | null
   >;
+
+  book_id: ColumnType<number, number, number>;
+
+  chapter_number: ColumnType<number, number, number>;
 }
 
 export type VerseHighlights = Selectable<VerseHighlightsTable>;


### PR DESCRIPTION
- Add book_id and chapter_number fields to CreateHighlightDto schema
- Update BibleRepository addHighlight method to handle new fields
- Extend HighlightResponseType schema with book_id and chapter_number
- Modify BibleService to pass book_id and chapter_number when adding highlights
- Create new migration to add book_id and chapter_number columns to verse_highlights table
- Backfill new columns using chapters table data and add not null constraints
- Add index on book_id and chapter_number for performance improvements