### PR TITLE
Update app store links with full URLs

### DIFF
--- a/apps/website/src/sections/desktop/DownloadApp.tsx
+++ b/apps/website/src/sections/desktop/DownloadApp.tsx
@@ -209,7 +209,7 @@ export default function DownloadAppSection() {
             >
               {/* Frame 8 - App Store Button */}
               <a
-                href="https://apps.apple.com/app/verse-mate"
+                href="https://apps.apple.com/us/app/verse-mate/id6756897180"
                 target="_blank"
                 rel="noopener noreferrer"
                 style={{
@@ -245,7 +245,7 @@ export default function DownloadAppSection() {
 
               {/* Frame 9 - Google Play Button */}
               <a
-                href="https://play.google.com/store/apps/details?id=org.versemate"
+                href="https://play.google.com/store/apps/details?id=org.versemate.app"
                 target="_blank"
                 rel="noopener noreferrer"
                 style={{

--- a/apps/website/src/sections/mobile/MobileDownloadApp.tsx
+++ b/apps/website/src/sections/mobile/MobileDownloadApp.tsx
@@ -196,7 +196,7 @@ export default function MobileDownloadApp() {
           >
             {/* Frame 8 - App Store Button */}
             <a
-              href="https://apps.apple.com/app/verse-mate"
+              href="https://apps.apple.com/us/app/verse-mate/id6756897180"
               target="_blank"
               rel="noopener noreferrer"
               style={{
@@ -232,7 +232,7 @@ export default function MobileDownloadApp() {
 
             {/* Frame 9 - Google Play Button */}
             <a
-              href="https://play.google.com/store/apps/details?id=org.versemate"
+              href="https://play.google.com/store/apps/details?id=org.versemate.app"
               target="_blank"
               rel="noopener noreferrer"
               style={{

--- a/apps/website/src/sections/tablet/DownloadApp.tsx
+++ b/apps/website/src/sections/tablet/DownloadApp.tsx
@@ -237,7 +237,7 @@ export default function DownloadAppSection() {
           >
             {/* Frame 8 - App Store Button */}
             <a
-              href="https://apps.apple.com/app/verse-mate"
+              href="https://apps.apple.com/us/app/verse-mate/id6756897180"
               target="_blank"
               rel="noopener noreferrer"
               style={{
@@ -273,7 +273,7 @@ export default function DownloadAppSection() {
 
             {/* Frame 9 - Google Play Button */}
             <a
-              href="https://play.google.com/store/apps/details?id=org.versemate"
+              href="https://play.google.com/store/apps/details?id=org.versemate.app"
               target="_blank"
               rel="noopener noreferrer"
               style={{


### PR DESCRIPTION
## Summary
- Updated App Store link to include full URL with app ID: `https://apps.apple.com/us/app/verse-mate/id6756897180`
- Updated Google Play link to use correct package identifier: `https://play.google.com/store/apps/details?id=org.versemate.app`

## Changes
- Updated all three responsive versions (desktop, mobile, tablet) of the download-app page with the correct store URLs

## Test plan
- [ ] Verify App Store button redirects to correct app listing
- [ ] Verify Google Play button redirects to correct app listing
- [ ] Test on desktop, tablet, and mobile layouts