### PR TITLE
fix: increase max_completion_tokens to prevent byline truncation (#82)

### DIFF
--- a/packages/backend-base/src/bible/explanation-queue.ts
+++ b/packages/backend-base/src/bible/explanation-queue.ts
@@ -2,6 +2,7 @@ import Queue from "bull";
 import { db } from "database";
 import ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import OpenAI from "openai";
+import { MAX_EXPLANATION_TOKENS } from "./types";
 
 const openai = new OpenAI({
   apiKey: process.env.OPEN_AI_KEY,
@@ -102,7 +103,7 @@ async function gpt5Text({
   const options: any = {
     model: "gpt-5",
     messages,
-    max_completion_tokens: 10000,
+    max_completion_tokens: MAX_EXPLANATION_TOKENS,
   };
 
   const chat = await openai.chat.completions.create(options as any);

--- a/packages/backend-base/src/bible/pregenerate-hebrews.ts
+++ b/packages/backend-base/src/bible/pregenerate-hebrews.ts
@@ -2,6 +2,7 @@ import { db } from "database";
 import ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import OpenAI from "openai";
 import { parseBibleData } from "./bible";
+import { MAX_EXPLANATION_TOKENS } from "./types";
 
 const openai = new OpenAI({
   apiKey: process.env.OPEN_AI_KEY,
@@ -96,7 +97,7 @@ async function gpt5Text({ system, user }: { system?: string; user: string }) {
   const options: any = {
     model: "gpt-5",
     messages,
-    max_completion_tokens: 10000,
+    max_completion_tokens: MAX_EXPLANATION_TOKENS,
   };
 
   const chat = await openai.chat.completions.create(options as any);

--- a/packages/backend-base/src/bible/pregenerate-popular-chapters.ts
+++ b/packages/backend-base/src/bible/pregenerate-popular-chapters.ts
@@ -2,6 +2,7 @@ import { db } from "database";
 import ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import OpenAI from "openai";
 import { parseBibleData } from "./bible";
+import { MAX_EXPLANATION_TOKENS } from "./types";
 
 const openai = new OpenAI({
   apiKey: process.env.OPEN_AI_KEY,
@@ -96,7 +97,7 @@ async function gpt5Text({ system, user }: { system?: string; user: string }) {
   const options: any = {
     model: "gpt-5",
     messages,
-    max_completion_tokens: 10000,
+    max_completion_tokens: MAX_EXPLANATION_TOKENS,
   };
 
   const chat = await openai.chat.completions.create(options as any);

--- a/packages/backend-base/src/bible/types.ts
+++ b/packages/backend-base/src/bible/types.ts
@@ -56,3 +56,10 @@ export type BookMeta = {
   genre: Genre;
   chaptersCount: number;
 };
+
+/**
+ * Maximum tokens for OpenAI explanation generation.
+ * Set high enough to handle the longest chapters (e.g., Psalm 119 with 176 verses).
+ * Each verse in by-line format uses ~100-150 tokens.
+ */
+export const MAX_EXPLANATION_TOKENS = 30000;


### PR DESCRIPTION
## Summary
- By-line view truncated long chapters (e.g., Psalm 119 showed only 24 of 176 verses) because `max_completion_tokens` was set to 10,000
- Increased to 30,000 via a shared `MAX_EXPLANATION_TOKENS` constant across all three generation entry points
- Existing truncated chapters will self-heal on next generation (on-demand or batch re-run)

## Changes
- `packages/backend-base/src/bible/types.ts` — added `MAX_EXPLANATION_TOKENS = 30000` constant
- `packages/backend-base/src/bible/explanation-queue.ts` — use constant
- `packages/backend-base/src/bible/pregenerate-popular-chapters.ts` — use constant
- `packages/backend-base/src/bible/pregenerate-hebrews.ts` — use constant

## Test plan
- [ ] Deploy and trigger re-generation of Psalm 119 byline explanation
- [ ] Verify all 176 verses appear in the by-line view
- [ ] Spot-check other long chapters (Numbers 7, Psalm 78)
- [ ] Verify short chapters still generate correctly

## Follow-up
After merge + deploy, run the pregenerate script for long chapters to regenerate truncated byline explanations stored in the database.

Closes https://github.com/verse-mate/verse-mate-mobile/issues/82