### PR TITLE
chore: update API URL to api.versemate.org

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -168,7 +168,7 @@ steps:
       - chmod 600 ~/.ssh/id_rsa
       - '[[ -f /.dockerenv ]] && echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config'
       # Deploy
-      - ssh root@verse-mate.apegro.dev "cd ~/verse-mate && docker compose pull && docker compose up -d && docker system prune -a -f"
+      - ssh root@app.versemate.org "cd ~/verse-mate && docker compose pull && docker compose up -d && docker system prune -a -f"
     environment:
       SSH_PRIVATE_KEY:
         from_secret: SSH_PRIVATE_KEY

--- a/apps/frontend-next/next.config.mjs
+++ b/apps/frontend-next/next.config.mjs
@@ -64,7 +64,7 @@ const nextConfig = {
   },
   // Environment variables available at build time
   env: {
-    API_URL: process.env.API_URL || "https://api.verse-mate.apegro.dev",
+    API_URL: process.env.API_URL || "https://api.versemate.org",
     NEXT_PUBLIC_ASK_VERSE_MATE:
       process.env.NEXT_PUBLIC_ASK_VERSE_MATE || "false",
   },

--- a/apps/frontend-next/src/app/bible/[bookId]/[chapterNumber]/lib/fetchChapterData.ts
+++ b/apps/frontend-next/src/app/bible/[bookId]/[chapterNumber]/lib/fetchChapterData.ts
@@ -2,7 +2,7 @@ export async function fetchChapterForPreview(
   bookId: number,
   chapterNumber: number,
 ) {
-  const apiUrl = process.env.API_URL || "https://api.verse-mate.apegro.dev";
+  const apiUrl = process.env.API_URL || "https://api.versemate.org";
 
   try {
     const response = await fetch(

--- a/apps/frontend-next/src/app/topic/[category]/[slug]/page.tsx
+++ b/apps/frontend-next/src/app/topic/[category]/[slug]/page.tsx
@@ -15,7 +15,7 @@ async function getTopicsByCategory(
   bibleVersion = "NASB1995",
 ) {
   try {
-    const baseUrl = process.env.API_URL || "https://api.verse-mate.apegro.dev";
+    const baseUrl = process.env.API_URL || "https://api.versemate.org";
     const response = await fetch(
       `${baseUrl}/topics/search?category=${category}&bible_version=${bibleVersion}`,
       { cache: "no-store" },

--- a/apps/frontend-next/src/lib/utils.ts
+++ b/apps/frontend-next/src/lib/utils.ts
@@ -1,5 +1,5 @@
 export function getUrl(path?: string): string {
-  const baseUrl = process.env.APP_URL || "https://verse-mate.apegro.dev";
+  const baseUrl = process.env.APP_URL || "https://app.versemate.org";
   const normalizedPath =
     path && !path.startsWith("/") ? `/${path}` : path || "";
   return `${baseUrl}${normalizedPath}`;

--- a/apps/frontend-next/wrangler.jsonc
+++ b/apps/frontend-next/wrangler.jsonc
@@ -13,7 +13,7 @@
 
   // Environment variables
   "vars": {
-    "API_URL": "https://api.verse-mate.apegro.dev",
+    "API_URL": "https://api.versemate.org",
     "APP_URL": "https://verse-mate.xyz",
     "NEXT_PUBLIC_ASK_VERSE_MATE": "false",
     "NEXT_PUBLIC_SSO_GOOGLE_ENABLED": "true",
@@ -71,7 +71,7 @@
     "preview": {
       "name": "v-m-preview-app",
       "vars": {
-        "API_URL": "https://api.verse-mate.apegro.dev",
+        "API_URL": "https://api.versemate.org",
         "APP_URL": "https://v-m-preview-app.verse-mate.workers.dev",
         "NEXT_PUBLIC_ASK_VERSE_MATE": "false",
         "NEXT_PUBLIC_SSO_GOOGLE_ENABLED": "true",
@@ -84,7 +84,7 @@
     "staging": {
       "name": "verse-mate-staging-app",
       "vars": {
-        "API_URL": "https://api.verse-mate.apegro.dev",
+        "API_URL": "https://api.versemate.org",
         "APP_URL": "https://staging.app.verse-mate.xyz",
         "NEXT_PUBLIC_ASK_VERSE_MATE": "false",
         "NEXT_PUBLIC_SSO_GOOGLE_ENABLED": "true",
@@ -103,7 +103,7 @@
     "production": {
       "name": "verse-mate-production",
       "vars": {
-        "API_URL": "https://api.verse-mate.apegro.dev",
+        "API_URL": "https://api.versemate.org",
         "APP_URL": "https://app.versemate.org",
         "NEXT_PUBLIC_ASK_VERSE_MATE": "false",
         "NEXT_PUBLIC_SSO_GOOGLE_ENABLED": "true",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,4 +57,4 @@ services:
   #   ports:
   #     - "3000:3000"
   #   environment:
-  #     - API_URL=https://api.verse-mate.apegro.dev
+  #     - API_URL=https://api.versemate.org

--- a/packages/frontend-base/src/utils/sharing.ts
+++ b/packages/frontend-base/src/utils/sharing.ts
@@ -14,7 +14,6 @@ interface ShareablePassageParams {
 // Allowed hosts for security validation
 const ALLOWED_HOSTS = [
   "localhost",
-  "verse-mate.apegro.dev",
   "app.versemate.org",
   "versemate.com", // Add production domain when available
 ];


### PR DESCRIPTION
Replace api.verse-mate.apegro.dev with api.versemate.org across the codebase.