### PR TITLE
chore: configure PostHog analytics for all environments

### DIFF
--- a/apps/frontend-next/wrangler.jsonc
+++ b/apps/frontend-next/wrangler.jsonc
@@ -15,7 +15,10 @@
   "vars": {
     "API_URL": "https://api.verse-mate.apegro.dev",
     "APP_URL": "https://verse-mate.xyz",
-    "NEXT_PUBLIC_ASK_VERSE_MATE": "false"
+    "NEXT_PUBLIC_ASK_VERSE_MATE": "false",
+    "POSTHOG_KEY": "phc_UhHXkLHgiD6916hYZgaKy9pjOOlZi9sTRic3RhWWLRC",
+    "POSTHOG_HOST": "https://us.i.posthog.com",
+    "POSTHOG_SESSION_REPLAY": "false"
   },
 
   // Custom domain routes
@@ -68,7 +71,10 @@
       "vars": {
         "API_URL": "https://api.verse-mate.apegro.dev",
         "APP_URL": "https://v-m-preview-app.verse-mate.workers.dev",
-        "NEXT_PUBLIC_ASK_VERSE_MATE": "false"
+        "NEXT_PUBLIC_ASK_VERSE_MATE": "false",
+        "POSTHOG_KEY": "phc_UhHXkLHgiD6916hYZgaKy9pjOOlZi9sTRic3RhWWLRC",
+        "POSTHOG_HOST": "https://us.i.posthog.com",
+        "POSTHOG_SESSION_REPLAY": "false"
       }
     },
     "staging": {
@@ -76,7 +82,10 @@
       "vars": {
         "API_URL": "https://api.verse-mate.apegro.dev",
         "APP_URL": "https://staging.app.verse-mate.xyz",
-        "NEXT_PUBLIC_ASK_VERSE_MATE": "false"
+        "NEXT_PUBLIC_ASK_VERSE_MATE": "false",
+        "POSTHOG_KEY": "phc_UhHXkLHgiD6916hYZgaKy9pjOOlZi9sTRic3RhWWLRC",
+        "POSTHOG_HOST": "https://us.i.posthog.com",
+        "POSTHOG_SESSION_REPLAY": "false"
       },
       "routes": [
         {
@@ -90,7 +99,10 @@
       "vars": {
         "API_URL": "https://api.verse-mate.apegro.dev",
         "APP_URL": "https://app.versemate.org",
-        "NEXT_PUBLIC_ASK_VERSE_MATE": "false"
+        "NEXT_PUBLIC_ASK_VERSE_MATE": "false",
+        "POSTHOG_KEY": "phc_UhHXkLHgiD6916hYZgaKy9pjOOlZi9sTRic3RhWWLRC",
+        "POSTHOG_HOST": "https://us.i.posthog.com",
+        "POSTHOG_SESSION_REPLAY": "true"
       },
       "routes": [
         {


### PR DESCRIPTION
Add PostHog configuration to wrangler.jsonc:
- Add POSTHOG_KEY, POSTHOG_HOST, and POSTHOG_SESSION_REPLAY vars
- Configure for default, preview, staging, and production environments
- Session replay enabled only in production environment
- Using US cloud region (us.i.posthog.com)