### PR TITLE
Fix English topics missing from offline endpoint [patch]

### DIFF
--- a/packages/backend-base/src/offline/offline.repository.ts
+++ b/packages/backend-base/src/offline/offline.repository.ts
@@ -374,11 +374,7 @@ export class OfflineRepository {
           eb("topic_translations.language_code", "=", languageCode),
           // Include originals when requesting English and no translation exists
           eb.and([
-            eb(
-              sql`${sql.lit(languageCode)}`,
-              "in",
-              sql`('en', 'en-US')`,
-            ),
+            eb(sql`${sql.lit(languageCode)}`, "in", sql`('en', 'en-US')`),
             eb("topic_translations.language_code", "is", null),
           ]),
         ]),
@@ -400,8 +396,7 @@ export class OfflineRepository {
       topics: topics.map((t) => ({
         topic_id: t.topic_id,
         name: t.translated_name || t.original_name,
-        content:
-          t.translated_description || t.original_description || "",
+        content: t.translated_description || t.original_description || "",
         language_code: t.translation_language_code || languageCode,
       })),
       references: [],
@@ -415,8 +410,7 @@ export class OfflineRepository {
     const connection = this.db.getOrCreateConnection();
 
     // For English, check the topics table directly since originals are in English
-    const isEnglish =
-      languageCode === "en" || languageCode === "en-US";
+    const isEnglish = languageCode === "en" || languageCode === "en-US";
 
     if (isEnglish) {
       const result = await connection


### PR DESCRIPTION
## Summary
- **Manifest builder**: English topics (stored as originals in `topics` table, not in `topic_translations`) were missing from the offline manifest. Now checks for active topics and includes "en" if not already present from translations.
- **`getAllTopics()`**: Changed from `INNER JOIN` to `LEFT JOIN` on `topic_translations` with fallback to `topics.name`/`topics.description`, matching the pattern used by the search API in `topic.repository.ts`.
- **`getTopicsUpdatedAt()`**: For English requests, now queries `topics.updated_at` directly instead of `topic_translations`.

## Test plan
- [ ] Verify `/offline/manifest` includes English in `topic_languages`
- [ ] Verify `/offline/topics/en` returns English topic data
- [ ] Verify non-English languages (e.g. Ukrainian) still work as before
- [ ] Existing offline service tests pass