### PR TITLE
fix: use backend API URL for SSO redirects instead of local routes

### DIFF
--- a/packages/frontend-base/src/auth/SSOButtons/SSOButtons.test.ts
+++ b/packages/frontend-base/src/auth/SSOButtons/SSOButtons.test.ts
@@ -209,13 +209,13 @@ describe("SSO Components Structure", () => {
 });
 
 describe("SSO Integration Points", () => {
-  it("should have correct redirect URLs defined", () => {
-    // These are the expected OAuth redirect endpoints
-    const googleRedirectUrl = "/api/auth/sso/google/redirect";
-    const appleRedirectUrl = "/api/auth/sso/apple/redirect";
+  it("should have correct redirect URL paths defined", () => {
+    // These are the expected OAuth redirect endpoint paths (appended to backend API URL)
+    const googleRedirectPath = "/auth/sso/google/redirect";
+    const appleRedirectPath = "/auth/sso/apple/redirect";
 
-    expect(googleRedirectUrl).toBe("/api/auth/sso/google/redirect");
-    expect(appleRedirectUrl).toBe("/api/auth/sso/apple/redirect");
+    expect(googleRedirectPath).toBe("/auth/sso/google/redirect");
+    expect(appleRedirectPath).toBe("/auth/sso/apple/redirect");
   });
 
   it("should define SSO button labels according to brand guidelines", () => {

--- a/packages/frontend-base/src/auth/SignIn/index.tsx
+++ b/packages/frontend-base/src/auth/SignIn/index.tsx
@@ -21,8 +21,8 @@ export interface SignInProps {
 }
 
 export function SignIn({ onSwitch }: SignInProps) {
-  const { ssoGoogleEnabled, ssoAppleEnabled } = useStore($env, {
-    keys: ["ssoGoogleEnabled", "ssoAppleEnabled"],
+  const { ssoGoogleEnabled, ssoAppleEnabled, apiUrl } = useStore($env, {
+    keys: ["ssoGoogleEnabled", "ssoAppleEnabled", "apiUrl"],
   });
   const {
     hookForm: { register, formState },
@@ -84,9 +84,9 @@ export function SignIn({ onSwitch }: SignInProps) {
         }
       }
     }
-    // Redirect to Google OAuth endpoint
-    window.location.href = "/api/auth/sso/google/redirect";
-  }, []);
+    // Redirect to Google OAuth endpoint on backend
+    window.location.href = `${apiUrl}/auth/sso/google/redirect`;
+  }, [apiUrl]);
 
   const handleAppleClick = useCallback(() => {
     setSsoLoading(true);
@@ -101,9 +101,9 @@ export function SignIn({ onSwitch }: SignInProps) {
         }
       }
     }
-    // Redirect to Apple OAuth endpoint
-    window.location.href = "/api/auth/sso/apple/redirect";
-  }, []);
+    // Redirect to Apple OAuth endpoint on backend
+    window.location.href = `${apiUrl}/auth/sso/apple/redirect`;
+  }, [apiUrl]);
 
   // Determine if error is SSO-related for custom action suggestion
   const errorIsSSORelated = backendError && isSSOError(backendError);

--- a/packages/frontend-base/src/auth/SignUp/index.tsx
+++ b/packages/frontend-base/src/auth/SignUp/index.tsx
@@ -22,8 +22,8 @@ export interface SignUpProps {
 }
 
 export function SignUp({ onSwitch }: SignUpProps) {
-  const { ssoGoogleEnabled, ssoAppleEnabled } = useStore($env, {
-    keys: ["ssoGoogleEnabled", "ssoAppleEnabled"],
+  const { ssoGoogleEnabled, ssoAppleEnabled, apiUrl } = useStore($env, {
+    keys: ["ssoGoogleEnabled", "ssoAppleEnabled", "apiUrl"],
   });
   const {
     hookForm: { register, formState, watch },
@@ -58,9 +58,9 @@ export function SignUp({ onSwitch }: SignUpProps) {
         }
       }
     }
-    // Redirect to Google OAuth endpoint
-    window.location.href = "/api/auth/sso/google/redirect";
-  }, []);
+    // Redirect to Google OAuth endpoint on backend
+    window.location.href = `${apiUrl}/auth/sso/google/redirect`;
+  }, [apiUrl]);
 
   const handleAppleClick = useCallback(() => {
     setSsoLoading(true);
@@ -79,9 +79,9 @@ export function SignUp({ onSwitch }: SignUpProps) {
         }
       }
     }
-    // Redirect to Apple OAuth endpoint
-    window.location.href = "/api/auth/sso/apple/redirect";
-  }, []);
+    // Redirect to Apple OAuth endpoint on backend
+    window.location.href = `${apiUrl}/auth/sso/apple/redirect`;
+  }, [apiUrl]);
 
   // Determine if error is SSO-related for custom action suggestion
   const errorIsSSORelated = backendError && isSSOError(backendError);


### PR DESCRIPTION
SSO redirect was pointing to /api/auth/sso/google/redirect which doesn't exist on the Next.js frontend. Changed to use the apiUrl from env store to redirect directly to the backend OAuth endpoints.
