### PR TITLE
VM-164: Fix byline truncation for long chapters (all generation paths)

### DIFF
--- a/packages/backend-base/src/admin/services/admin-prompt.service.ts
+++ b/packages/backend-base/src/admin/services/admin-prompt.service.ts
@@ -4,6 +4,11 @@ import OpenAI from "openai";
 import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { UserPromptRepository } from "../../bible/repository/user-prompt.repository";
 import { ForbiddenError, NotFoundError } from "../../common/errors";
+import {
+  generateChunkedBylineParallel,
+  shouldUseBylineChunking,
+  toBylineVerses,
+} from "../../shared/byline-chunking";
 import type { db } from "../../shared/shared.plugin";
 
 const PROTECTED_PROMPT_IDS = [1, 2, 3];
@@ -207,7 +212,9 @@ export class AdminPromptService {
       finalUserPrompt = this.getUserPrompt({
         explanationPrompt: user_prompt
           .replace("{bookName}", book_name)
-          .replace("{chapterNumber}", chapter_number.toString()),
+          .replace("{chapterNumber}", chapter_number.toString())
+          .replace("{verseRange}", "all verses")
+          .replace("{verseRangeContext}", ""),
         language,
       });
 
@@ -244,6 +251,67 @@ export class AdminPromptService {
           );
         }
         contextText = `\r\n\r\nBiblical Text (${book_name} ${chapter_number}):\r\n${verses.map((v) => `${v.verse_number}. ${v.text}`).join("\n")}`;
+      }
+    }
+
+    // Check if we should use chunked generation for byline on long chapters
+    if (
+      prompt_type === "byline" &&
+      send_chapter_context &&
+      book_name &&
+      chapter_number
+    ) {
+      const book = await connection
+        .selectFrom("books")
+        .where("name", "=", book_name)
+        .select("book_id")
+        .executeTakeFirst();
+
+      if (book) {
+        const chapter = await connection
+          .selectFrom("chapters")
+          .where("book_id", "=", book.book_id)
+          .where("chapter_number", "=", chapter_number)
+          .select("chapter_id")
+          .executeTakeFirst();
+
+        if (chapter) {
+          const verses = await connection
+            .selectFrom("verses")
+            .where("chapter_id", "=", chapter.chapter_id)
+            .where("version_id", "=", version.id)
+            .select(["verse_number", "text"])
+            .orderBy("verse_number", "asc")
+            .execute();
+
+          const verseRows = toBylineVerses(verses);
+
+          if (shouldUseBylineChunking(prompt_type, verseRows.length)) {
+            console.log(
+              `[PLAYGROUND] Using chunked byline for ${book_name} ${chapter_number}: ${verseRows.length} verses`,
+            );
+
+            const result = await generateChunkedBylineParallel({
+              verses: verseRows,
+              bookName: book_name,
+              chapterNumber: chapter_number,
+              bylineTemplate: user_prompt
+                .replace("{bookName}", book_name)
+                .replace("{chapterNumber}", chapter_number.toString()),
+              logPrefix: "[PLAYGROUND_BYLINE]",
+              generateChunk: async ({ prompt }) =>
+                this.gpt5Text({
+                  instructions: system_prompt,
+                  input: prompt,
+                  model,
+                  effort,
+                  max_output_tokens: request.max_output_tokens,
+                }),
+            });
+
+            return { result };
+          }
+        }
       }
     }
 

--- a/packages/backend-base/src/admin/services/batch-operations.service.test.ts
+++ b/packages/backend-base/src/admin/services/batch-operations.service.test.ts
@@ -1,0 +1,537 @@
+import { describe, expect, it } from "bun:test";
+import { stitchBylineChunks } from "../../shared/byline-chunking";
+
+/**
+ * Unit tests for batch operations chunked byline parsing.
+ *
+ * These tests simulate the exact JSONL output format from the OpenAI Batch API
+ * and verify our custom_id regex, chunk collection, and stitching logic.
+ *
+ * The batch response format uses the Responses API (not Chat Completions):
+ *   - output_text for the main text
+ *   - usage.input_tokens / output_tokens
+ */
+
+// --- Helpers ---
+
+const CHUNK_PATTERN =
+  /^(.+)-(\d+)-byline-(\d+)-chunk-(\d+)-of-(\d+)-v(\d+)-(\d+)$/;
+
+/** Build a fake batch JSONL response line (Responses API format) */
+function makeBatchResponseLine({
+  customId,
+  text,
+  inputTokens = 1000,
+  outputTokens = 3000,
+  statusCode = 200,
+}: {
+  customId: string;
+  text: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  statusCode?: number;
+}) {
+  return JSON.stringify({
+    custom_id: customId,
+    response: {
+      status_code: statusCode,
+      body: {
+        output_text: text,
+        usage: {
+          input_tokens: inputTokens,
+          output_tokens: outputTokens,
+        },
+      },
+    },
+  });
+}
+
+/** Build a fake batch response using the fallback output[] format */
+function makeBatchResponseLineAltFormat({
+  customId,
+  text,
+}: {
+  customId: string;
+  text: string;
+}) {
+  return JSON.stringify({
+    custom_id: customId,
+    response: {
+      status_code: 200,
+      body: {
+        output: [
+          { type: "reasoning", content: [] },
+          { type: "message", content: [{ type: "text", text }] },
+        ],
+        usage: { input_tokens: 1000, output_tokens: 3000 },
+      },
+    },
+  });
+}
+
+function makeChunkText(
+  bookName: string,
+  chapter: number,
+  startVerse: number,
+  endVerse: number,
+) {
+  const lines: string[] = [];
+  for (let v = startVerse; v <= endVerse; v++) {
+    lines.push(
+      `## ${bookName} ${chapter}:${v}\n> {verse:${bookName} ${chapter}:${v}}\n\n### Summary\nExplanation for verse ${v} of ${bookName} ${chapter}.`,
+    );
+  }
+  return lines.join("\n\n");
+}
+
+// --- CHUNK_PATTERN regex tests ---
+
+describe("CHUNK_PATTERN regex", () => {
+  it("matches standard chunked custom_id", () => {
+    const id = "psalms-119-byline-1060-chunk-0-of-5-v1-40";
+    const match = id.match(CHUNK_PATTERN);
+    expect(match).toBeTruthy();
+    expect(match?.[1]).toBe("psalms"); // book slug
+    expect(match?.[2]).toBe("119"); // chapter number
+    expect(match?.[3]).toBe("1060"); // chapter_id
+    expect(match?.[4]).toBe("0"); // chunk index
+    expect(match?.[5]).toBe("5"); // total chunks
+    expect(match?.[6]).toBe("1"); // start verse
+    expect(match?.[7]).toBe("40"); // end verse
+  });
+
+  it("matches multi-word book slug", () => {
+    const id = "1-chronicles-29-byline-500-chunk-2-of-3-v21-30";
+    const match = id.match(CHUNK_PATTERN);
+    expect(match).toBeTruthy();
+    expect(match?.[1]).toBe("1-chronicles");
+    expect(match?.[2]).toBe("29");
+    expect(match?.[3]).toBe("500");
+    expect(match?.[4]).toBe("2");
+    expect(match?.[5]).toBe("3");
+  });
+
+  it("matches last chunk with smaller range", () => {
+    const id = "psalms-119-byline-1060-chunk-4-of-5-v161-176";
+    const match = id.match(CHUNK_PATTERN);
+    expect(match).toBeTruthy();
+    expect(match?.[4]).toBe("4");
+    expect(match?.[6]).toBe("161");
+    expect(match?.[7]).toBe("176");
+  });
+
+  it("does NOT match non-chunked custom_id (4-part format)", () => {
+    const id = "genesis-1-summary-42";
+    const match = id.match(CHUNK_PATTERN);
+    expect(match).toBeNull();
+  });
+
+  it("does NOT match non-chunked byline custom_id", () => {
+    const id = "genesis-1-byline-42";
+    const match = id.match(CHUNK_PATTERN);
+    expect(match).toBeNull();
+  });
+
+  it("does NOT match legacy 3-part format", () => {
+    const id = "genesis-1-summary";
+    const match = id.match(CHUNK_PATTERN);
+    expect(match).toBeNull();
+  });
+});
+
+// --- Chunk collection + stitching simulation ---
+
+describe("batch output chunk collection and stitching", () => {
+  /**
+   * Simulates the exact loop from processOutputFile:
+   * 1. Parse each JSONL line
+   * 2. Extract text (output_text or fallback output[].content)
+   * 3. Match CHUNK_PATTERN on custom_id
+   * 4. Collect chunks in map
+   * 5. Stitch complete sets
+   */
+  function simulateProcessOutputFile(jsonlLines: string[]) {
+    const bylineChunkCollector = new Map<
+      string,
+      {
+        chapterNumber: number;
+        chapterId: number;
+        totalChunks: number;
+        chunks: Array<{ chunkIndex: number; text: string }>;
+      }
+    >();
+
+    const nonChunkedResults: Array<{
+      customId: string;
+      type: string;
+      text: string;
+    }> = [];
+
+    let processedCount = 0;
+    let errorCount = 0;
+    let totalPromptTokens = 0;
+    let totalCompletionTokens = 0;
+
+    for (const line of jsonlLines) {
+      const parsedLine = JSON.parse(line);
+
+      if (parsedLine.response?.body?.usage) {
+        totalPromptTokens += parsedLine.response.body.usage.input_tokens || 0;
+        totalCompletionTokens +=
+          parsedLine.response.body.usage.output_tokens || 0;
+      }
+
+      const responseBody = parsedLine.response?.body;
+      const outputText: string | undefined = responseBody?.output_text;
+      let extractedText: string | undefined = outputText;
+
+      if (!extractedText && Array.isArray(responseBody?.output)) {
+        for (const item of responseBody.output) {
+          const textCandidate = item?.content?.find?.(
+            (c: any) => typeof c?.text === "string",
+          )?.text;
+          if (textCandidate) {
+            extractedText = textCandidate;
+            break;
+          }
+        }
+      }
+
+      if (
+        parsedLine.custom_id &&
+        parsedLine.response?.status_code === 200 &&
+        typeof extractedText === "string" &&
+        extractedText.length > 0
+      ) {
+        const chunkMatch = parsedLine.custom_id.match(CHUNK_PATTERN);
+
+        if (chunkMatch) {
+          const chapterNumber = Number.parseInt(chunkMatch[2], 10);
+          const chapterId = Number.parseInt(chunkMatch[3], 10);
+          const chunkIndex = Number.parseInt(chunkMatch[4], 10);
+          const totalChunks = Number.parseInt(chunkMatch[5], 10);
+
+          const key = `${chapterId}`;
+          if (!bylineChunkCollector.has(key)) {
+            bylineChunkCollector.set(key, {
+              chapterNumber,
+              chapterId,
+              totalChunks,
+              chunks: [],
+            });
+          }
+
+          bylineChunkCollector
+            .get(key)
+            ?.chunks.push({ chunkIndex, text: extractedText });
+        } else {
+          // Non-chunked: extract type from custom_id
+          const parts = parsedLine.custom_id.split("-");
+          nonChunkedResults.push({
+            customId: parsedLine.custom_id,
+            type: parts[parts.length - 2] || "unknown",
+            text: extractedText,
+          });
+          processedCount++;
+        }
+      } else {
+        errorCount++;
+      }
+    }
+
+    // Stitch complete chunk sets
+    const stitchedResults: Array<{
+      chapterId: number;
+      chapterNumber: number;
+      text: string;
+    }> = [];
+
+    for (const [, collected] of bylineChunkCollector) {
+      if (collected.chunks.length < collected.totalChunks) {
+        errorCount++;
+        continue;
+      }
+      stitchedResults.push({
+        chapterId: collected.chapterId,
+        chapterNumber: collected.chapterNumber,
+        text: stitchBylineChunks(collected.chunks),
+      });
+      processedCount++;
+    }
+
+    return {
+      stitchedResults,
+      nonChunkedResults,
+      processedCount,
+      errorCount,
+      totalPromptTokens,
+      totalCompletionTokens,
+    };
+  }
+
+  it("collects and stitches 5 chunks for Psalms 119", () => {
+    const lines = [
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-0-of-5-v1-40",
+        text: makeChunkText("Psalms", 119, 1, 40),
+      }),
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-1-of-5-v41-80",
+        text: makeChunkText("Psalms", 119, 41, 80),
+      }),
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-2-of-5-v81-120",
+        text: makeChunkText("Psalms", 119, 81, 120),
+      }),
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-3-of-5-v121-160",
+        text: makeChunkText("Psalms", 119, 121, 160),
+      }),
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-4-of-5-v161-176",
+        text: makeChunkText("Psalms", 119, 161, 176),
+      }),
+    ];
+
+    const result = simulateProcessOutputFile(lines);
+
+    expect(result.stitchedResults).toHaveLength(1);
+    expect(result.stitchedResults[0].chapterId).toBe(1060);
+    expect(result.stitchedResults[0].chapterNumber).toBe(119);
+    expect(result.processedCount).toBe(1);
+    expect(result.errorCount).toBe(0);
+
+    // Verify stitched output contains all verses
+    const stitched = result.stitchedResults[0].text;
+    expect(stitched).toContain("119:1");
+    expect(stitched).toContain("119:40");
+    expect(stitched).toContain("119:41");
+    expect(stitched).toContain("119:176");
+    expect(stitched).toContain("{verse:Psalms 119:1}");
+    expect(stitched).toContain("{verse:Psalms 119:176}");
+  });
+
+  it("handles chunks arriving out of order", () => {
+    const lines = [
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-4-of-5-v161-176",
+        text: makeChunkText("Psalms", 119, 161, 176),
+      }),
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-1-of-5-v41-80",
+        text: makeChunkText("Psalms", 119, 41, 80),
+      }),
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-3-of-5-v121-160",
+        text: makeChunkText("Psalms", 119, 121, 160),
+      }),
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-0-of-5-v1-40",
+        text: makeChunkText("Psalms", 119, 1, 40),
+      }),
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-2-of-5-v81-120",
+        text: makeChunkText("Psalms", 119, 81, 120),
+      }),
+    ];
+
+    const result = simulateProcessOutputFile(lines);
+
+    expect(result.stitchedResults).toHaveLength(1);
+    expect(result.errorCount).toBe(0);
+
+    // Verify stitching reorders correctly — verse 1 should come before verse 41
+    const stitched = result.stitchedResults[0].text;
+    const pos1 = stitched.indexOf("119:1\n");
+    const pos41 = stitched.indexOf("119:41\n");
+    const pos161 = stitched.indexOf("119:161\n");
+    expect(pos1).toBeLessThan(pos41);
+    expect(pos41).toBeLessThan(pos161);
+  });
+
+  it("handles mixed chunked and non-chunked lines in same batch", () => {
+    const lines = [
+      // Non-chunked summary for Psalms 119
+      makeBatchResponseLine({
+        customId: "psalms-119-summary-1060",
+        text: "# Summary of Psalms 119\n\nThis is a summary...",
+      }),
+      // Chunked byline for Psalms 119
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-0-of-2-v1-40",
+        text: makeChunkText("Psalms", 119, 1, 40),
+      }),
+      // Non-chunked detailed for Psalms 119
+      makeBatchResponseLine({
+        customId: "psalms-119-detailed-1060",
+        text: "# In-Depth Analysis of Psalms 119\n\nDetailed...",
+      }),
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-1-of-2-v41-80",
+        text: makeChunkText("Psalms", 119, 41, 80),
+      }),
+    ];
+
+    const result = simulateProcessOutputFile(lines);
+
+    expect(result.nonChunkedResults).toHaveLength(2);
+    expect(result.stitchedResults).toHaveLength(1);
+    expect(result.processedCount).toBe(3); // 2 non-chunked + 1 stitched
+    expect(result.errorCount).toBe(0);
+  });
+
+  it("reports error for incomplete chunk set", () => {
+    const lines = [
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-0-of-3-v1-40",
+        text: makeChunkText("Psalms", 119, 1, 40),
+      }),
+      // chunk 1 missing
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-2-of-3-v81-120",
+        text: makeChunkText("Psalms", 119, 81, 120),
+      }),
+    ];
+
+    const result = simulateProcessOutputFile(lines);
+
+    expect(result.stitchedResults).toHaveLength(0);
+    expect(result.errorCount).toBe(1);
+  });
+
+  it("handles multiple chapters with chunks in same batch", () => {
+    const lines = [
+      // Numbers 7 (chapter_id=200): 3 chunks
+      makeBatchResponseLine({
+        customId: "numbers-7-byline-200-chunk-0-of-3-v1-40",
+        text: makeChunkText("Numbers", 7, 1, 40),
+      }),
+      // Psalms 119 (chapter_id=1060): 2 chunks
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-0-of-2-v1-40",
+        text: makeChunkText("Psalms", 119, 1, 40),
+      }),
+      makeBatchResponseLine({
+        customId: "numbers-7-byline-200-chunk-1-of-3-v41-80",
+        text: makeChunkText("Numbers", 7, 41, 80),
+      }),
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-1-of-2-v41-80",
+        text: makeChunkText("Psalms", 119, 41, 80),
+      }),
+      makeBatchResponseLine({
+        customId: "numbers-7-byline-200-chunk-2-of-3-v81-89",
+        text: makeChunkText("Numbers", 7, 81, 89),
+      }),
+    ];
+
+    const result = simulateProcessOutputFile(lines);
+
+    expect(result.stitchedResults).toHaveLength(2);
+    expect(result.processedCount).toBe(2);
+    expect(result.errorCount).toBe(0);
+
+    const psalms = result.stitchedResults.find((r) => r.chapterId === 1060);
+    const numbers = result.stitchedResults.find((r) => r.chapterId === 200);
+    expect(psalms).toBeTruthy();
+    expect(numbers).toBeTruthy();
+    expect(psalms?.text).toContain("119:1");
+    expect(numbers?.text).toContain("7:89");
+  });
+
+  it("handles failed chunk response (non-200 status)", () => {
+    const lines = [
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-0-of-2-v1-40",
+        text: makeChunkText("Psalms", 119, 1, 40),
+      }),
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-1-of-2-v41-80",
+        text: "",
+        statusCode: 500,
+      }),
+    ];
+
+    const result = simulateProcessOutputFile(lines);
+
+    // chunk 1 fails (empty text + 500), so only 1 of 2 collected → incomplete
+    expect(result.stitchedResults).toHaveLength(0);
+    expect(result.errorCount).toBe(2); // 1 for failed response + 1 for incomplete set
+  });
+
+  it("extracts text from fallback output[] format", () => {
+    const lines = [
+      makeBatchResponseLineAltFormat({
+        customId: "psalms-119-byline-1060-chunk-0-of-1-v1-40",
+        text: makeChunkText("Psalms", 119, 1, 40),
+      }),
+    ];
+
+    const result = simulateProcessOutputFile(lines);
+
+    expect(result.stitchedResults).toHaveLength(1);
+    expect(result.stitchedResults[0].text).toContain("119:1");
+  });
+
+  it("tracks token usage across all chunks", () => {
+    const lines = [
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-0-of-2-v1-40",
+        text: makeChunkText("Psalms", 119, 1, 40),
+        inputTokens: 2000,
+        outputTokens: 5000,
+      }),
+      makeBatchResponseLine({
+        customId: "psalms-119-byline-1060-chunk-1-of-2-v41-80",
+        text: makeChunkText("Psalms", 119, 41, 80),
+        inputTokens: 2100,
+        outputTokens: 5200,
+      }),
+    ];
+
+    const result = simulateProcessOutputFile(lines);
+
+    expect(result.totalPromptTokens).toBe(4100);
+    expect(result.totalCompletionTokens).toBe(10200);
+  });
+});
+
+// --- JSONL generation format tests ---
+
+describe("batch JSONL custom_id format", () => {
+  it("generates correct custom_id for chunked byline", () => {
+    const bookSlug = "psalms";
+    const chapterNumber = 119;
+    const chapterId = 1060;
+    const chunkIndex = 2;
+    const totalChunks = 5;
+    const startVerse = 81;
+    const endVerse = 120;
+
+    const customId = `${bookSlug}-${chapterNumber}-byline-${chapterId}-chunk-${chunkIndex}-of-${totalChunks}-v${startVerse}-${endVerse}`;
+
+    expect(customId).toBe("psalms-119-byline-1060-chunk-2-of-5-v81-120");
+
+    // Verify it matches the parser regex
+    const match = customId.match(CHUNK_PATTERN);
+    expect(match).toBeTruthy();
+    expect(Number.parseInt(match?.[2] ?? "", 10)).toBe(chapterNumber);
+    expect(Number.parseInt(match?.[3] ?? "", 10)).toBe(chapterId);
+    expect(Number.parseInt(match?.[4] ?? "", 10)).toBe(chunkIndex);
+    expect(Number.parseInt(match?.[5] ?? "", 10)).toBe(totalChunks);
+    expect(Number.parseInt(match?.[6] ?? "", 10)).toBe(startVerse);
+    expect(Number.parseInt(match?.[7] ?? "", 10)).toBe(endVerse);
+  });
+
+  it("generates correct custom_id for multi-word book", () => {
+    const customId = "1-chronicles-29-byline-500-chunk-0-of-2-v1-40";
+    const match = customId.match(CHUNK_PATTERN);
+    expect(match).toBeTruthy();
+    expect(match?.[1]).toBe("1-chronicles");
+  });
+
+  it("non-chunked byline custom_id does NOT match chunk pattern", () => {
+    const customId = "genesis-3-byline-42";
+    expect(customId.match(CHUNK_PATTERN)).toBeNull();
+  });
+});

--- a/packages/backend-base/src/admin/services/batch-operations.service.ts
+++ b/packages/backend-base/src/admin/services/batch-operations.service.ts
@@ -6,6 +6,12 @@ import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { UserPromptRepository } from "../../bible/repository/user-prompt.repository";
 import { ValidationError } from "../../common/errors";
 import { BATCH_MONITORING_QUEUE } from "../../queue/batch-monitoring.queue";
+import {
+  buildBylineChunkPrompts,
+  shouldUseBylineChunking,
+  stitchBylineChunks,
+  toBylineVerses,
+} from "../../shared/byline-chunking";
 import { getExplanationTypePrompt } from "../../shared/prompt-utils";
 import type { db } from "../../shared/shared.plugin";
 import { generateTopicSlug } from "../../topics/utils/slug.utils";
@@ -2188,6 +2194,10 @@ export class BatchOperationService {
       );
     }
 
+    const sanitizedSystemPrompt = systemPrompt.prompt
+      .replace(/\r\n/g, "\n")
+      .replace(/\r/g, "\n");
+
     for (const chapter of chapters) {
       for (const explanationType of explanationTypes) {
         const chapterTypeKey = `${chapter.chapter_number}-${explanationType}`;
@@ -2197,6 +2207,60 @@ export class BatchOperationService {
             `[BATCH] Skipping existing explanation: ${book.name} ${chapter.chapter_number} ${explanationType}`,
           );
           continue;
+        }
+
+        const bookSlug = book.name.toLowerCase().replace(/\s+/g, "-");
+
+        // Check if this byline chapter needs chunking
+        if (explanationType === "byline") {
+          const verses = await connection
+            .selectFrom("verses")
+            .where("chapter_id", "=", chapter.chapter_id)
+            .where("version_id", "=", version.id)
+            .select(["verse_number", "text"])
+            .orderBy("verse_number", "asc")
+            .execute();
+
+          const verseRows = toBylineVerses(verses);
+
+          if (shouldUseBylineChunking(explanationType, verseRows.length)) {
+            const bylineConfig = await getExplanationTypePrompt(
+              explanationType,
+              book.name,
+              chapter.chapter_number,
+              this.db,
+              language,
+            );
+
+            const chunkPrompts = buildBylineChunkPrompts({
+              verses: verseRows,
+              bookName: book.name,
+              chapterNumber: chapter.chapter_number,
+              bylineTemplate: bylineConfig.prompt,
+            });
+
+            console.log(
+              `[BATCH] Chunking byline for ${book.name} ${chapter.chapter_number}: ${verseRows.length} verses → ${chunkPrompts.length} chunks`,
+            );
+
+            for (const chunk of chunkPrompts) {
+              batchRequests.push({
+                custom_id: `${bookSlug}-${chapter.chapter_number}-byline-${chapter.chapter_id}-chunk-${chunk.chunkIndex}-of-${chunk.totalChunks}-v${chunk.startVerse}-${chunk.endVerse}`,
+                method: "POST",
+                url: "/v1/responses",
+                body: {
+                  model,
+                  reasoning: { effort },
+                  instructions: sanitizedSystemPrompt,
+                  input: chunk.prompt
+                    .replace(/\r\n/g, "\n")
+                    .replace(/\r/g, "\n"),
+                  max_output_tokens: maxOutputTokens,
+                },
+              });
+            }
+            continue;
+          }
         }
 
         const explanationConfig = await getExplanationTypePrompt(
@@ -2212,21 +2276,12 @@ export class BatchOperationService {
           language,
         });
 
-        const sanitizedSystemPrompt = systemPrompt.prompt
-          .replace(/\r\n/g, "\n")
-          .replace(/\r/g, "\n");
-
         const sanitizedUserPrompt = userPrompt
           .replace(/\r\n/g, "\n")
           .replace(/\r/g, "\n");
 
         batchRequests.push({
-          custom_id: `${book.name
-            .toLowerCase()
-            .replace(
-              /\s+/g,
-              "-",
-            )}-${chapter.chapter_number}-${explanationType}-${chapter.chapter_id}`,
+          custom_id: `${bookSlug}-${chapter.chapter_number}-${explanationType}-${chapter.chapter_id}`,
           method: "POST",
           url: "/v1/responses",
           body: {
@@ -2363,6 +2418,20 @@ export class BatchOperationService {
         type: string;
       }[] = [];
 
+      // Collect byline chunks: key = "chapterId" → { totalChunks, collected chunks }
+      const bylineChunkCollector = new Map<
+        string,
+        {
+          chapterNumber: number;
+          chapterId: number;
+          totalChunks: number;
+          chunks: Array<{ chunkIndex: number; text: string }>;
+        }
+      >();
+
+      const CHUNK_PATTERN =
+        /^(.+)-(\d+)-byline-(\d+)-chunk-(\d+)-of-(\d+)-v(\d+)-(\d+)$/;
+
       for (const line of lines) {
         try {
           const parsedLine = JSON.parse(line);
@@ -2397,6 +2466,35 @@ export class BatchOperationService {
             typeof extractedText === "string" &&
             extractedText.length > 0
           ) {
+            // Check if this is a chunked byline response
+            const chunkMatch = parsedLine.custom_id.match(CHUNK_PATTERN);
+
+            if (chunkMatch) {
+              const chapterNumber = Number.parseInt(chunkMatch[2], 10);
+              const chapterId = Number.parseInt(chunkMatch[3], 10);
+              const chunkIndex = Number.parseInt(chunkMatch[4], 10);
+              const totalChunks = Number.parseInt(chunkMatch[5], 10);
+
+              const key = `${chapterId}`;
+              if (!bylineChunkCollector.has(key)) {
+                bylineChunkCollector.set(key, {
+                  chapterNumber,
+                  chapterId,
+                  totalChunks,
+                  chunks: [],
+                });
+              }
+
+              bylineChunkCollector
+                .get(key)
+                ?.chunks.push({ chunkIndex, text: extractedText });
+
+              console.log(
+                `[BATCH] Collected byline chunk ${chunkIndex + 1}/${totalChunks} for chapter ${chapterNumber} (ID: ${chapterId})`,
+              );
+              continue;
+            }
+
             const customIdParts = parsedLine.custom_id.split("-");
 
             // Handle both new format (4 parts) and legacy format (3 parts) for backward compatibility
@@ -2551,6 +2649,95 @@ export class BatchOperationService {
         } catch (error) {
           errorCount++;
           console.error("[BATCH] Error processing explanation line:", error);
+        }
+      }
+
+      // Stitch and save collected byline chunks
+      for (const [_key, collected] of bylineChunkCollector) {
+        try {
+          if (collected.chunks.length < collected.totalChunks) {
+            console.warn(
+              `[BATCH] Incomplete byline chunks for chapter ${collected.chapterNumber} (ID: ${collected.chapterId}): got ${collected.chunks.length}/${collected.totalChunks}`,
+            );
+            errorCount++;
+            continue;
+          }
+
+          const stitchedText = stitchBylineChunks(collected.chunks);
+
+          const chapter = await this.db
+            .getOrCreateConnection()
+            .selectFrom("chapters")
+            .where("chapter_id", "=", collected.chapterId)
+            .select("chapter_id")
+            .executeTakeFirst();
+
+          if (!chapter) {
+            console.error(
+              `[BATCH] Chapter not found for stitched byline: ID ${collected.chapterId}`,
+            );
+            errorCount++;
+            continue;
+          }
+
+          const existingExplanation = await this.db
+            .getOrCreateConnection()
+            .selectFrom("explanations")
+            .where("chapter_id", "=", chapter.chapter_id)
+            .where("type", "=", "byline" as any)
+            .where("language_code", "=", version.language_code)
+            .orderBy("version", "desc")
+            .select("version")
+            .executeTakeFirst();
+
+          const nextVersion = existingExplanation
+            ? existingExplanation.version + 1
+            : 1;
+
+          await this.db
+            .getOrCreateConnection()
+            .transaction()
+            .execute(async (trx) => {
+              await trx
+                .updateTable("explanations")
+                .set({ is_active: false })
+                .where("chapter_id", "=", chapter.chapter_id)
+                .where("type", "=", "byline" as any)
+                .where("language_code", "=", version.language_code)
+                .execute();
+
+              await trx
+                .insertInto("explanations")
+                .values({
+                  type: "byline" as any,
+                  explanation: stitchedText,
+                  chapter_id: chapter.chapter_id,
+                  language_code: version.language_code,
+                  version: nextVersion,
+                  is_active: true,
+                  created_at: new Date(),
+                })
+                .execute();
+            });
+
+          processedCount++;
+          console.log(
+            `[BATCH] Saved stitched byline for chapter ${collected.chapterNumber} (${collected.chunks.length} chunks → ${stitchedText.length} chars)`,
+          );
+
+          if (version.language_code === "en" && batchJob.book_id) {
+            successfulExplanations.push({
+              bookId: batchJob.book_id,
+              chapterNumber: collected.chapterNumber,
+              type: "byline",
+            });
+          }
+        } catch (error) {
+          errorCount++;
+          console.error(
+            `[BATCH] Error stitching byline for chapter ${collected.chapterNumber}:`,
+            error,
+          );
         }
       }
 

--- a/packages/backend-base/src/admin/services/explanation-regeneration.service.ts
+++ b/packages/backend-base/src/admin/services/explanation-regeneration.service.ts
@@ -1,16 +1,18 @@
-import ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
+import type ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import OpenAI from "openai";
 import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { NotFoundError } from "../../common/errors";
+import {
+  generateChunkedByline,
+  shouldUseBylineChunking,
+  toBylineVerses,
+} from "../../shared/byline-chunking";
 import { getExplanationTypePrompt } from "../../shared/prompt-utils";
 import type { db } from "../../shared/shared.plugin";
 
-const BYLINE_CHUNK_SIZE = 40;
-const BYLINE_CHUNK_THRESHOLD = 50;
-
 export class ExplanationRegenerationService {
-  private openai: OpenAI;
-  private promptRepository: PromptRepository;
+  private readonly openai: OpenAI;
+  private readonly promptRepository: PromptRepository;
 
   constructor(private readonly db: db) {
     this.openai = new OpenAI({
@@ -41,73 +43,6 @@ export class ExplanationRegenerationService {
     });
 
     return response.output_text || "";
-  }
-
-  private async generateBylineInChunks({
-    versesText,
-    bookName,
-    chapterNumber,
-    verseCount,
-    instructions,
-    model,
-    effort,
-    language,
-  }: {
-    versesText: string;
-    bookName: string;
-    chapterNumber: number;
-    verseCount: number;
-    instructions?: string;
-    model: string;
-    effort: "low" | "medium" | "high";
-    language: string;
-  }): Promise<string> {
-    const chunks: string[] = [];
-
-    for (
-      let startVerse = 1;
-      startVerse <= verseCount;
-      startVerse += BYLINE_CHUNK_SIZE
-    ) {
-      const endVerse = Math.min(startVerse + BYLINE_CHUNK_SIZE - 1, verseCount);
-      const isFirst = startVerse === 1;
-
-      const chunkPrompt = `${isFirst ? `# ${bookName} ${chapterNumber}: Verse-by-Verse Analysis\n\n` : ""}Provide a verse-by-verse explanation for **verses ${startVerse} through ${endVerse}** of this chapter. For each verse:
-1. Quote the verse using blockquote format (>)
-2. Provide a clear summary
-3. Include relevant key takeaways
-4. Add key definitions as appropriate
-5. Highlight theological themes as appropriate
-
-CRITICAL INSTRUCTIONS:
-- ONLY cover verses ${startVerse} through ${endVerse}
-- Keep chronological order at all times
-- Do not group verses unless absolutely necessary
-- Ensure takeaways and themes are full sentences
-- Use proper markdown formatting with line breaks
-${!isFirst ? "- Do NOT include a title heading — this is a continuation" : ""}
-
-Biblical Text (${bookName} ${chapterNumber}):
-${versesText}
-
-The response should be in ${language} using Markdown format only.`;
-
-      console.log(
-        `  [REGENERATION] Generating byline chunk: verses ${startVerse}-${endVerse}`,
-      );
-
-      const chunkText = await this.gpt5Text({
-        instructions,
-        input: chunkPrompt,
-        model,
-        effort,
-        maxTokens: 20000,
-      });
-
-      chunks.push(chunkText);
-    }
-
-    return chunks.join("\n\n---\n\n");
   }
 
   private getLanguageName(code: string, locale = "en"): string {
@@ -200,31 +135,36 @@ The response should be in ${language} using Markdown format only.`;
         .orderBy("verse_number", "asc")
         .execute();
 
-      const verseCount = verses.length;
-      const useChunking =
-        explanationType === ExplanationTypeEnum.byline &&
-        verseCount > BYLINE_CHUNK_THRESHOLD;
+      const verseRows = toBylineVerses(verses);
+      const useChunking = shouldUseBylineChunking(
+        explanationType,
+        verseRows.length,
+      );
+      const chunkSuffix = useChunking
+        ? ` (chunked: ${verseRows.length} verses)`
+        : "";
 
       console.log(
-        `[REGENERATION] Generating new explanation for ${book.name} ${chapterNumber}, type: ${explanationType}, model: ${model}${useChunking ? ` (chunked: ${verseCount} verses)` : ""}`,
+        `[REGENERATION] Generating new explanation for ${book.name} ${chapterNumber}, type: ${explanationType}, model: ${model}${chunkSuffix}`,
       );
 
       let newExplanationContent: string;
 
-      if (useChunking && verses.length > 0) {
-        const versesText = verses
-          .map((v) => `${v.verse_number}. ${v.text}`)
-          .join("\n");
-
-        newExplanationContent = await this.generateBylineInChunks({
-          versesText,
+      if (useChunking && verseRows.length > 0) {
+        newExplanationContent = await generateChunkedByline({
+          verses: verseRows,
           bookName: book.name,
           chapterNumber,
-          verseCount,
-          instructions: systemPrompt.prompt,
-          model,
-          effort,
           language,
+          logPrefix: "[REGENERATION_BYLINE]",
+          generateChunk: async ({ prompt }) =>
+            this.gpt5Text({
+              instructions: systemPrompt.prompt,
+              input: prompt,
+              model,
+              effort,
+              maxTokens: 20000,
+            }),
         });
       } else {
         let userPrompt: string;

--- a/packages/backend-base/src/admin/services/explanation-regeneration.service.ts
+++ b/packages/backend-base/src/admin/services/explanation-regeneration.service.ts
@@ -3,7 +3,7 @@ import OpenAI from "openai";
 import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { NotFoundError } from "../../common/errors";
 import {
-  generateChunkedByline,
+  generateChunkedBylineParallel,
   shouldUseBylineChunking,
   toBylineVerses,
 } from "../../shared/byline-chunking";
@@ -151,11 +151,11 @@ export class ExplanationRegenerationService {
       let newExplanationContent: string;
 
       if (useChunking && verseRows.length > 0) {
-        newExplanationContent = await generateChunkedByline({
+        newExplanationContent = await generateChunkedBylineParallel({
           verses: verseRows,
           bookName: book.name,
           chapterNumber,
-          language,
+          bylineTemplate: explanationConfig.prompt,
           logPrefix: "[REGENERATION_BYLINE]",
           generateChunk: async ({ prompt }) =>
             this.gpt5Text({

--- a/packages/backend-base/src/admin/services/explanation-regeneration.service.ts
+++ b/packages/backend-base/src/admin/services/explanation-regeneration.service.ts
@@ -1,9 +1,12 @@
-import type ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
+import ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import OpenAI from "openai";
 import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { NotFoundError } from "../../common/errors";
 import { getExplanationTypePrompt } from "../../shared/prompt-utils";
 import type { db } from "../../shared/shared.plugin";
+
+const BYLINE_CHUNK_SIZE = 40;
+const BYLINE_CHUNK_THRESHOLD = 50;
 
 export class ExplanationRegenerationService {
   private openai: OpenAI;
@@ -21,21 +24,90 @@ export class ExplanationRegenerationService {
     input,
     model,
     effort = "medium",
+    maxTokens = 20000,
   }: {
     instructions?: string;
     input: string;
     model: string;
     effort?: "low" | "medium" | "high";
+    maxTokens?: number;
   }) {
     const response = await this.openai.responses.create({
       model,
       reasoning: { effort },
       instructions,
       input,
-      max_output_tokens: 20000,
+      max_output_tokens: maxTokens,
     });
 
     return response.output_text || "";
+  }
+
+  private async generateBylineInChunks({
+    versesText,
+    bookName,
+    chapterNumber,
+    verseCount,
+    instructions,
+    model,
+    effort,
+    language,
+  }: {
+    versesText: string;
+    bookName: string;
+    chapterNumber: number;
+    verseCount: number;
+    instructions?: string;
+    model: string;
+    effort: "low" | "medium" | "high";
+    language: string;
+  }): Promise<string> {
+    const chunks: string[] = [];
+
+    for (
+      let startVerse = 1;
+      startVerse <= verseCount;
+      startVerse += BYLINE_CHUNK_SIZE
+    ) {
+      const endVerse = Math.min(startVerse + BYLINE_CHUNK_SIZE - 1, verseCount);
+      const isFirst = startVerse === 1;
+
+      const chunkPrompt = `${isFirst ? `# ${bookName} ${chapterNumber}: Verse-by-Verse Analysis\n\n` : ""}Provide a verse-by-verse explanation for **verses ${startVerse} through ${endVerse}** of this chapter. For each verse:
+1. Quote the verse using blockquote format (>)
+2. Provide a clear summary
+3. Include relevant key takeaways
+4. Add key definitions as appropriate
+5. Highlight theological themes as appropriate
+
+CRITICAL INSTRUCTIONS:
+- ONLY cover verses ${startVerse} through ${endVerse}
+- Keep chronological order at all times
+- Do not group verses unless absolutely necessary
+- Ensure takeaways and themes are full sentences
+- Use proper markdown formatting with line breaks
+${!isFirst ? "- Do NOT include a title heading — this is a continuation" : ""}
+
+Biblical Text (${bookName} ${chapterNumber}):
+${versesText}
+
+The response should be in ${language} using Markdown format only.`;
+
+      console.log(
+        `  [REGENERATION] Generating byline chunk: verses ${startVerse}-${endVerse}`,
+      );
+
+      const chunkText = await this.gpt5Text({
+        instructions,
+        input: chunkPrompt,
+        model,
+        effort,
+        maxTokens: 20000,
+      });
+
+      chunks.push(chunkText);
+    }
+
+    return chunks.join("\n\n---\n\n");
   }
 
   private getLanguageName(code: string, locale = "en"): string {
@@ -120,48 +192,66 @@ export class ExplanationRegenerationService {
         language,
       );
 
-      let userPrompt: string;
+      const verses = await connection
+        .selectFrom("verses")
+        .where("chapter_id", "=", chapter_id)
+        .where("version_id", "=", version.id)
+        .select(["verse_number", "text"])
+        .orderBy("verse_number", "asc")
+        .execute();
 
-      if (sendChapterContext) {
-        const verses = await connection
-          .selectFrom("verses")
-          .where("chapter_id", "=", chapter_id)
-          .where("version_id", "=", version.id)
-          .select(["verse_number", "text"])
-          .orderBy("verse_number", "asc")
-          .execute();
+      const verseCount = verses.length;
+      const useChunking =
+        explanationType === ExplanationTypeEnum.byline &&
+        verseCount > BYLINE_CHUNK_THRESHOLD;
 
-        if (!verses || verses.length === 0) {
-          throw new NotFoundError(
-            `No verses found for chapter ${chapterNumber} in version ${bibleVersion}`,
-          );
-        }
+      console.log(
+        `[REGENERATION] Generating new explanation for ${book.name} ${chapterNumber}, type: ${explanationType}, model: ${model}${useChunking ? ` (chunked: ${verseCount} verses)` : ""}`,
+      );
 
+      let newExplanationContent: string;
+
+      if (useChunking && verses.length > 0) {
         const versesText = verses
           .map((v) => `${v.verse_number}. ${v.text}`)
           .join("\n");
 
-        userPrompt = this.getUserPrompt({
-          explanationPrompt: `${explanationConfig.prompt}\n\nBiblical Text (${book.name} ${chapterNumber}):\n${versesText}`,
+        newExplanationContent = await this.generateBylineInChunks({
+          versesText,
+          bookName: book.name,
+          chapterNumber,
+          verseCount,
+          instructions: systemPrompt.prompt,
+          model,
+          effort,
           language,
         });
       } else {
-        userPrompt = this.getUserPrompt({
-          explanationPrompt: explanationConfig.prompt,
-          language,
+        let userPrompt: string;
+
+        if (sendChapterContext && verses.length > 0) {
+          const versesText = verses
+            .map((v) => `${v.verse_number}. ${v.text}`)
+            .join("\n");
+
+          userPrompt = this.getUserPrompt({
+            explanationPrompt: `${explanationConfig.prompt}\n\nBiblical Text (${book.name} ${chapterNumber}):\n${versesText}`,
+            language,
+          });
+        } else {
+          userPrompt = this.getUserPrompt({
+            explanationPrompt: explanationConfig.prompt,
+            language,
+          });
+        }
+
+        newExplanationContent = await this.gpt5Text({
+          instructions: systemPrompt.prompt,
+          input: userPrompt,
+          model,
+          effort,
         });
       }
-
-      console.log(
-        `[REGENERATION] Generating new explanation for ${book.name} ${chapterNumber}, type: ${explanationType}, model: ${model}`,
-      );
-
-      const newExplanationContent = await this.gpt5Text({
-        instructions: systemPrompt.prompt,
-        input: userPrompt,
-        model,
-        effort,
-      });
 
       const originalExplanation = await connection
         .selectFrom("explanations")

--- a/packages/backend-base/src/bible/dry-run-byline-chunking.ts
+++ b/packages/backend-base/src/bible/dry-run-byline-chunking.ts
@@ -1,0 +1,418 @@
+/**
+ * Dry-run script to verify byline chunking works end-to-end across all generation paths.
+ *
+ * Usage:
+ *   cd packages/backend-base && bun run src/bible/dry-run-byline-chunking.ts
+ *
+ * Prerequisites:
+ *   - Docker running (PostgreSQL + Valkey)
+ *   - .env file present with POSTGRES_URL
+ *   - Database seeded with bible data
+ *
+ * This script does NOT call OpenAI. It uses a mock generator to verify:
+ *   1. DB verse counts are correct for known long chapters
+ *   2. parseBibleData verse shapes are handled by toBylineVerses
+ *   3. Chunking activates for the right chapters
+ *   4. All 4 generation paths produce correct chunk splits
+ */
+
+import { db } from "database";
+import ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
+import {
+  BYLINE_CHUNK_SIZE,
+  BYLINE_CHUNK_THRESHOLD,
+  type BylineVerse,
+  generateChunkedByline,
+  shouldUseBylineChunking,
+  toBylineVerses,
+} from "../shared/byline-chunking";
+import { parseBibleData } from "./bible";
+
+// --- Config ---
+
+const LONG_CHAPTERS = [
+  { book: "Psalms", bookId: 19, chapter: 119, expectedVerses: 176 },
+  { book: "Numbers", bookId: 4, chapter: 7, expectedVerses: 89 },
+  { book: "Luke", bookId: 42, chapter: 1, expectedVerses: 80 },
+  { book: "Genesis", bookId: 1, chapter: 1, expectedVerses: 31 }, // short, should NOT chunk
+];
+
+// --- Mock generator ---
+
+function createMockGenerator(bookName: string, chapterNumber: number) {
+  return async ({
+    startVerse,
+    endVerse,
+  }: { startVerse: number; endVerse: number }) => {
+    const lines: string[] = [];
+    for (let v = startVerse; v <= endVerse; v++) {
+      lines.push(
+        `## ${bookName} ${chapterNumber}:${v}\n> Mock verse ${v} text.\nMock explanation for verse ${v}.`,
+      );
+    }
+    return lines.join("\n\n");
+  };
+}
+
+// --- Helpers ---
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, label: string, detail?: string) {
+  if (condition) {
+    console.log(`  PASS  ${label}`);
+    passed++;
+  } else {
+    console.error(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+    failed++;
+  }
+}
+
+// --- Tests ---
+
+async function testDbVerses() {
+  console.log(
+    "\n=== Path 1: DB verse rows (explanation-queue & regeneration service) ===\n",
+  );
+
+  const connection = db.getOrCreateConnection();
+
+  const activeVersion = await connection
+    .selectFrom("bible_versions")
+    .select(["id", "language_code"])
+    .where("is_active", "=", true)
+    .executeTakeFirst();
+
+  if (!activeVersion) {
+    console.error("  SKIP  No active bible version found in DB");
+    return;
+  }
+
+  console.log(
+    `  Active version: id=${activeVersion.id}, language=${activeVersion.language_code}\n`,
+  );
+
+  for (const { book, bookId, chapter, expectedVerses } of LONG_CHAPTERS) {
+    const chapterRow = await connection
+      .selectFrom("chapters")
+      .select(["chapter_id"])
+      .where("book_id", "=", bookId)
+      .where("chapter_number", "=", chapter)
+      .executeTakeFirst();
+
+    if (!chapterRow) {
+      console.log(`  SKIP  ${book} ${chapter} — chapter not in DB`);
+      continue;
+    }
+
+    const verses = await connection
+      .selectFrom("verses")
+      .where("chapter_id", "=", chapterRow.chapter_id)
+      .where("version_id", "=", activeVersion.id)
+      .select(["verse_number", "text"])
+      .orderBy("verse_number", "asc")
+      .execute();
+
+    const verseRows = toBylineVerses(verses);
+    const shouldChunk = shouldUseBylineChunking("byline", verseRows.length);
+
+    const verseCountMatch = verseRows.length === expectedVerses;
+    if (!verseCountMatch) {
+      console.log(
+        `  INFO  ${book} ${chapter}: DB has ${verseRows.length} verses (expected ${expectedVerses}, may be partial seed)`,
+      );
+    }
+
+    assert(
+      verseRows.length > 0,
+      `${book} ${chapter}: has verses in DB (${verseRows.length})`,
+    );
+
+    assert(
+      verseRows.every((v) => v.verseNumber > 0 && v.text.length > 0),
+      `${book} ${chapter}: all verses have valid number and text`,
+    );
+
+    // Use actual DB count for chunking decision (not expectedVerses)
+    if (shouldChunk) {
+      console.log(
+        `  INFO  ${book} ${chapter}: chunking with ${verseRows.length} DB verses`,
+      );
+      const expectedChunks = Math.ceil(verseRows.length / BYLINE_CHUNK_SIZE);
+      const chunkRanges: Array<[number, number]> = [];
+
+      const result = await generateChunkedByline({
+        verses: verseRows,
+        bookName: book,
+        chapterNumber: chapter,
+        bylineTemplate: `Dry run byline template for ${book} ${chapter}`,
+        logPrefix: "[DRY-RUN-DB]",
+        generateChunk: async ({ startVerse, endVerse }) => {
+          chunkRanges.push([startVerse, endVerse]);
+          return createMockGenerator(book, chapter)({ startVerse, endVerse });
+        },
+      });
+
+      assert(
+        chunkRanges.length === expectedChunks,
+        `${book} ${chapter}: produced ${chunkRanges.length} chunks`,
+        `expected ${expectedChunks}`,
+      );
+
+      assert(
+        result.includes(`${chapter}:1`),
+        `${book} ${chapter}: output contains first verse reference`,
+      );
+
+      const lastVerseNum = verseRows[verseRows.length - 1].verseNumber;
+      assert(
+        result.includes(`${chapter}:${lastVerseNum}`),
+        `${book} ${chapter}: output contains last verse reference (${lastVerseNum})`,
+      );
+
+      const separators = (result.match(/\n\n---\n\n/g) || []).length;
+      assert(
+        separators === expectedChunks - 1,
+        `${book} ${chapter}: ${separators} chunk separators`,
+        `expected ${expectedChunks - 1}`,
+      );
+    } else {
+      assert(
+        !shouldChunk,
+        `${book} ${chapter}: chunking skipped (${verseRows.length} <= ${BYLINE_CHUNK_THRESHOLD})`,
+      );
+    }
+  }
+}
+
+async function testParseBibleDataShape() {
+  console.log("\n=== Path 2: parseBibleData shape (pregenerate scripts) ===\n");
+
+  const metadataFile = Bun.file(`${import.meta.dir}/data/key_english.json`);
+  const bibleFile = Bun.file(`${import.meta.dir}/data/NASB1995.json`);
+
+  if (!(await bibleFile.exists()) || !(await metadataFile.exists())) {
+    console.log("  SKIP  Bible data files not found");
+    return;
+  }
+
+  const bible = await parseBibleData(bibleFile, metadataFile);
+
+  for (const { book, bookId, chapter, expectedVerses } of LONG_CHAPTERS) {
+    const bookData = bible.books.find((b) => b.bookId === bookId);
+    if (!bookData) {
+      console.log(`  SKIP  ${book} not found in parsed bible data`);
+      continue;
+    }
+
+    // This is the fix we made: use chapterId (not chapterNumber)
+    const chapterData = bookData.chapters.find((c) => c.chapterId === chapter);
+
+    assert(!!chapterData, `${book} ${chapter}: found via chapterId lookup`);
+
+    if (!chapterData) continue;
+
+    // Verify raw verse shape
+    const rawVerse = chapterData.verses[0];
+    assert(
+      "verseId" in rawVerse && typeof rawVerse.verseId === "number",
+      `${book} ${chapter}: raw verse has verseId property`,
+    );
+
+    // Test that toBylineVerses handles the raw shape directly (the fix)
+    const verseRows = toBylineVerses(chapterData.verses);
+    assert(
+      verseRows.length === expectedVerses,
+      `${book} ${chapter}: toBylineVerses from parseBibleData = ${verseRows.length}`,
+      `expected ${expectedVerses}`,
+    );
+
+    assert(
+      verseRows[0].verseNumber === 1,
+      `${book} ${chapter}: first verse number is 1`,
+    );
+
+    const shouldChunk = shouldUseBylineChunking("byline", verseRows.length);
+
+    if (expectedVerses > BYLINE_CHUNK_THRESHOLD) {
+      assert(
+        shouldChunk,
+        `${book} ${chapter}: parseBibleData path triggers chunking`,
+      );
+
+      const chunkRanges: Array<[number, number]> = [];
+
+      await generateChunkedByline({
+        verses: verseRows,
+        bookName: book,
+        chapterNumber: chapter,
+        bylineTemplate: `Dry run byline template for ${book} ${chapter}`,
+        logPrefix: "[DRY-RUN-PARSE]",
+        generateChunk: async ({ startVerse, endVerse }) => {
+          chunkRanges.push([startVerse, endVerse]);
+          return createMockGenerator(
+            book,
+            chapter,
+          )({
+            startVerse,
+            endVerse,
+          });
+        },
+      });
+
+      // Verify last chunk ends at the right verse
+      const lastChunk = chunkRanges[chunkRanges.length - 1];
+      assert(
+        lastChunk[1] === expectedVerses,
+        `${book} ${chapter}: last chunk ends at verse ${lastChunk[1]}`,
+        `expected ${expectedVerses}`,
+      );
+    }
+  }
+}
+
+async function testNonBylineSkipsChunking() {
+  console.log("\n=== Path 3: Non-byline types skip chunking ===\n");
+
+  const nonBylineTypes = Object.values(ExplanationTypeEnum).filter(
+    (t) => t !== "byline",
+  );
+
+  for (const type of nonBylineTypes) {
+    assert(
+      !shouldUseBylineChunking(type, 200),
+      `${type}: chunking skipped even with 200 verses`,
+    );
+  }
+}
+
+async function testEdgeCases() {
+  console.log("\n=== Path 4: Edge cases ===\n");
+
+  // Exactly at threshold
+  assert(
+    !shouldUseBylineChunking("byline", BYLINE_CHUNK_THRESHOLD),
+    `byline with exactly ${BYLINE_CHUNK_THRESHOLD} verses: no chunking`,
+  );
+
+  // One above threshold
+  assert(
+    shouldUseBylineChunking("byline", BYLINE_CHUNK_THRESHOLD + 1),
+    `byline with ${BYLINE_CHUNK_THRESHOLD + 1} verses: chunking activates`,
+  );
+
+  // Mixed property names (simulating different code paths)
+  const mixedInput = [
+    { verse_number: 1, text: "DB format" },
+    { verseNumber: 2, text: "camelCase format" },
+    { verseId: 3, text: "parseBibleData format" },
+  ];
+  const mixed = toBylineVerses(mixedInput);
+  assert(
+    mixed.length === 3 &&
+      mixed[0].verseNumber === 1 &&
+      mixed[1].verseNumber === 2 &&
+      mixed[2].verseNumber === 3,
+    "toBylineVerses handles mixed property names in single array",
+  );
+
+  // Chunk size boundary: exactly BYLINE_CHUNK_SIZE verses should be 1 chunk
+  const exactChunkVerses: BylineVerse[] = Array.from(
+    { length: BYLINE_CHUNK_SIZE },
+    (_, i) => ({
+      verseNumber: i + 1,
+      text: `v${i + 1}`,
+    }),
+  );
+  const exactChunkRanges: Array<[number, number]> = [];
+  await generateChunkedByline({
+    verses: exactChunkVerses,
+    bookName: "Test",
+    chapterNumber: 1,
+    bylineTemplate: "Dry run edge case template",
+    logPrefix: "[DRY-RUN-EDGE]",
+    generateChunk: async ({ startVerse, endVerse }) => {
+      exactChunkRanges.push([startVerse, endVerse]);
+      return createMockGenerator("Test", 1)({ startVerse, endVerse });
+    },
+  });
+  assert(
+    exactChunkRanges.length === 1,
+    `exactly ${BYLINE_CHUNK_SIZE} verses = 1 chunk`,
+  );
+
+  // BYLINE_CHUNK_SIZE + 1 verses should be 2 chunks
+  const overChunkVerses: BylineVerse[] = Array.from(
+    { length: BYLINE_CHUNK_SIZE + 1 },
+    (_, i) => ({
+      verseNumber: i + 1,
+      text: `v${i + 1}`,
+    }),
+  );
+  const overChunkRanges: Array<[number, number]> = [];
+  await generateChunkedByline({
+    verses: overChunkVerses,
+    bookName: "Test",
+    chapterNumber: 1,
+    bylineTemplate: "Dry run edge case template",
+    logPrefix: "[DRY-RUN-EDGE]",
+    generateChunk: async ({ startVerse, endVerse }) => {
+      overChunkRanges.push([startVerse, endVerse]);
+      return createMockGenerator("Test", 1)({ startVerse, endVerse });
+    },
+  });
+  assert(
+    overChunkRanges.length === 2,
+    `${BYLINE_CHUNK_SIZE + 1} verses = 2 chunks`,
+  );
+  assert(
+    overChunkRanges[1][0] === BYLINE_CHUNK_SIZE + 1 &&
+      overChunkRanges[1][1] === BYLINE_CHUNK_SIZE + 1,
+    `second chunk is single verse ${BYLINE_CHUNK_SIZE + 1}`,
+  );
+}
+
+// --- Main ---
+
+async function main() {
+  console.log("=== Byline Chunking Dry Run ===");
+  console.log(
+    `Chunk size: ${BYLINE_CHUNK_SIZE}, Threshold: ${BYLINE_CHUNK_THRESHOLD}\n`,
+  );
+
+  try {
+    await testDbVerses();
+  } catch (err) {
+    console.error("  ERROR  DB verse test failed:", err);
+  }
+
+  try {
+    await testParseBibleDataShape();
+  } catch (err) {
+    console.error("  ERROR  parseBibleData test failed:", err);
+  }
+
+  try {
+    await testNonBylineSkipsChunking();
+  } catch (err) {
+    console.error("  ERROR  non-byline test failed:", err);
+  }
+
+  try {
+    await testEdgeCases();
+  } catch (err) {
+    console.error("  ERROR  edge case test failed:", err);
+  }
+
+  console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
+
+  db.closeConnection();
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  db.closeConnection();
+  process.exit(1);
+});

--- a/packages/backend-base/src/bible/e2e-batch-byline-chunking.ts
+++ b/packages/backend-base/src/bible/e2e-batch-byline-chunking.ts
@@ -1,0 +1,372 @@
+/**
+ * E2E: Submit a REAL OpenAI Batch API job for Psalms 119 byline chunking.
+ *
+ * Usage:
+ *   cd packages/backend-base && bun run src/bible/e2e-batch-byline-chunking.ts
+ *
+ * This submits the batch, polls until complete, then parses the output
+ * using the exact same logic as batch-operations.service.ts.
+ */
+
+import { db } from "database";
+import OpenAI from "openai";
+import {
+  buildBylineChunkPrompts,
+  stitchBylineChunks,
+  toBylineVerses,
+} from "../shared/byline-chunking";
+
+const openai = new OpenAI({ apiKey: process.env.OPEN_AI_KEY });
+
+const PSALMS_119_CHAPTER_ID = 1060;
+const MODEL = "gpt-5-mini";
+const LANGUAGE_CODE = "en";
+const MAX_OUTPUT_TOKENS = 16000;
+const EFFORT = "medium";
+
+const CHUNK_PATTERN =
+  /^(.+)-(\d+)-byline-(\d+)-chunk-(\d+)-of-(\d+)-v(\d+)-(\d+)$/;
+
+async function main() {
+  const connection = db.getOrCreateConnection();
+  console.log("=== E2E Batch Byline Chunking: Psalms 119 ===\n");
+
+  // --- Step 1: Load data ---
+  console.log("Step 1: Loading data from DB...");
+
+  const activeVersion = await connection
+    .selectFrom("bible_versions")
+    .select(["id", "language_code"])
+    .where("is_active", "=", true)
+    .executeTakeFirst();
+  if (!activeVersion) throw new Error("No active bible version");
+
+  const verses = await connection
+    .selectFrom("verses")
+    .where("chapter_id", "=", PSALMS_119_CHAPTER_ID)
+    .where("version_id", "=", activeVersion.id)
+    .select(["verse_number", "text"])
+    .orderBy("verse_number", "asc")
+    .execute();
+  const verseRows = toBylineVerses(verses);
+  console.log(`  ${verseRows.length} verses`);
+
+  const systemPrompt = await connection
+    .selectFrom("prompts")
+    .where("status", "=", "active" as any)
+    .where("prompt_type", "=", "system" as any)
+    .select("prompt")
+    .executeTakeFirst();
+  if (!systemPrompt) throw new Error("No active system prompt");
+
+  const bylineTemplate = await connection
+    .selectFrom("user_prompt_templates")
+    .where("explanation_type", "=", "byline")
+    .where("status", "=", "active")
+    .select("prompt_template")
+    .executeTakeFirst();
+  if (!bylineTemplate) throw new Error("No active byline template");
+
+  const resolvedTemplate = bylineTemplate.prompt_template
+    .replace("{bookName}", "Psalms")
+    .replace("{chapterNumber}", "119")
+    .replace("{language}", "English");
+
+  // --- Step 2: Build JSONL (exact same as batch-operations.service.ts) ---
+  console.log("\nStep 2: Building JSONL...");
+
+  const chunkPrompts = buildBylineChunkPrompts({
+    verses: verseRows,
+    bookName: "Psalms",
+    chapterNumber: 119,
+    bylineTemplate: resolvedTemplate,
+  });
+
+  const sanitizedSystemPrompt = systemPrompt.prompt
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n");
+
+  const bookSlug = "psalms";
+  const batchRequests = chunkPrompts.map((chunk) => ({
+    custom_id: `${bookSlug}-119-byline-${PSALMS_119_CHAPTER_ID}-chunk-${chunk.chunkIndex}-of-${chunk.totalChunks}-v${chunk.startVerse}-${chunk.endVerse}`,
+    method: "POST" as const,
+    url: "/v1/responses" as const,
+    body: {
+      model: MODEL,
+      reasoning: { effort: EFFORT },
+      instructions: sanitizedSystemPrompt,
+      input: chunk.prompt.replace(/\r\n/g, "\n").replace(/\r/g, "\n"),
+      max_output_tokens: MAX_OUTPUT_TOKENS,
+    },
+  }));
+
+  const jsonlContent = batchRequests.map((r) => JSON.stringify(r)).join("\n");
+
+  console.log(`  ${batchRequests.length} JSONL lines`);
+  for (const r of batchRequests) {
+    console.log(`    ${r.custom_id}`);
+  }
+
+  // --- Step 3: Upload JSONL file ---
+  console.log("\nStep 3: Uploading JSONL to OpenAI...");
+
+  const blob = new Blob([jsonlContent], { type: "application/jsonl" });
+  const file = new File([blob], "psalms-119-byline-chunks.jsonl", {
+    type: "application/jsonl",
+  });
+
+  const uploadedFile = await openai.files.create({
+    file,
+    purpose: "batch",
+  });
+  console.log(`  File uploaded: ${uploadedFile.id}`);
+
+  // --- Step 4: Create batch ---
+  console.log("\nStep 4: Submitting batch...");
+
+  const batch = await openai.batches.create({
+    input_file_id: uploadedFile.id,
+    endpoint: "/v1/responses",
+    completion_window: "24h",
+  });
+  console.log(`  Batch created: ${batch.id}`);
+  console.log(`  Status: ${batch.status}`);
+
+  // --- Step 5: Poll for completion ---
+  console.log("\nStep 5: Polling for completion...");
+  const startTime = Date.now();
+
+  let currentBatch = batch;
+  while (
+    currentBatch.status !== "completed" &&
+    currentBatch.status !== "failed" &&
+    currentBatch.status !== "expired" &&
+    currentBatch.status !== "cancelled"
+  ) {
+    const elapsed = Math.round((Date.now() - startTime) / 1000);
+    process.stdout.write(
+      `\r  Status: ${currentBatch.status} (${elapsed}s)    `,
+    );
+    await new Promise((r) => setTimeout(r, 10000));
+    currentBatch = await openai.batches.retrieve(batch.id);
+  }
+
+  const totalTime = Math.round((Date.now() - startTime) / 1000);
+  console.log(`\n  Final status: ${currentBatch.status} (${totalTime}s)`);
+
+  if (currentBatch.status !== "completed") {
+    console.error("  Batch did not complete successfully");
+    console.error("  Errors:", currentBatch.errors);
+    db.closeConnection();
+    process.exit(1);
+  }
+
+  console.log(
+    `  Counts: ${currentBatch.request_counts?.completed} completed, ${currentBatch.request_counts?.failed} failed`,
+  );
+
+  // --- Step 6: Download and parse output ---
+  console.log("\nStep 6: Downloading and parsing output...");
+
+  const outputFileId = currentBatch.output_file_id;
+  if (!outputFileId) throw new Error("No output file ID");
+
+  const fileContent = await openai.files.content(outputFileId);
+  const jsonl = await fileContent.text();
+  const lines = jsonl.split("\n").filter((l) => l.trim());
+
+  console.log(`  ${lines.length} output lines`);
+
+  // Parse using exact same logic as processOutputFile
+  const bylineChunkCollector = new Map<
+    string,
+    {
+      chapterNumber: number;
+      chapterId: number;
+      totalChunks: number;
+      chunks: Array<{ chunkIndex: number; text: string }>;
+    }
+  >();
+
+  let totalInputTokens = 0;
+  let totalOutputTokens = 0;
+  let errors = 0;
+
+  for (const line of lines) {
+    const parsedLine = JSON.parse(line);
+
+    if (parsedLine.response?.body?.usage) {
+      totalInputTokens += parsedLine.response.body.usage.input_tokens || 0;
+      totalOutputTokens += parsedLine.response.body.usage.output_tokens || 0;
+    }
+
+    const responseBody = parsedLine.response?.body;
+    let extractedText: string | undefined = responseBody?.output_text;
+
+    if (!extractedText && Array.isArray(responseBody?.output)) {
+      for (const item of responseBody.output) {
+        const textCandidate = item?.content?.find?.(
+          (c: any) => typeof c?.text === "string",
+        )?.text;
+        if (textCandidate) {
+          extractedText = textCandidate;
+          break;
+        }
+      }
+    }
+
+    if (
+      parsedLine.custom_id &&
+      parsedLine.response?.status_code === 200 &&
+      typeof extractedText === "string" &&
+      extractedText.length > 0
+    ) {
+      const chunkMatch = parsedLine.custom_id.match(CHUNK_PATTERN);
+      if (chunkMatch) {
+        const chapterNumber = Number.parseInt(chunkMatch[2], 10);
+        const chapterId = Number.parseInt(chunkMatch[3], 10);
+        const chunkIndex = Number.parseInt(chunkMatch[4], 10);
+        const totalChunks = Number.parseInt(chunkMatch[5], 10);
+
+        const key = `${chapterId}`;
+        if (!bylineChunkCollector.has(key)) {
+          bylineChunkCollector.set(key, {
+            chapterNumber,
+            chapterId,
+            totalChunks,
+            chunks: [],
+          });
+        }
+        bylineChunkCollector
+          .get(key)
+          ?.chunks.push({ chunkIndex, text: extractedText });
+
+        console.log(
+          `  Chunk ${chunkIndex + 1}/${totalChunks}: ${extractedText.length} chars`,
+        );
+      }
+    } else {
+      console.error(
+        `  Failed line: ${parsedLine.custom_id} status=${parsedLine.response?.status_code}`,
+      );
+      errors++;
+    }
+  }
+
+  // --- Step 7: Stitch and verify ---
+  console.log("\nStep 7: Stitching and verifying...");
+
+  const collected = bylineChunkCollector.get(`${PSALMS_119_CHAPTER_ID}`);
+  if (!collected) {
+    throw new Error("No chunks collected for Psalms 119");
+  }
+
+  if (collected.chunks.length < collected.totalChunks) {
+    throw new Error(
+      `Incomplete: ${collected.chunks.length}/${collected.totalChunks} chunks`,
+    );
+  }
+
+  const stitchedText = stitchBylineChunks(collected.chunks);
+  console.log(`  Stitched: ${stitchedText.length} chars`);
+
+  // Verify format
+  const headings = stitchedText.match(/^## Psalms 119:\d+/gm) || [];
+  const verseRefs = stitchedText.match(/>\s*\{verse:Psalms 119:\d+\}/g) || [];
+  const summaries = stitchedText.match(/^### Summary/gm) || [];
+
+  console.log(`  ## headings: ${headings.length}`);
+  console.log(`  > {verse:...} refs: ${verseRefs.length}`);
+  console.log(`  ### Summary sections: ${summaries.length}`);
+
+  // Verify verse coverage
+  const verseMentionPattern = /\b119\s*[:\-]\s*(\d{1,3})\b/g;
+  const mentionedVerses = new Set<number>();
+  for (const m of stitchedText.matchAll(verseMentionPattern)) {
+    mentionedVerses.add(Number.parseInt(m[1], 10));
+  }
+  const missing: number[] = [];
+  for (let v = 1; v <= 176; v++) {
+    if (!mentionedVerses.has(v)) missing.push(v);
+  }
+
+  // Show sample
+  const firstVerse = stitchedText.match(
+    /## Psalms 119:1[\s\S]*?(?=## Psalms 119:2|$)/,
+  );
+  if (firstVerse) {
+    console.log("\n  --- Sample ---");
+    console.log(firstVerse[0].slice(0, 400));
+    console.log("  --- end ---");
+  }
+
+  // --- Step 8: Save to DB ---
+  console.log("\nStep 8: Saving to DB...");
+
+  const existingExplanation = await connection
+    .selectFrom("explanations")
+    .where("chapter_id", "=", PSALMS_119_CHAPTER_ID)
+    .where("type", "=", "byline" as any)
+    .where("language_code", "=", LANGUAGE_CODE)
+    .orderBy("version", "desc")
+    .select("version")
+    .executeTakeFirst();
+
+  const nextVersion = existingExplanation ? existingExplanation.version + 1 : 1;
+
+  await connection.transaction().execute(async (trx) => {
+    await trx
+      .updateTable("explanations")
+      .set({ is_active: false })
+      .where("chapter_id", "=", PSALMS_119_CHAPTER_ID)
+      .where("type", "=", "byline" as any)
+      .where("language_code", "=", LANGUAGE_CODE)
+      .execute();
+
+    await trx
+      .insertInto("explanations")
+      .values({
+        type: "byline" as any,
+        explanation: stitchedText,
+        chapter_id: PSALMS_119_CHAPTER_ID,
+        language_code: LANGUAGE_CODE,
+        version: nextVersion,
+        is_active: true,
+        created_at: new Date(),
+      })
+      .execute();
+  });
+
+  console.log(`  Saved as version ${nextVersion}`);
+
+  // --- Summary ---
+  const formatOk =
+    verseRefs.length >= 176 * 0.9 && summaries.length >= 176 * 0.9;
+  const allPass = missing.length === 0 && errors === 0 && formatOk;
+
+  console.log("\n=== Results ===");
+  console.log(`  Batch ID: ${batch.id}`);
+  console.log(`  Batch time: ${totalTime}s`);
+  console.log(
+    `  Tokens: ${totalInputTokens} in + ${totalOutputTokens} out = ${totalInputTokens + totalOutputTokens}`,
+  );
+  console.log(`  Verse coverage: ${mentionedVerses.size}/176`);
+  console.log(
+    `  Missing: ${missing.length === 0 ? "none" : missing.join(", ")}`,
+  );
+  console.log(
+    `  Format: ${headings.length} headings, ${verseRefs.length} refs, ${summaries.length} summaries`,
+  );
+  console.log(`  API errors: ${errors}`);
+  console.log(`  DB version: ${nextVersion}`);
+  console.log(`  Status: ${allPass ? "PASS" : "FAIL"}`);
+
+  db.closeConnection();
+  process.exit(allPass ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  db.closeConnection();
+  process.exit(1);
+});

--- a/packages/backend-base/src/bible/e2e-byline-chunking.ts
+++ b/packages/backend-base/src/bible/e2e-byline-chunking.ts
@@ -1,0 +1,334 @@
+/**
+ * E2E test: Real OpenAI API call for Psalms 119 byline chunked generation.
+ *
+ * Usage:
+ *   cd packages/backend-base && bun run src/bible/e2e-byline-chunking.ts
+ *
+ * Prerequisites:
+ *   - Docker running (PostgreSQL)
+ *   - .env with POSTGRES_URL and OPEN_AI_KEY
+ *
+ * What it does:
+ *   1. Reads Psalms 119 verses from DB (chapter_id=1060, mapped under 2 Timothy locally)
+ *   2. Loads the real byline template from user_prompt_templates
+ *   3. Builds chunked prompts using the real template (same as batch-operations)
+ *   4. Calls OpenAI in PARALLEL for all chunks
+ *   5. Stitches chunks together
+ *   6. Saves to DB as a new explanation version
+ *   7. Reads it back and verifies verse coverage
+ */
+
+import { db } from "database";
+import OpenAI from "openai";
+import {
+  buildBylineChunkPrompts,
+  shouldUseBylineChunking,
+  stitchBylineChunks,
+  toBylineVerses,
+} from "../shared/byline-chunking";
+
+const openai = new OpenAI({ apiKey: process.env.OPEN_AI_KEY });
+
+// Psalms 119 is under chapter_id=1060 in the local DB (mapped to book 55 / 2 Timothy due to seed bug)
+const PSALMS_119_CHAPTER_ID = 1060;
+const EXPECTED_VERSES = 176;
+const MODEL = "gpt-5-mini";
+const LANGUAGE_CODE = "en";
+
+async function main() {
+  const connection = db.getOrCreateConnection();
+
+  console.log("=== E2E Byline Chunking Test: Psalms 119 ===\n");
+
+  // Step 1: Read verses
+  console.log("Step 1: Reading verses from DB...");
+  const activeVersion = await connection
+    .selectFrom("bible_versions")
+    .select(["id", "language_code"])
+    .where("is_active", "=", true)
+    .executeTakeFirst();
+
+  if (!activeVersion) {
+    throw new Error("No active bible version");
+  }
+
+  const verses = await connection
+    .selectFrom("verses")
+    .where("chapter_id", "=", PSALMS_119_CHAPTER_ID)
+    .where("version_id", "=", activeVersion.id)
+    .select(["verse_number", "text"])
+    .orderBy("verse_number", "asc")
+    .execute();
+
+  const verseRows = toBylineVerses(verses);
+  console.log(`  Found ${verseRows.length} verses`);
+
+  if (verseRows.length !== EXPECTED_VERSES) {
+    throw new Error(
+      `Expected ${EXPECTED_VERSES} verses, got ${verseRows.length}`,
+    );
+  }
+
+  if (!shouldUseBylineChunking("byline", verseRows.length)) {
+    throw new Error("shouldUseBylineChunking returned false — logic error");
+  }
+
+  // Step 2: Load prompts from DB (same as batch-operations and playground)
+  console.log("\nStep 2: Loading prompts from DB...");
+  const systemPrompt = await connection
+    .selectFrom("prompts")
+    .where("status", "=", "active" as any)
+    .where("prompt_type", "=", "system" as any)
+    .select("prompt")
+    .executeTakeFirst();
+
+  if (!systemPrompt) {
+    throw new Error("No active system prompt found");
+  }
+  console.log(`  System prompt loaded (${systemPrompt.prompt.length} chars)`);
+
+  const bylineTemplate = await connection
+    .selectFrom("user_prompt_templates")
+    .where("explanation_type", "=", "byline")
+    .where("status", "=", "active")
+    .select("prompt_template")
+    .executeTakeFirst();
+
+  if (!bylineTemplate) {
+    throw new Error("No active byline template found");
+  }
+
+  // Replace placeholders (same as getExplanationTypePrompt does, minus {verseRange}/{verseRangeContext} which chunking handles)
+  const resolvedTemplate = bylineTemplate.prompt_template
+    .replace("{bookName}", "Psalms")
+    .replace("{chapterNumber}", "119")
+    .replace("{language}", "English");
+
+  console.log(
+    `  Byline template loaded and resolved (${resolvedTemplate.length} chars)`,
+  );
+
+  // Step 3: Build chunk prompts using the real template
+  console.log("\nStep 3: Building chunk prompts...");
+  const chunkPrompts = buildBylineChunkPrompts({
+    verses: verseRows,
+    bookName: "Psalms",
+    chapterNumber: 119,
+    bylineTemplate: resolvedTemplate,
+  });
+
+  console.log(`  Generated ${chunkPrompts.length} chunk prompts:`);
+  for (const chunk of chunkPrompts) {
+    console.log(
+      `    Chunk ${chunk.chunkIndex}: verses ${chunk.startVerse}-${chunk.endVerse}`,
+    );
+  }
+
+  // Step 4: Call OpenAI in PARALLEL for all chunks
+  console.log("\nStep 4: Calling OpenAI in parallel for all chunks...");
+  const startTime = Date.now();
+
+  const chunkResults = await Promise.all(
+    chunkPrompts.map(async (chunk) => {
+      const label = `  Chunk ${chunk.chunkIndex + 1}/${chunk.totalChunks} (verses ${chunk.startVerse}-${chunk.endVerse})`;
+      console.log(`${label}: calling API...`);
+
+      const chunkStart = Date.now();
+      const response = await openai.responses.create({
+        model: MODEL,
+        reasoning: { effort: "medium" as any },
+        instructions: systemPrompt.prompt,
+        input: chunk.prompt,
+        max_output_tokens: 16000,
+      });
+
+      const text = response.output_text || "";
+      const elapsed = ((Date.now() - chunkStart) / 1000).toFixed(1);
+      const usage = response.usage;
+      const inputTok = usage?.input_tokens || 0;
+      const outputTok = usage?.output_tokens || 0;
+
+      console.log(
+        `${label}: done — ${text.length} chars, ${inputTok}+${outputTok} tokens, ${elapsed}s`,
+      );
+
+      if (!text.trim()) {
+        throw new Error(
+          `Empty response for chunk ${chunk.chunkIndex} (verses ${chunk.startVerse}-${chunk.endVerse})`,
+        );
+      }
+
+      return {
+        chunkIndex: chunk.chunkIndex,
+        text,
+        inputTokens: inputTok,
+        outputTokens: outputTok,
+      };
+    }),
+  );
+
+  const totalElapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  const totalInputTokens = chunkResults.reduce((s, r) => s + r.inputTokens, 0);
+  const totalOutputTokens = chunkResults.reduce(
+    (s, r) => s + r.outputTokens,
+    0,
+  );
+
+  console.log(`\n  All chunks done in ${totalElapsed}s (parallel)`);
+  console.log(
+    `  Total tokens: ${totalInputTokens} input + ${totalOutputTokens} output = ${totalInputTokens + totalOutputTokens}`,
+  );
+
+  // Step 5: Stitch chunks
+  console.log("\nStep 5: Stitching chunks...");
+  const stitchedExplanation = stitchBylineChunks(chunkResults);
+  console.log(`  Stitched length: ${stitchedExplanation.length} chars`);
+
+  // Step 6: Verify verse coverage in stitched output
+  console.log("\nStep 6: Verifying verse coverage...");
+  const verseMentionPattern = /\b119\s*[:\-]\s*(\d{1,3})\b/g;
+  const mentionedVerses = new Set<number>();
+  for (const m of stitchedExplanation.matchAll(verseMentionPattern)) {
+    mentionedVerses.add(Number.parseInt(m[1], 10));
+  }
+
+  const missingVerses: number[] = [];
+  for (let v = 1; v <= EXPECTED_VERSES; v++) {
+    if (!mentionedVerses.has(v)) {
+      missingVerses.push(v);
+    }
+  }
+
+  console.log(`  Verses mentioned: ${mentionedVerses.size}/${EXPECTED_VERSES}`);
+  if (missingVerses.length > 0) {
+    console.warn(`  Missing verses: ${missingVerses.join(", ")}`);
+  } else {
+    console.log("  All 176 verses covered!");
+  }
+
+  // Step 7: Check format matches prod (## Book Ch:V, > {verse:...}, ### Summary)
+  console.log("\nStep 7: Checking output format...");
+  const headingPattern = /^## Psalms 119:\d+/gm;
+  const verseRefPattern = />\s*\{verse:Psalms 119:\d+\}/g;
+  const summaryPattern = /^### Summary/gm;
+
+  const headings = stitchedExplanation.match(headingPattern) || [];
+  const verseRefs = stitchedExplanation.match(verseRefPattern) || [];
+  const summaries = stitchedExplanation.match(summaryPattern) || [];
+
+  console.log(
+    `  ## headings: ${headings.length} (expected ${EXPECTED_VERSES})`,
+  );
+  console.log(
+    `  > {verse:...} refs: ${verseRefs.length} (expected ${EXPECTED_VERSES})`,
+  );
+  console.log(
+    `  ### Summary sections: ${summaries.length} (expected ${EXPECTED_VERSES})`,
+  );
+
+  // Show first verse as sample
+  const firstVerseMatch = stitchedExplanation.match(
+    /## Psalms 119:1[\s\S]*?(?=## Psalms 119:2|$)/,
+  );
+  if (firstVerseMatch) {
+    console.log("\n  --- Sample: first verse ---");
+    console.log(firstVerseMatch[0].slice(0, 500));
+    console.log("  --- end sample ---");
+  }
+
+  // Step 8: Save to DB
+  console.log("\nStep 8: Saving to DB...");
+  const existingExplanation = await connection
+    .selectFrom("explanations")
+    .where("chapter_id", "=", PSALMS_119_CHAPTER_ID)
+    .where("type", "=", "byline" as any)
+    .where("language_code", "=", LANGUAGE_CODE)
+    .orderBy("version", "desc")
+    .select("version")
+    .executeTakeFirst();
+
+  const nextVersion = existingExplanation ? existingExplanation.version + 1 : 1;
+
+  await connection.transaction().execute(async (trx) => {
+    await trx
+      .updateTable("explanations")
+      .set({ is_active: false })
+      .where("chapter_id", "=", PSALMS_119_CHAPTER_ID)
+      .where("type", "=", "byline" as any)
+      .where("language_code", "=", LANGUAGE_CODE)
+      .execute();
+
+    await trx
+      .insertInto("explanations")
+      .values({
+        type: "byline" as any,
+        explanation: stitchedExplanation,
+        chapter_id: PSALMS_119_CHAPTER_ID,
+        language_code: LANGUAGE_CODE,
+        version: nextVersion,
+        is_active: true,
+        created_at: new Date(),
+      })
+      .execute();
+  });
+
+  console.log(`  Saved as version ${nextVersion}`);
+
+  // Step 9: Read back and verify
+  console.log("\nStep 9: Reading back from DB...");
+  const savedExplanation = await connection
+    .selectFrom("explanations")
+    .where("chapter_id", "=", PSALMS_119_CHAPTER_ID)
+    .where("type", "=", "byline" as any)
+    .where("language_code", "=", LANGUAGE_CODE)
+    .where("is_active", "=", true)
+    .select(["explanation_id", "explanation", "version"])
+    .executeTakeFirst();
+
+  if (!savedExplanation) {
+    throw new Error("Failed to read back saved explanation");
+  }
+
+  console.log(
+    `  Read back: explanation_id=${savedExplanation.explanation_id}, version=${savedExplanation.version}, length=${savedExplanation.explanation.length}`,
+  );
+
+  const lengthMatch =
+    savedExplanation.explanation.length === stitchedExplanation.length;
+  console.log(`  Length matches stitched: ${lengthMatch}`);
+
+  // Summary
+  const formatOk =
+    headings.length >= EXPECTED_VERSES * 0.9 &&
+    verseRefs.length >= EXPECTED_VERSES * 0.9 &&
+    summaries.length >= EXPECTED_VERSES * 0.9;
+
+  console.log("\n=== Results ===");
+  console.log(`  Verses: ${verseRows.length}/${EXPECTED_VERSES}`);
+  console.log(
+    `  Chunks: ${chunkPrompts.length} (parallel in ${totalElapsed}s)`,
+  );
+  console.log(
+    `  Tokens: ${totalInputTokens} in + ${totalOutputTokens} out = ${totalInputTokens + totalOutputTokens}`,
+  );
+  console.log(`  Verse coverage: ${mentionedVerses.size}/${EXPECTED_VERSES}`);
+  console.log(
+    `  Missing: ${missingVerses.length === 0 ? "none" : missingVerses.join(", ")}`,
+  );
+  console.log(
+    `  Format: ${headings.length} headings, ${verseRefs.length} {verse:} refs, ${summaries.length} summaries`,
+  );
+  console.log(`  DB version: ${savedExplanation.version}`);
+  console.log(
+    `  Status: ${missingVerses.length === 0 && lengthMatch && formatOk ? "PASS" : "FAIL"}`,
+  );
+
+  db.closeConnection();
+  process.exit(missingVerses.length === 0 && lengthMatch && formatOk ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  db.closeConnection();
+  process.exit(1);
+});

--- a/packages/backend-base/src/bible/explanation-queue.ts
+++ b/packages/backend-base/src/bible/explanation-queue.ts
@@ -184,7 +184,7 @@ explanationQueue.process("generate-explanation", 1, async (job: any) => {
         verses: verseRows,
         bookName,
         chapterNumber,
-        language: "English",
+        bylineTemplate: explanationConfig.prompt,
         logPrefix: "[QUEUE_BYLINE]",
         generateChunk: async ({ prompt }) =>
           gpt5Text({

--- a/packages/backend-base/src/bible/explanation-queue.ts
+++ b/packages/backend-base/src/bible/explanation-queue.ts
@@ -86,12 +86,22 @@ Provide an in-depth yet accessible explanation of ${bookName} ${chapterNumber} w
   }
 };
 
+const BYLINE_CHUNK_SIZE = 40;
+const BYLINE_CHUNK_THRESHOLD = 50;
+
+function countVersesInReference(reference: string): number {
+  return reference.split("\n").filter((line) => /^\d+$/.test(line.trim()))
+    .length;
+}
+
 async function gpt5Text({
   system,
   user,
+  maxTokens = 16000,
 }: {
   system?: string;
   user: string;
+  maxTokens?: number;
 }) {
   const messages: OpenAI.ChatCompletionMessageParam[] = [];
   if (system) {
@@ -102,11 +112,76 @@ async function gpt5Text({
   const options: any = {
     model: "gpt-5",
     messages,
-    max_completion_tokens: 10000,
+    max_completion_tokens: maxTokens,
   };
 
   const chat = await openai.chat.completions.create(options as any);
   return chat.choices[0].message.content || "";
+}
+
+async function generateBylineInChunks({
+  reference,
+  bookName,
+  chapterNumber,
+  systemPrompt,
+  verseCount,
+}: {
+  reference: string;
+  bookName: string;
+  chapterNumber: number;
+  systemPrompt?: string;
+  verseCount: number;
+}): Promise<string> {
+  const chunks: string[] = [];
+
+  for (
+    let startVerse = 1;
+    startVerse <= verseCount;
+    startVerse += BYLINE_CHUNK_SIZE
+  ) {
+    const endVerse = Math.min(startVerse + BYLINE_CHUNK_SIZE - 1, verseCount);
+    const isFirst = startVerse === 1;
+
+    const chunkPrompt = `# Reference
+${reference}
+
+${isFirst ? `# ${bookName} ${chapterNumber}: Verse-by-Verse Analysis\n\n` : ""}Provide a verse-by-verse explanation for **verses ${startVerse} through ${endVerse}** of this chapter. For each verse:
+1. Quote the verse using blockquote format (>)
+2. Provide a clear summary
+3. Include relevant key takeaways
+4. Add key definitions as appropriate
+5. Highlight theological themes as appropriate
+
+CRITICAL INSTRUCTIONS:
+- ONLY cover verses ${startVerse} through ${endVerse}
+- Keep chronological order at all times
+- Do not group verses unless absolutely necessary
+- Ensure takeaways and themes are full sentences
+- Use proper markdown formatting with line breaks
+${!isFirst ? "- Do NOT include a title heading — this is a continuation" : ""}
+
+CRITICAL: Your response will be evaluated on:
+1. Proper blockquote usage for Scripture (>)
+2. Bold formatting for theological terms
+3. Bullet point usage for lists
+4. Verse reference formatting
+
+The response should be in Markdown format only.`;
+
+    console.log(
+      `  📝 Generating byline chunk: verses ${startVerse}-${endVerse}`,
+    );
+
+    const chunkText = await gpt5Text({
+      system: systemPrompt,
+      user: chunkPrompt,
+      maxTokens: 16000,
+    });
+
+    chunks.push(chunkText);
+  }
+
+  return chunks.join("\n\n---\n\n");
 }
 
 // Create explanation generation queue
@@ -133,7 +208,26 @@ explanationQueue.process("generate-explanation", 1, async (job: any) => {
       chapterNumber,
     );
 
-    const userPrompt = `# Reference
+    const verseCount = countVersesInReference(reference);
+    const useChunking =
+      type === ExplanationTypeEnum.byline &&
+      verseCount > BYLINE_CHUNK_THRESHOLD;
+
+    let text: string;
+
+    if (useChunking) {
+      console.log(
+        `📖 Chapter has ${verseCount} verses — using chunked byline generation`,
+      );
+      text = await generateBylineInChunks({
+        reference,
+        bookName,
+        chapterNumber,
+        systemPrompt,
+        verseCount,
+      });
+    } else {
+      const userPrompt = `# Reference
 ${reference}
 
 ${explanationConfig.prompt}
@@ -146,10 +240,11 @@ CRITICAL: Your response will be evaluated on:
 
 The response should be in Markdown format only.`;
 
-    const text = await gpt5Text({
-      system: systemPrompt,
-      user: userPrompt,
-    });
+      text = await gpt5Text({
+        system: systemPrompt,
+        user: userPrompt,
+      });
+    }
 
     const connection = db.getOrCreateConnection();
 

--- a/packages/backend-base/src/bible/explanation-queue.ts
+++ b/packages/backend-base/src/bible/explanation-queue.ts
@@ -2,6 +2,11 @@ import Queue from "bull";
 import { db } from "database";
 import ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import OpenAI from "openai";
+import {
+  generateChunkedByline,
+  shouldUseBylineChunking,
+  toBylineVerses,
+} from "../shared/byline-chunking";
 
 const openai = new OpenAI({
   apiKey: process.env.OPEN_AI_KEY,
@@ -86,14 +91,6 @@ Provide an in-depth yet accessible explanation of ${bookName} ${chapterNumber} w
   }
 };
 
-const BYLINE_CHUNK_SIZE = 40;
-const BYLINE_CHUNK_THRESHOLD = 50;
-
-function countVersesInReference(reference: string): number {
-  return reference.split("\n").filter((line) => /^\d+$/.test(line.trim()))
-    .length;
-}
-
 async function gpt5Text({
   system,
   user,
@@ -115,73 +112,8 @@ async function gpt5Text({
     max_completion_tokens: maxTokens,
   };
 
-  const chat = await openai.chat.completions.create(options as any);
+  const chat = await openai.chat.completions.create(options);
   return chat.choices[0].message.content || "";
-}
-
-async function generateBylineInChunks({
-  reference,
-  bookName,
-  chapterNumber,
-  systemPrompt,
-  verseCount,
-}: {
-  reference: string;
-  bookName: string;
-  chapterNumber: number;
-  systemPrompt?: string;
-  verseCount: number;
-}): Promise<string> {
-  const chunks: string[] = [];
-
-  for (
-    let startVerse = 1;
-    startVerse <= verseCount;
-    startVerse += BYLINE_CHUNK_SIZE
-  ) {
-    const endVerse = Math.min(startVerse + BYLINE_CHUNK_SIZE - 1, verseCount);
-    const isFirst = startVerse === 1;
-
-    const chunkPrompt = `# Reference
-${reference}
-
-${isFirst ? `# ${bookName} ${chapterNumber}: Verse-by-Verse Analysis\n\n` : ""}Provide a verse-by-verse explanation for **verses ${startVerse} through ${endVerse}** of this chapter. For each verse:
-1. Quote the verse using blockquote format (>)
-2. Provide a clear summary
-3. Include relevant key takeaways
-4. Add key definitions as appropriate
-5. Highlight theological themes as appropriate
-
-CRITICAL INSTRUCTIONS:
-- ONLY cover verses ${startVerse} through ${endVerse}
-- Keep chronological order at all times
-- Do not group verses unless absolutely necessary
-- Ensure takeaways and themes are full sentences
-- Use proper markdown formatting with line breaks
-${!isFirst ? "- Do NOT include a title heading — this is a continuation" : ""}
-
-CRITICAL: Your response will be evaluated on:
-1. Proper blockquote usage for Scripture (>)
-2. Bold formatting for theological terms
-3. Bullet point usage for lists
-4. Verse reference formatting
-
-The response should be in Markdown format only.`;
-
-    console.log(
-      `  📝 Generating byline chunk: verses ${startVerse}-${endVerse}`,
-    );
-
-    const chunkText = await gpt5Text({
-      system: systemPrompt,
-      user: chunkPrompt,
-      maxTokens: 16000,
-    });
-
-    chunks.push(chunkText);
-  }
-
-  return chunks.join("\n\n---\n\n");
 }
 
 // Create explanation generation queue
@@ -207,24 +139,59 @@ explanationQueue.process("generate-explanation", 1, async (job: any) => {
       bookName,
       chapterNumber,
     );
+    const connection = db.getOrCreateConnection();
 
-    const verseCount = countVersesInReference(reference);
-    const useChunking =
-      type === ExplanationTypeEnum.byline &&
-      verseCount > BYLINE_CHUNK_THRESHOLD;
+    const chapter = await connection
+      .selectFrom("chapters")
+      .select(["chapter_id"])
+      .where("book_id", "=", bookId)
+      .where("chapter_number", "=", chapterNumber)
+      .executeTakeFirst();
+
+    if (!chapter) {
+      throw new Error(
+        `Chapter not found for book ${bookId}, chapter ${chapterNumber}`,
+      );
+    }
+
+    const activeVersion = await connection
+      .selectFrom("bible_versions")
+      .select(["id", "language_code"])
+      .where("is_active", "=", true)
+      .executeTakeFirst();
+
+    if (!activeVersion) {
+      throw new Error("No active bible version found");
+    }
 
     let text: string;
+    const verses = await connection
+      .selectFrom("verses")
+      .where("chapter_id", "=", chapter.chapter_id)
+      .where("version_id", "=", activeVersion.id)
+      .select(["verse_number", "text"])
+      .orderBy("verse_number", "asc")
+      .execute();
+
+    const verseRows = toBylineVerses(verses);
+    const useChunking = shouldUseBylineChunking(type, verseRows.length);
 
     if (useChunking) {
       console.log(
-        `📖 Chapter has ${verseCount} verses — using chunked byline generation`,
+        `📖 Chapter has ${verseRows.length} verses — using chunked byline generation`,
       );
-      text = await generateBylineInChunks({
-        reference,
+      text = await generateChunkedByline({
+        verses: verseRows,
         bookName,
         chapterNumber,
-        systemPrompt,
-        verseCount,
+        language: "English",
+        logPrefix: "[QUEUE_BYLINE]",
+        generateChunk: async ({ prompt }) =>
+          gpt5Text({
+            system: systemPrompt,
+            user: prompt,
+            maxTokens: 16000,
+          }),
       });
     } else {
       const userPrompt = `# Reference
@@ -244,31 +211,6 @@ The response should be in Markdown format only.`;
         system: systemPrompt,
         user: userPrompt,
       });
-    }
-
-    const connection = db.getOrCreateConnection();
-
-    const chapter = await connection
-      .selectFrom("chapters")
-      .select(["chapter_id"])
-      .where("book_id", "=", bookId)
-      .where("chapter_number", "=", chapterNumber)
-      .executeTakeFirst();
-
-    if (!chapter) {
-      throw new Error(
-        `Chapter not found for book ${bookId}, chapter ${chapterNumber}`,
-      );
-    }
-
-    const activeVersion = await connection
-      .selectFrom("bible_versions")
-      .select(["language_code"])
-      .where("is_active", "=", true)
-      .executeTakeFirst();
-
-    if (!activeVersion) {
-      throw new Error("No active bible version found");
     }
 
     await connection
@@ -326,8 +268,12 @@ export async function queueExplanationGeneration(
   bookName: string,
   priority: "high" | "normal" | "low" = "normal",
 ) {
-  const priorityValue =
-    priority === "high" ? 1 : priority === "normal" ? 0 : -1;
+  let priorityValue = -1;
+  if (priority === "high") {
+    priorityValue = 1;
+  } else if (priority === "normal") {
+    priorityValue = 0;
+  }
 
   const job = await explanationQueue.add(
     "generate-explanation",

--- a/packages/backend-base/src/bible/pregenerate-hebrews.ts
+++ b/packages/backend-base/src/bible/pregenerate-hebrews.ts
@@ -210,18 +210,19 @@ async function pregenerateHebrewsChapters() {
     // Format chapter content for AI
     const reference = formatChapterContent(bibleChapter, "Hebrews");
 
-    const verseRows = toBylineVerses(
-      (bibleChapter.verses ?? []).map((v: any) => ({
-        verseNumber: v.verseId,
-        text: v.text,
-      })),
-    );
+    const verseRows = toBylineVerses(bibleChapter.verses ?? []);
 
     // Generate missing explanations
     for (const type of missingTypes) {
       try {
         console.log(
           `  🤖 Generating ${type} explanation for Hebrews ${chapterNumber}...`,
+        );
+
+        const explanationConfig = getExplanationTypePrompt(
+          type,
+          "Hebrews",
+          chapterNumber,
         );
 
         const useChunking = shouldUseBylineChunking(type, verseRows.length);
@@ -236,7 +237,7 @@ async function pregenerateHebrewsChapters() {
             verses: verseRows,
             bookName: "Hebrews",
             chapterNumber,
-            language: "English",
+            bylineTemplate: explanationConfig.prompt,
             logPrefix: "[PREGENERATE_HEBREWS_BYLINE]",
             generateChunk: async ({ prompt }) =>
               gpt5Text({
@@ -246,12 +247,6 @@ async function pregenerateHebrewsChapters() {
               }),
           });
         } else {
-          const explanationConfig = getExplanationTypePrompt(
-            type,
-            "Hebrews",
-            chapterNumber,
-          );
-
           const userPrompt = `# Reference
 ${reference}
 

--- a/packages/backend-base/src/bible/pregenerate-hebrews.ts
+++ b/packages/backend-base/src/bible/pregenerate-hebrews.ts
@@ -1,6 +1,11 @@
 import { db } from "database";
 import ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import OpenAI from "openai";
+import {
+  generateChunkedByline,
+  shouldUseBylineChunking,
+  toBylineVerses,
+} from "../shared/byline-chunking";
 import { parseBibleData } from "./bible";
 
 const openai = new OpenAI({
@@ -86,9 +91,6 @@ Provide an in-depth yet accessible explanation of ${bookName} ${chapterNumber} w
   }
 };
 
-const BYLINE_CHUNK_SIZE = 40;
-const BYLINE_CHUNK_THRESHOLD = 50;
-
 async function gpt5Text({
   system,
   user,
@@ -110,78 +112,8 @@ async function gpt5Text({
     max_completion_tokens: maxTokens,
   };
 
-  const chat = await openai.chat.completions.create(options as any);
+  const chat = await openai.chat.completions.create(options);
   return chat.choices[0].message.content || "";
-}
-
-async function generateBylineInChunks({
-  reference,
-  bookName,
-  chapterNumber,
-  systemPrompt,
-  verseCount,
-}: {
-  reference: string;
-  bookName: string;
-  chapterNumber: number;
-  systemPrompt?: string;
-  verseCount: number;
-}): Promise<string> {
-  const chunks: string[] = [];
-
-  for (
-    let startVerse = 1;
-    startVerse <= verseCount;
-    startVerse += BYLINE_CHUNK_SIZE
-  ) {
-    const endVerse = Math.min(startVerse + BYLINE_CHUNK_SIZE - 1, verseCount);
-    const isFirst = startVerse === 1;
-
-    const chunkPrompt = `# Reference
-${reference}
-
-${isFirst ? `# ${bookName} ${chapterNumber}: Verse-by-Verse Analysis\n\n` : ""}Provide a verse-by-verse explanation for **verses ${startVerse} through ${endVerse}** of this chapter. For each verse:
-1. Quote the verse using blockquote format (>)
-2. Provide a clear summary
-3. Include relevant key takeaways
-4. Add key definitions as appropriate
-5. Highlight theological themes as appropriate
-
-CRITICAL INSTRUCTIONS:
-- ONLY cover verses ${startVerse} through ${endVerse}
-- Keep chronological order at all times
-- Do not group verses unless absolutely necessary
-- Ensure takeaways and themes are full sentences
-- Use proper markdown formatting with line breaks
-${!isFirst ? "- Do NOT include a title heading — this is a continuation" : ""}
-
-CRITICAL: Your response will be evaluated on:
-1. Proper blockquote usage for Scripture (>)
-2. Bold formatting for theological terms
-3. Bullet point usage for lists
-4. Verse reference formatting
-
-The response should be in Markdown format only.`;
-
-    console.log(
-      `  📝 Generating byline chunk: verses ${startVerse}-${endVerse}`,
-    );
-
-    const chunkText = await gpt5Text({
-      system: systemPrompt,
-      user: chunkPrompt,
-      maxTokens: 16000,
-    });
-
-    chunks.push(chunkText);
-
-    // Add delay between chunks to avoid rate limiting
-    if (endVerse < verseCount) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-  }
-
-  return chunks.join("\n\n---\n\n");
 }
 
 async function pregenerateHebrewsChapters() {
@@ -278,7 +210,12 @@ async function pregenerateHebrewsChapters() {
     // Format chapter content for AI
     const reference = formatChapterContent(bibleChapter, "Hebrews");
 
-    const verseCount = bibleChapter.verses?.length ?? 0;
+    const verseRows = toBylineVerses(
+      (bibleChapter.verses ?? []).map((v: any) => ({
+        verseNumber: v.verseId,
+        text: v.text,
+      })),
+    );
 
     // Generate missing explanations
     for (const type of missingTypes) {
@@ -287,22 +224,26 @@ async function pregenerateHebrewsChapters() {
           `  🤖 Generating ${type} explanation for Hebrews ${chapterNumber}...`,
         );
 
-        const useChunking =
-          type === ExplanationTypeEnum.byline &&
-          verseCount > BYLINE_CHUNK_THRESHOLD;
+        const useChunking = shouldUseBylineChunking(type, verseRows.length);
 
         let text: string;
 
         if (useChunking) {
           console.log(
-            `  📖 Chapter has ${verseCount} verses — using chunked byline generation`,
+            `  📖 Chapter has ${verseRows.length} verses — using chunked byline generation`,
           );
-          text = await generateBylineInChunks({
-            reference,
+          text = await generateChunkedByline({
+            verses: verseRows,
             bookName: "Hebrews",
             chapterNumber,
-            systemPrompt: activePrompt.prompt,
-            verseCount,
+            language: "English",
+            logPrefix: "[PREGENERATE_HEBREWS_BYLINE]",
+            generateChunk: async ({ prompt }) =>
+              gpt5Text({
+                system: activePrompt.prompt,
+                user: prompt,
+                maxTokens: 16000,
+              }),
           });
         } else {
           const explanationConfig = getExplanationTypePrompt(

--- a/packages/backend-base/src/bible/pregenerate-hebrews.ts
+++ b/packages/backend-base/src/bible/pregenerate-hebrews.ts
@@ -86,7 +86,18 @@ Provide an in-depth yet accessible explanation of ${bookName} ${chapterNumber} w
   }
 };
 
-async function gpt5Text({ system, user }: { system?: string; user: string }) {
+const BYLINE_CHUNK_SIZE = 40;
+const BYLINE_CHUNK_THRESHOLD = 50;
+
+async function gpt5Text({
+  system,
+  user,
+  maxTokens = 16000,
+}: {
+  system?: string;
+  user: string;
+  maxTokens?: number;
+}) {
   const messages: OpenAI.ChatCompletionMessageParam[] = [];
   if (system) {
     messages.push({ role: "system", content: system });
@@ -96,11 +107,81 @@ async function gpt5Text({ system, user }: { system?: string; user: string }) {
   const options: any = {
     model: "gpt-5",
     messages,
-    max_completion_tokens: 10000,
+    max_completion_tokens: maxTokens,
   };
 
   const chat = await openai.chat.completions.create(options as any);
   return chat.choices[0].message.content || "";
+}
+
+async function generateBylineInChunks({
+  reference,
+  bookName,
+  chapterNumber,
+  systemPrompt,
+  verseCount,
+}: {
+  reference: string;
+  bookName: string;
+  chapterNumber: number;
+  systemPrompt?: string;
+  verseCount: number;
+}): Promise<string> {
+  const chunks: string[] = [];
+
+  for (
+    let startVerse = 1;
+    startVerse <= verseCount;
+    startVerse += BYLINE_CHUNK_SIZE
+  ) {
+    const endVerse = Math.min(startVerse + BYLINE_CHUNK_SIZE - 1, verseCount);
+    const isFirst = startVerse === 1;
+
+    const chunkPrompt = `# Reference
+${reference}
+
+${isFirst ? `# ${bookName} ${chapterNumber}: Verse-by-Verse Analysis\n\n` : ""}Provide a verse-by-verse explanation for **verses ${startVerse} through ${endVerse}** of this chapter. For each verse:
+1. Quote the verse using blockquote format (>)
+2. Provide a clear summary
+3. Include relevant key takeaways
+4. Add key definitions as appropriate
+5. Highlight theological themes as appropriate
+
+CRITICAL INSTRUCTIONS:
+- ONLY cover verses ${startVerse} through ${endVerse}
+- Keep chronological order at all times
+- Do not group verses unless absolutely necessary
+- Ensure takeaways and themes are full sentences
+- Use proper markdown formatting with line breaks
+${!isFirst ? "- Do NOT include a title heading — this is a continuation" : ""}
+
+CRITICAL: Your response will be evaluated on:
+1. Proper blockquote usage for Scripture (>)
+2. Bold formatting for theological terms
+3. Bullet point usage for lists
+4. Verse reference formatting
+
+The response should be in Markdown format only.`;
+
+    console.log(
+      `  📝 Generating byline chunk: verses ${startVerse}-${endVerse}`,
+    );
+
+    const chunkText = await gpt5Text({
+      system: systemPrompt,
+      user: chunkPrompt,
+      maxTokens: 16000,
+    });
+
+    chunks.push(chunkText);
+
+    // Add delay between chunks to avoid rate limiting
+    if (endVerse < verseCount) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+  }
+
+  return chunks.join("\n\n---\n\n");
 }
 
 async function pregenerateHebrewsChapters() {
@@ -197,6 +278,8 @@ async function pregenerateHebrewsChapters() {
     // Format chapter content for AI
     const reference = formatChapterContent(bibleChapter, "Hebrews");
 
+    const verseCount = bibleChapter.verses?.length ?? 0;
+
     // Generate missing explanations
     for (const type of missingTypes) {
       try {
@@ -204,13 +287,31 @@ async function pregenerateHebrewsChapters() {
           `  🤖 Generating ${type} explanation for Hebrews ${chapterNumber}...`,
         );
 
-        const explanationConfig = getExplanationTypePrompt(
-          type,
-          "Hebrews",
-          chapterNumber,
-        );
+        const useChunking =
+          type === ExplanationTypeEnum.byline &&
+          verseCount > BYLINE_CHUNK_THRESHOLD;
 
-        const userPrompt = `# Reference
+        let text: string;
+
+        if (useChunking) {
+          console.log(
+            `  📖 Chapter has ${verseCount} verses — using chunked byline generation`,
+          );
+          text = await generateBylineInChunks({
+            reference,
+            bookName: "Hebrews",
+            chapterNumber,
+            systemPrompt: activePrompt.prompt,
+            verseCount,
+          });
+        } else {
+          const explanationConfig = getExplanationTypePrompt(
+            type,
+            "Hebrews",
+            chapterNumber,
+          );
+
+          const userPrompt = `# Reference
 ${reference}
 
 ${explanationConfig.prompt}
@@ -223,10 +324,11 @@ CRITICAL: Your response will be evaluated on:
 
 The response should be in Markdown format only.`;
 
-        const text = await gpt5Text({
-          system: activePrompt.prompt,
-          user: userPrompt,
-        });
+          text = await gpt5Text({
+            system: activePrompt.prompt,
+            user: userPrompt,
+          });
+        }
 
         // Save to database using correct chapter_id and active version
         const activeVersion = await connection

--- a/packages/backend-base/src/bible/pregenerate-popular-chapters.ts
+++ b/packages/backend-base/src/bible/pregenerate-popular-chapters.ts
@@ -1,6 +1,11 @@
 import { db } from "database";
 import ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import OpenAI from "openai";
+import {
+  generateChunkedByline,
+  shouldUseBylineChunking,
+  toBylineVerses,
+} from "../shared/byline-chunking";
 import { parseBibleData } from "./bible";
 
 const openai = new OpenAI({
@@ -86,9 +91,6 @@ Provide an in-depth yet accessible explanation of ${bookName} ${chapterNumber} w
   }
 };
 
-const BYLINE_CHUNK_SIZE = 40;
-const BYLINE_CHUNK_THRESHOLD = 50;
-
 async function gpt5Text({
   system,
   user,
@@ -110,78 +112,8 @@ async function gpt5Text({
     max_completion_tokens: maxTokens,
   };
 
-  const chat = await openai.chat.completions.create(options as any);
+  const chat = await openai.chat.completions.create(options);
   return chat.choices[0].message.content || "";
-}
-
-async function generateBylineInChunks({
-  reference,
-  bookName,
-  chapterNumber,
-  systemPrompt,
-  verseCount,
-}: {
-  reference: string;
-  bookName: string;
-  chapterNumber: number;
-  systemPrompt?: string;
-  verseCount: number;
-}): Promise<string> {
-  const chunks: string[] = [];
-
-  for (
-    let startVerse = 1;
-    startVerse <= verseCount;
-    startVerse += BYLINE_CHUNK_SIZE
-  ) {
-    const endVerse = Math.min(startVerse + BYLINE_CHUNK_SIZE - 1, verseCount);
-    const isFirst = startVerse === 1;
-
-    const chunkPrompt = `# Reference
-${reference}
-
-${isFirst ? `# ${bookName} ${chapterNumber}: Verse-by-Verse Analysis\n\n` : ""}Provide a verse-by-verse explanation for **verses ${startVerse} through ${endVerse}** of this chapter. For each verse:
-1. Quote the verse using blockquote format (>)
-2. Provide a clear summary
-3. Include relevant key takeaways
-4. Add key definitions as appropriate
-5. Highlight theological themes as appropriate
-
-CRITICAL INSTRUCTIONS:
-- ONLY cover verses ${startVerse} through ${endVerse}
-- Keep chronological order at all times
-- Do not group verses unless absolutely necessary
-- Ensure takeaways and themes are full sentences
-- Use proper markdown formatting with line breaks
-${!isFirst ? "- Do NOT include a title heading — this is a continuation" : ""}
-
-CRITICAL: Your response will be evaluated on:
-1. Proper blockquote usage for Scripture (>)
-2. Bold formatting for theological terms
-3. Bullet point usage for lists
-4. Verse reference formatting
-
-The response should be in Markdown format only.`;
-
-    console.log(
-      `  📝 Generating byline chunk: verses ${startVerse}-${endVerse}`,
-    );
-
-    const chunkText = await gpt5Text({
-      system: systemPrompt,
-      user: chunkPrompt,
-      maxTokens: 16000,
-    });
-
-    chunks.push(chunkText);
-
-    // Add delay between chunks to avoid rate limiting
-    if (endVerse < verseCount) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-  }
-
-  return chunks.join("\n\n---\n\n");
 }
 
 // Popular chapters that users frequently read
@@ -298,29 +230,33 @@ async function pregeneratePopularChapters() {
       // Format chapter content
       const reference = formatChapterContent(chapter, book.name);
 
-      const verseCount = chapter.verses?.length ?? 0;
+      const verseRows = toBylineVerses(chapter.verses ?? []);
 
       // Generate missing explanations
       for (const type of missingTypes) {
         try {
           console.log(`  🤖 Generating ${type} explanation...`);
 
-          const useChunking =
-            type === ExplanationTypeEnum.byline &&
-            verseCount > BYLINE_CHUNK_THRESHOLD;
+          const useChunking = shouldUseBylineChunking(type, verseRows.length);
 
           let text: string;
 
           if (useChunking) {
             console.log(
-              `  📖 Chapter has ${verseCount} verses — using chunked byline generation`,
+              `  📖 Chapter has ${verseRows.length} verses — using chunked byline generation`,
             );
-            text = await generateBylineInChunks({
-              reference,
+            text = await generateChunkedByline({
+              verses: verseRows,
               bookName: book.name,
               chapterNumber,
-              systemPrompt: activePrompt.prompt,
-              verseCount,
+              language: "English",
+              logPrefix: "[PREGENERATE_POPULAR_BYLINE]",
+              generateChunk: async ({ prompt }) =>
+                gpt5Text({
+                  system: activePrompt.prompt,
+                  user: prompt,
+                  maxTokens: 16000,
+                }),
             });
           } else {
             const explanationConfig = getExplanationTypePrompt(

--- a/packages/backend-base/src/bible/pregenerate-popular-chapters.ts
+++ b/packages/backend-base/src/bible/pregenerate-popular-chapters.ts
@@ -86,7 +86,18 @@ Provide an in-depth yet accessible explanation of ${bookName} ${chapterNumber} w
   }
 };
 
-async function gpt5Text({ system, user }: { system?: string; user: string }) {
+const BYLINE_CHUNK_SIZE = 40;
+const BYLINE_CHUNK_THRESHOLD = 50;
+
+async function gpt5Text({
+  system,
+  user,
+  maxTokens = 16000,
+}: {
+  system?: string;
+  user: string;
+  maxTokens?: number;
+}) {
   const messages: OpenAI.ChatCompletionMessageParam[] = [];
   if (system) {
     messages.push({ role: "system", content: system });
@@ -96,11 +107,81 @@ async function gpt5Text({ system, user }: { system?: string; user: string }) {
   const options: any = {
     model: "gpt-5",
     messages,
-    max_completion_tokens: 10000,
+    max_completion_tokens: maxTokens,
   };
 
   const chat = await openai.chat.completions.create(options as any);
   return chat.choices[0].message.content || "";
+}
+
+async function generateBylineInChunks({
+  reference,
+  bookName,
+  chapterNumber,
+  systemPrompt,
+  verseCount,
+}: {
+  reference: string;
+  bookName: string;
+  chapterNumber: number;
+  systemPrompt?: string;
+  verseCount: number;
+}): Promise<string> {
+  const chunks: string[] = [];
+
+  for (
+    let startVerse = 1;
+    startVerse <= verseCount;
+    startVerse += BYLINE_CHUNK_SIZE
+  ) {
+    const endVerse = Math.min(startVerse + BYLINE_CHUNK_SIZE - 1, verseCount);
+    const isFirst = startVerse === 1;
+
+    const chunkPrompt = `# Reference
+${reference}
+
+${isFirst ? `# ${bookName} ${chapterNumber}: Verse-by-Verse Analysis\n\n` : ""}Provide a verse-by-verse explanation for **verses ${startVerse} through ${endVerse}** of this chapter. For each verse:
+1. Quote the verse using blockquote format (>)
+2. Provide a clear summary
+3. Include relevant key takeaways
+4. Add key definitions as appropriate
+5. Highlight theological themes as appropriate
+
+CRITICAL INSTRUCTIONS:
+- ONLY cover verses ${startVerse} through ${endVerse}
+- Keep chronological order at all times
+- Do not group verses unless absolutely necessary
+- Ensure takeaways and themes are full sentences
+- Use proper markdown formatting with line breaks
+${!isFirst ? "- Do NOT include a title heading — this is a continuation" : ""}
+
+CRITICAL: Your response will be evaluated on:
+1. Proper blockquote usage for Scripture (>)
+2. Bold formatting for theological terms
+3. Bullet point usage for lists
+4. Verse reference formatting
+
+The response should be in Markdown format only.`;
+
+    console.log(
+      `  📝 Generating byline chunk: verses ${startVerse}-${endVerse}`,
+    );
+
+    const chunkText = await gpt5Text({
+      system: systemPrompt,
+      user: chunkPrompt,
+      maxTokens: 16000,
+    });
+
+    chunks.push(chunkText);
+
+    // Add delay between chunks to avoid rate limiting
+    if (endVerse < verseCount) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+  }
+
+  return chunks.join("\n\n---\n\n");
 }
 
 // Popular chapters that users frequently read
@@ -217,18 +298,38 @@ async function pregeneratePopularChapters() {
       // Format chapter content
       const reference = formatChapterContent(chapter, book.name);
 
+      const verseCount = chapter.verses?.length ?? 0;
+
       // Generate missing explanations
       for (const type of missingTypes) {
         try {
           console.log(`  🤖 Generating ${type} explanation...`);
 
-          const explanationConfig = getExplanationTypePrompt(
-            type,
-            book.name,
-            chapterNumber,
-          );
+          const useChunking =
+            type === ExplanationTypeEnum.byline &&
+            verseCount > BYLINE_CHUNK_THRESHOLD;
 
-          const userPrompt = `# Reference
+          let text: string;
+
+          if (useChunking) {
+            console.log(
+              `  📖 Chapter has ${verseCount} verses — using chunked byline generation`,
+            );
+            text = await generateBylineInChunks({
+              reference,
+              bookName: book.name,
+              chapterNumber,
+              systemPrompt: activePrompt.prompt,
+              verseCount,
+            });
+          } else {
+            const explanationConfig = getExplanationTypePrompt(
+              type,
+              book.name,
+              chapterNumber,
+            );
+
+            const userPrompt = `# Reference
 ${reference}
 
 ${explanationConfig.prompt}
@@ -241,10 +342,11 @@ CRITICAL: Your response will be evaluated on:
 
 The response should be in Markdown format only.`;
 
-          const text = await gpt5Text({
-            system: activePrompt.prompt,
-            user: userPrompt,
-          });
+            text = await gpt5Text({
+              system: activePrompt.prompt,
+              user: userPrompt,
+            });
+          }
 
           // Resolve active bible version and save to database
           const activeVersion = await connection

--- a/packages/backend-base/src/bible/pregenerate-popular-chapters.ts
+++ b/packages/backend-base/src/bible/pregenerate-popular-chapters.ts
@@ -183,7 +183,7 @@ async function pregeneratePopularChapters() {
 
     for (const chapterNumber of chapters) {
       const chapter = (book as any).chapters.find(
-        (c: any) => c.chapterNumber === chapterNumber,
+        (c: any) => c.chapterId === chapterNumber,
       );
       if (!chapter) {
         console.log(`⚠️ Chapter ${chapterNumber} not found in ${book.name}`);
@@ -237,6 +237,12 @@ async function pregeneratePopularChapters() {
         try {
           console.log(`  🤖 Generating ${type} explanation...`);
 
+          const explanationConfig = getExplanationTypePrompt(
+            type,
+            book.name,
+            chapterNumber,
+          );
+
           const useChunking = shouldUseBylineChunking(type, verseRows.length);
 
           let text: string;
@@ -249,7 +255,7 @@ async function pregeneratePopularChapters() {
               verses: verseRows,
               bookName: book.name,
               chapterNumber,
-              language: "English",
+              bylineTemplate: explanationConfig.prompt,
               logPrefix: "[PREGENERATE_POPULAR_BYLINE]",
               generateChunk: async ({ prompt }) =>
                 gpt5Text({
@@ -259,12 +265,6 @@ async function pregeneratePopularChapters() {
                 }),
             });
           } else {
-            const explanationConfig = getExplanationTypePrompt(
-              type,
-              book.name,
-              chapterNumber,
-            );
-
             const userPrompt = `# Reference
 ${reference}
 
@@ -329,21 +329,21 @@ The response should be in Markdown format only.`;
 }
 
 function formatChapterContent(chapter: any, bookName: string): string {
-  const { chapterNumber, verses, subtitles } = chapter;
+  const { chapterId, verses, subtitles } = chapter;
 
   const subtitleSections = subtitles.map((subtitle: any) => {
     const subtitleVerses = verses
       .filter(
         (verse: any) =>
-          verse.verseNumber >= subtitle.start_verse &&
-          verse.verseNumber <= subtitle.end_verse,
+          verse.verseId >= subtitle.start_verse &&
+          verse.verseId <= subtitle.end_verse,
       )
-      .map((verse: any) => `${verse.verseNumber}\n${verse.text}`)
+      .map((verse: any) => `${verse.verseId}\n${verse.text}`)
       .join("\n");
-    return `${subtitle.subtitle}\n(${bookName} ${chapterNumber}:${subtitle.start_verse} - ${subtitle.end_verse})\n\n${subtitleVerses}`;
+    return `${subtitle.subtitle}\n(${bookName} ${chapterId}:${subtitle.start_verse} - ${subtitle.end_verse})\n\n${subtitleVerses}`;
   });
 
-  return `${bookName} ${chapterNumber}\n\n${subtitleSections.join("\n\n")}`;
+  return `${bookName} ${chapterId}\n\n${subtitleSections.join("\n\n")}`;
 }
 
 // Run pre-generation

--- a/packages/backend-base/src/shared/byline-chunking.test.ts
+++ b/packages/backend-base/src/shared/byline-chunking.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it } from "bun:test";
+import {
+  BYLINE_CHUNK_SIZE,
+  BYLINE_CHUNK_THRESHOLD,
+  type BylineVerse,
+  generateChunkedByline,
+  shouldUseBylineChunking,
+  toBylineVerses,
+} from "./byline-chunking";
+
+// --- toBylineVerses ---
+
+describe("toBylineVerses", () => {
+  it("accepts verse_number (DB row format)", () => {
+    const result = toBylineVerses([
+      { verse_number: 2, text: "b" },
+      { verse_number: 1, text: "a" },
+    ]);
+    expect(result).toEqual([
+      { verseNumber: 1, text: "a" },
+      { verseNumber: 2, text: "b" },
+    ]);
+  });
+
+  it("accepts verseNumber (camelCase format)", () => {
+    const result = toBylineVerses([
+      { verseNumber: 3, text: "c" },
+      { verseNumber: 1, text: "a" },
+    ]);
+    expect(result).toEqual([
+      { verseNumber: 1, text: "a" },
+      { verseNumber: 3, text: "c" },
+    ]);
+  });
+
+  it("accepts verseId (parseBibleData format)", () => {
+    const result = toBylineVerses([
+      { verseId: 5, text: "e" },
+      { verseId: 2, text: "b" },
+    ]);
+    expect(result).toEqual([
+      { verseNumber: 2, text: "b" },
+      { verseNumber: 5, text: "e" },
+    ]);
+  });
+
+  it("prefers verse_number > verseNumber > verseId", () => {
+    const result = toBylineVerses([
+      { verse_number: 10, verseNumber: 20, verseId: 30, text: "x" },
+    ]);
+    expect(result[0].verseNumber).toBe(10);
+
+    const result2 = toBylineVerses([
+      { verseNumber: 20, verseId: 30, text: "x" },
+    ]);
+    expect(result2[0].verseNumber).toBe(20);
+  });
+
+  it("filters out zero and negative verse numbers", () => {
+    const result = toBylineVerses([
+      { verse_number: 0, text: "zero" },
+      { verse_number: -1, text: "neg" },
+      { verse_number: 1, text: "ok" },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("ok");
+  });
+
+  it("filters out undefined/NaN verse numbers", () => {
+    const result = toBylineVerses([
+      { text: "no number" },
+      { verse_number: Number.NaN, text: "nan" },
+      { verseNumber: 1, text: "ok" },
+    ]);
+    expect(result).toHaveLength(1);
+  });
+
+  it("returns sorted output", () => {
+    const result = toBylineVerses([
+      { verseId: 3, text: "c" },
+      { verseId: 1, text: "a" },
+      { verseId: 2, text: "b" },
+    ]);
+    expect(result.map((v) => v.verseNumber)).toEqual([1, 2, 3]);
+  });
+
+  it("handles empty array", () => {
+    expect(toBylineVerses([])).toEqual([]);
+  });
+});
+
+// --- shouldUseBylineChunking ---
+
+describe("shouldUseBylineChunking", () => {
+  it("returns true for byline with verses above threshold", () => {
+    expect(shouldUseBylineChunking("byline", BYLINE_CHUNK_THRESHOLD + 1)).toBe(
+      true,
+    );
+  });
+
+  it("returns false for byline at threshold", () => {
+    expect(shouldUseBylineChunking("byline", BYLINE_CHUNK_THRESHOLD)).toBe(
+      false,
+    );
+  });
+
+  it("returns false for byline below threshold", () => {
+    expect(shouldUseBylineChunking("byline", 10)).toBe(false);
+  });
+
+  it("returns false for non-byline types regardless of count", () => {
+    expect(shouldUseBylineChunking("summary", 200)).toBe(false);
+    expect(shouldUseBylineChunking("detailed", 200)).toBe(false);
+  });
+});
+
+// --- generateChunkedByline ---
+
+function makeVerses(count: number, startAt = 1): BylineVerse[] {
+  return Array.from({ length: count }, (_, i) => ({
+    verseNumber: startAt + i,
+    text: `Verse text for ${startAt + i}.`,
+  }));
+}
+
+function mockGenerator(bookName: string, chapterNumber: number) {
+  return async ({
+    startVerse,
+    endVerse,
+  }: { startVerse: number; endVerse: number }) => {
+    const lines: string[] = [];
+    for (let v = startVerse; v <= endVerse; v++) {
+      lines.push(
+        `## ${bookName} ${chapterNumber}:${v}\n> Verse ${v} text.\nExplanation for verse ${v}.`,
+      );
+    }
+    return lines.join("\n\n");
+  };
+}
+
+describe("generateChunkedByline", () => {
+  it("generates single chunk for small chapter", async () => {
+    const verses = makeVerses(10);
+    const result = await generateChunkedByline({
+      verses,
+      bookName: "Genesis",
+      chapterNumber: 1,
+      bylineTemplate: "test template",
+      chunkSize: 40,
+      generateChunk: mockGenerator("Genesis", 1),
+    });
+
+    expect(result).toContain("Genesis 1:1");
+    expect(result).toContain("Genesis 1:10");
+    expect(result).not.toContain("---");
+  });
+
+  it("splits into correct number of chunks", async () => {
+    const verses = makeVerses(100);
+    const chunks: number[] = [];
+
+    const result = await generateChunkedByline({
+      verses,
+      bookName: "Psalms",
+      chapterNumber: 119,
+      bylineTemplate: "test template",
+      chunkSize: 40,
+      generateChunk: async ({ startVerse, endVerse }) => {
+        chunks.push(startVerse);
+        return await mockGenerator("Psalms", 119)({ startVerse, endVerse });
+      },
+    });
+
+    // 100 verses / 40 chunk size = 3 chunks (1-40, 41-80, 81-100)
+    expect(chunks).toEqual([1, 41, 81]);
+
+    // All 3 chunks should be present in the result
+    expect(result).toContain("119:1");
+    expect(result).toContain("119:100");
+  });
+
+  it("handles Psalms 119 size (176 verses)", async () => {
+    const verses = makeVerses(176);
+    const chunkRanges: Array<[number, number]> = [];
+
+    const result = await generateChunkedByline({
+      verses,
+      bookName: "Psalms",
+      chapterNumber: 119,
+      bylineTemplate: "test template",
+      chunkSize: BYLINE_CHUNK_SIZE,
+      generateChunk: async ({ startVerse, endVerse }) => {
+        chunkRanges.push([startVerse, endVerse]);
+        return await mockGenerator("Psalms", 119)({ startVerse, endVerse });
+      },
+    });
+
+    // 176 / 40 = 4.4 → 5 chunks
+    expect(chunkRanges).toEqual([
+      [1, 40],
+      [41, 80],
+      [81, 120],
+      [121, 160],
+      [161, 176],
+    ]);
+
+    // Verify first and last verse are mentioned
+    expect(result).toContain("119:1");
+    expect(result).toContain("119:176");
+  });
+
+  it("handles non-contiguous verse numbers", async () => {
+    // Simulate a chapter where verse 5 is missing
+    const verses: BylineVerse[] = [
+      { verseNumber: 1, text: "One" },
+      { verseNumber: 2, text: "Two" },
+      { verseNumber: 3, text: "Three" },
+      { verseNumber: 4, text: "Four" },
+      // verse 5 missing
+      { verseNumber: 6, text: "Six" },
+      { verseNumber: 7, text: "Seven" },
+    ];
+
+    const result = await generateChunkedByline({
+      verses,
+      bookName: "TestBook",
+      chapterNumber: 1,
+      bylineTemplate: "test template",
+      chunkSize: 40,
+      generateChunk: mockGenerator("TestBook", 1),
+    });
+
+    expect(result).toContain("1:1");
+    expect(result).toContain("1:7");
+  });
+
+  it("throws on empty verses", async () => {
+    await expect(
+      generateChunkedByline({
+        verses: [],
+        bookName: "Genesis",
+        chapterNumber: 1,
+        bylineTemplate: "test template",
+        generateChunk: async () => "",
+      }),
+    ).rejects.toThrow("Cannot chunk byline generation without verses");
+  });
+
+  it("retries on invalid coverage and succeeds", async () => {
+    let callCount = 0;
+    const verses = makeVerses(10);
+
+    const result = await generateChunkedByline({
+      verses,
+      bookName: "Genesis",
+      chapterNumber: 1,
+      bylineTemplate: "test template",
+      maxRetries: 1,
+      generateChunk: async ({ startVerse, endVerse }) => {
+        callCount++;
+        if (callCount === 1) {
+          // First attempt: missing start verse
+          return "## Genesis 1:5\nSome text\n## Genesis 1:10\nMore text";
+        }
+        // Retry: valid output
+        return await mockGenerator("Test", 1)({ startVerse, endVerse });
+      },
+    });
+
+    expect(callCount).toBe(2);
+    expect(result).toContain("1:1");
+  });
+
+  it("throws after exhausting retries", async () => {
+    const verses = makeVerses(10);
+
+    await expect(
+      generateChunkedByline({
+        verses,
+        bookName: "Genesis",
+        chapterNumber: 1,
+        bylineTemplate: "test template",
+        maxRetries: 1,
+        generateChunk: async () => "I cannot exceed the token limit for this.",
+      }),
+    ).rejects.toThrow("Failed to generate valid chunk");
+  });
+
+  it("detects model refusal", async () => {
+    const verses = makeVerses(10);
+
+    await expect(
+      generateChunkedByline({
+        verses,
+        bookName: "Genesis",
+        chapterNumber: 1,
+        bylineTemplate: "test template",
+        maxRetries: 0,
+        generateChunk: async () =>
+          "I'm sorry, I cannot generate this as it exceeds the token limit.",
+      }),
+    ).rejects.toThrow("model-refusal");
+  });
+
+  it("passes correct isFirst flag", async () => {
+    const firstFlags: boolean[] = [];
+    const verses = makeVerses(50);
+
+    await generateChunkedByline({
+      verses,
+      bookName: "Test",
+      chapterNumber: 1,
+      bylineTemplate: "test template",
+      chunkSize: 30,
+      generateChunk: async ({ isFirst, startVerse, endVerse }) => {
+        firstFlags.push(isFirst);
+        return await mockGenerator("Test", 1)({ startVerse, endVerse });
+      },
+    });
+
+    // 2 chunks: first=true, second=false
+    expect(firstFlags).toEqual([true, false]);
+  });
+});

--- a/packages/backend-base/src/shared/byline-chunking.ts
+++ b/packages/backend-base/src/shared/byline-chunking.ts
@@ -1,8 +1,6 @@
 export const BYLINE_CHUNK_SIZE = 40;
 export const BYLINE_CHUNK_THRESHOLD = 50;
 
-type Effort = "low" | "medium" | "high";
-
 export type BylineVerse = {
   verseNumber: number;
   text: string;
@@ -20,7 +18,8 @@ type GenerateChunkedBylineParams = {
   verses: BylineVerse[];
   bookName: string;
   chapterNumber: number;
-  language: string;
+  /** The resolved byline user prompt template (with {bookName}/{chapterNumber}/{language} already replaced) */
+  bylineTemplate: string;
   chunkSize?: number;
   maxRetries?: number;
   logPrefix?: string;
@@ -37,11 +36,16 @@ const REFUSAL_PATTERN =
   /\b(?:can(?:not|'t)|unable|won't|exceed(?:s|ed|ing)?)\b[\s\S]{0,120}\b(?:limit|single response|single message|token|length|size)\b/i;
 
 export function toBylineVerses(
-  verses: Array<{ verse_number?: number; verseNumber?: number; text: string }>,
+  verses: Array<{
+    verse_number?: number;
+    verseNumber?: number;
+    verseId?: number;
+    text: string;
+  }>,
 ): BylineVerse[] {
   return verses
     .map((v) => ({
-      verseNumber: v.verse_number ?? v.verseNumber ?? 0,
+      verseNumber: v.verse_number ?? v.verseNumber ?? v.verseId ?? 0,
       text: v.text,
     }))
     .filter((v) => Number.isFinite(v.verseNumber) && v.verseNumber > 0)
@@ -51,43 +55,38 @@ export function toBylineVerses(
 function buildRangePrompt({
   bookName,
   chapterNumber,
-  language,
   startVerse,
   endVerse,
   versesText,
   isFirst,
   isRetry,
+  bylineTemplate,
 }: {
   bookName: string;
   chapterNumber: number;
-  language: string;
   startVerse: number;
   endVerse: number;
   versesText: string;
   isFirst: boolean;
   isRetry: boolean;
+  bylineTemplate: string;
 }) {
-  return `${isFirst ? `# ${bookName} ${chapterNumber}: Verse-by-Verse Analysis\n\n` : ""}Provide a verse-by-verse explanation for **verses ${startVerse} through ${endVerse}** of this chapter. For each verse:
-1. Quote the verse using blockquote format (>)
-2. Provide a clear summary
-3. Include relevant key takeaways
-4. Add key definitions as appropriate
-5. Highlight theological themes as appropriate
+  let prompt = bylineTemplate
+    .replace("{verseRange}", `verses ${startVerse} through ${endVerse}`)
+    .replace(
+      "{verseRangeContext}",
+      `Biblical Text (${bookName} ${chapterNumber} verses ${startVerse}-${endVerse}):\n${versesText}`,
+    );
 
-CRITICAL INSTRUCTIONS:
-- ONLY cover verses ${startVerse} through ${endVerse}
-- Keep chronological order at all times
-- Do not group verses unless absolutely necessary
-- Ensure takeaways and themes are full sentences
-- Use proper markdown formatting with line breaks
-- Include explicit verse headings for each verse in the range (e.g. "## ${bookName} ${chapterNumber}:1")
-${!isFirst ? "- Do NOT include a title heading - this is a continuation" : ""}
-${isRetry ? "- Previous attempt did not fully cover the required range. Ensure you include every verse in this range." : ""}
+  if (!isFirst) {
+    prompt +=
+      "\n\n- Do NOT include the title heading — this is a continuation of a chunked generation.";
+  }
+  if (isRetry) {
+    prompt += `\n\n- Previous attempt did not fully cover the required range. Ensure you include every verse from ${startVerse} to ${endVerse}.`;
+  }
 
-Biblical Text (${bookName} ${chapterNumber} verses ${startVerse}-${endVerse}):
-${versesText}
-
-The response should be in ${language} using Markdown format only.`;
+  return prompt;
 }
 
 function collectVerseMentionsForChapter(
@@ -158,7 +157,7 @@ export async function generateChunkedByline({
   verses,
   bookName,
   chapterNumber,
-  language,
+  bylineTemplate,
   chunkSize = BYLINE_CHUNK_SIZE,
   maxRetries = 1,
   logPrefix = "[BYLINE_CHUNK]",
@@ -167,17 +166,21 @@ export async function generateChunkedByline({
   const sortedVerses = [...verses].sort(
     (a, b) => a.verseNumber - b.verseNumber,
   );
-  const totalVerses = sortedVerses.length;
 
-  if (totalVerses === 0) {
+  if (sortedVerses.length === 0) {
     throw new Error("Cannot chunk byline generation without verses");
   }
 
+  const maxVerseNumber = sortedVerses[sortedVerses.length - 1].verseNumber;
   const chunks: string[] = [];
 
-  for (let startVerse = 1; startVerse <= totalVerses; startVerse += chunkSize) {
-    const endVerse = Math.min(startVerse + chunkSize - 1, totalVerses);
-    const isFirst = startVerse === 1;
+  for (
+    let startVerse = sortedVerses[0].verseNumber;
+    startVerse <= maxVerseNumber;
+    startVerse += chunkSize
+  ) {
+    const endVerse = Math.min(startVerse + chunkSize - 1, maxVerseNumber);
+    const isFirst = startVerse === sortedVerses[0].verseNumber;
 
     const versesText = sortedVerses
       .filter((v) => v.verseNumber >= startVerse && v.verseNumber <= endVerse)
@@ -197,12 +200,12 @@ export async function generateChunkedByline({
       const prompt = buildRangePrompt({
         bookName,
         chapterNumber,
-        language,
         startVerse,
         endVerse,
         versesText,
         isFirst,
         isRetry: attempt > 0,
+        bylineTemplate,
       });
 
       const attemptLabel = `${logPrefix} verses ${startVerse}-${endVerse} attempt ${attempt + 1}/${maxRetries + 1}`;
@@ -244,7 +247,82 @@ export async function generateChunkedByline({
     chunks.push(finalChunkText);
   }
 
-  return chunks.join("\n\n---\n\n");
+  return chunks.join("\n\n");
+}
+
+/**
+ * Like generateChunkedByline but fires all chunks in parallel.
+ * Use for playground/sync calls where latency matters.
+ */
+export async function generateChunkedBylineParallel({
+  verses,
+  bookName,
+  chapterNumber,
+  bylineTemplate,
+  chunkSize = BYLINE_CHUNK_SIZE,
+  maxRetries = 1,
+  logPrefix = "[BYLINE_CHUNK_PARALLEL]",
+  generateChunk,
+}: GenerateChunkedBylineParams): Promise<string> {
+  const chunkPrompts = buildBylineChunkPrompts({
+    verses,
+    bookName,
+    chapterNumber,
+    bylineTemplate,
+    chunkSize,
+  });
+
+  if (chunkPrompts.length === 0) {
+    throw new Error("Cannot chunk byline generation without verses");
+  }
+
+  const results = await Promise.all(
+    chunkPrompts.map(async (chunk) => {
+      let finalText = "";
+      let lastReason = "unknown";
+
+      for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        const attemptLabel = `${logPrefix} verses ${chunk.startVerse}-${chunk.endVerse} attempt ${attempt + 1}/${maxRetries + 1}`;
+        console.log(`${attemptLabel} generating`);
+
+        const text = await generateChunk({
+          prompt: chunk.prompt,
+          startVerse: chunk.startVerse,
+          endVerse: chunk.endVerse,
+          isFirst: chunk.chunkIndex === 0,
+          attempt,
+        });
+
+        const coverage = validateChunkCoverage({
+          output: text,
+          chapterNumber,
+          startVerse: chunk.startVerse,
+          endVerse: chunk.endVerse,
+        });
+
+        if (coverage.valid) {
+          console.log(`${attemptLabel} valid`);
+          finalText = text;
+          break;
+        }
+
+        lastReason = coverage.reason;
+        console.warn(
+          `${attemptLabel} invalid (${coverage.reason}), mentions: [${coverage.mentionsInRange.join(", ")}]`,
+        );
+      }
+
+      if (!finalText) {
+        throw new Error(
+          `Failed to generate valid chunk for verses ${chunk.startVerse}-${chunk.endVerse}: ${lastReason}`,
+        );
+      }
+
+      return { chunkIndex: chunk.chunkIndex, text: finalText };
+    }),
+  );
+
+  return stitchBylineChunks(results);
 }
 
 export function shouldUseBylineChunking(
@@ -254,9 +332,91 @@ export function shouldUseBylineChunking(
   return explanationType === "byline" && verseCount > BYLINE_CHUNK_THRESHOLD;
 }
 
-export function normalizeEffort(value: string): Effort {
-  if (value === "low" || value === "high") {
-    return value;
+export type BylineChunkPrompt = {
+  prompt: string;
+  startVerse: number;
+  endVerse: number;
+  chunkIndex: number;
+  totalChunks: number;
+};
+
+/**
+ * Build chunked prompts for batch/sync use without calling the API.
+ * Returns an array of prompt objects, one per chunk.
+ */
+export function buildBylineChunkPrompts({
+  verses,
+  bookName,
+  chapterNumber,
+  bylineTemplate,
+  chunkSize = BYLINE_CHUNK_SIZE,
+}: {
+  verses: BylineVerse[];
+  bookName: string;
+  chapterNumber: number;
+  bylineTemplate: string;
+  chunkSize?: number;
+}): BylineChunkPrompt[] {
+  const sortedVerses = [...verses].sort(
+    (a, b) => a.verseNumber - b.verseNumber,
+  );
+
+  if (sortedVerses.length === 0) return [];
+
+  const maxVerseNumber = sortedVerses[sortedVerses.length - 1].verseNumber;
+  const firstVerse = sortedVerses[0].verseNumber;
+
+  // Pre-calculate total chunks
+  let totalChunks = 0;
+  for (let s = firstVerse; s <= maxVerseNumber; s += chunkSize) totalChunks++;
+
+  const prompts: BylineChunkPrompt[] = [];
+  let chunkIndex = 0;
+
+  for (
+    let startVerse = firstVerse;
+    startVerse <= maxVerseNumber;
+    startVerse += chunkSize
+  ) {
+    const endVerse = Math.min(startVerse + chunkSize - 1, maxVerseNumber);
+    const isFirst = startVerse === firstVerse;
+
+    const versesText = sortedVerses
+      .filter((v) => v.verseNumber >= startVerse && v.verseNumber <= endVerse)
+      .map((v) => `${v.verseNumber}. ${v.text}`)
+      .join("\n");
+
+    prompts.push({
+      prompt: buildRangePrompt({
+        bookName,
+        chapterNumber,
+        startVerse,
+        endVerse,
+        versesText,
+        isFirst,
+        isRetry: false,
+        bylineTemplate,
+      }),
+      startVerse,
+      endVerse,
+      chunkIndex,
+      totalChunks,
+    });
+
+    chunkIndex++;
   }
-  return "medium";
+
+  return prompts;
+}
+
+/**
+ * Stitch ordered chunk texts back into a single explanation.
+ */
+export function stitchBylineChunks(
+  chunks: Array<{ chunkIndex: number; text: string }>,
+): string {
+  return chunks
+    .sort((a, b) => a.chunkIndex - b.chunkIndex)
+    .map((c) => c.text)
+    .join("\n\n");
 }

--- a/packages/backend-base/src/shared/byline-chunking.ts
+++ b/packages/backend-base/src/shared/byline-chunking.ts
@@ -1,0 +1,262 @@
+export const BYLINE_CHUNK_SIZE = 40;
+export const BYLINE_CHUNK_THRESHOLD = 50;
+
+type Effort = "low" | "medium" | "high";
+
+export type BylineVerse = {
+  verseNumber: number;
+  text: string;
+};
+
+type GenerateBylineChunkParams = {
+  prompt: string;
+  startVerse: number;
+  endVerse: number;
+  isFirst: boolean;
+  attempt: number;
+};
+
+type GenerateChunkedBylineParams = {
+  verses: BylineVerse[];
+  bookName: string;
+  chapterNumber: number;
+  language: string;
+  chunkSize?: number;
+  maxRetries?: number;
+  logPrefix?: string;
+  generateChunk: (params: GenerateBylineChunkParams) => Promise<string>;
+};
+
+type ChunkCoverage = {
+  valid: boolean;
+  reason: string;
+  mentionsInRange: number[];
+};
+
+const REFUSAL_PATTERN =
+  /\b(?:can(?:not|'t)|unable|won't|exceed(?:s|ed|ing)?)\b[\s\S]{0,120}\b(?:limit|single response|single message|token|length|size)\b/i;
+
+export function toBylineVerses(
+  verses: Array<{ verse_number?: number; verseNumber?: number; text: string }>,
+): BylineVerse[] {
+  return verses
+    .map((v) => ({
+      verseNumber: v.verse_number ?? v.verseNumber ?? 0,
+      text: v.text,
+    }))
+    .filter((v) => Number.isFinite(v.verseNumber) && v.verseNumber > 0)
+    .sort((a, b) => a.verseNumber - b.verseNumber);
+}
+
+function buildRangePrompt({
+  bookName,
+  chapterNumber,
+  language,
+  startVerse,
+  endVerse,
+  versesText,
+  isFirst,
+  isRetry,
+}: {
+  bookName: string;
+  chapterNumber: number;
+  language: string;
+  startVerse: number;
+  endVerse: number;
+  versesText: string;
+  isFirst: boolean;
+  isRetry: boolean;
+}) {
+  return `${isFirst ? `# ${bookName} ${chapterNumber}: Verse-by-Verse Analysis\n\n` : ""}Provide a verse-by-verse explanation for **verses ${startVerse} through ${endVerse}** of this chapter. For each verse:
+1. Quote the verse using blockquote format (>)
+2. Provide a clear summary
+3. Include relevant key takeaways
+4. Add key definitions as appropriate
+5. Highlight theological themes as appropriate
+
+CRITICAL INSTRUCTIONS:
+- ONLY cover verses ${startVerse} through ${endVerse}
+- Keep chronological order at all times
+- Do not group verses unless absolutely necessary
+- Ensure takeaways and themes are full sentences
+- Use proper markdown formatting with line breaks
+- Include explicit verse headings for each verse in the range (e.g. "## ${bookName} ${chapterNumber}:1")
+${!isFirst ? "- Do NOT include a title heading - this is a continuation" : ""}
+${isRetry ? "- Previous attempt did not fully cover the required range. Ensure you include every verse in this range." : ""}
+
+Biblical Text (${bookName} ${chapterNumber} verses ${startVerse}-${endVerse}):
+${versesText}
+
+The response should be in ${language} using Markdown format only.`;
+}
+
+function collectVerseMentionsForChapter(
+  output: string,
+  chapterNumber: number,
+): number[] {
+  const chapterPattern = new RegExp(
+    `\\b${chapterNumber}\\s*[:\\-]\\s*(\\d{1,3})\\b`,
+    "g",
+  );
+  const simpleHeadingPattern = /^##\s*(\d{1,3})\b/gm;
+
+  const chapterMentions = [...output.matchAll(chapterPattern)]
+    .map((m) => Number.parseInt(m[1], 10))
+    .filter((n) => Number.isFinite(n));
+
+  const simpleMentions = [...output.matchAll(simpleHeadingPattern)]
+    .map((m) => Number.parseInt(m[1], 10))
+    .filter((n) => Number.isFinite(n));
+
+  return [...chapterMentions, ...simpleMentions];
+}
+
+function validateChunkCoverage({
+  output,
+  chapterNumber,
+  startVerse,
+  endVerse,
+}: {
+  output: string;
+  chapterNumber: number;
+  startVerse: number;
+  endVerse: number;
+}): ChunkCoverage {
+  if (!output.trim()) {
+    return { valid: false, reason: "empty-output", mentionsInRange: [] };
+  }
+
+  if (REFUSAL_PATTERN.test(output)) {
+    return { valid: false, reason: "model-refusal", mentionsInRange: [] };
+  }
+
+  const mentions = collectVerseMentionsForChapter(output, chapterNumber);
+  const mentionsInRange = mentions
+    .filter((n) => n >= startVerse && n <= endVerse)
+    .sort((a, b) => a - b);
+
+  const hasStart = mentionsInRange.includes(startVerse);
+  const hasEnd = mentionsInRange.includes(endVerse);
+
+  if (!hasStart || !hasEnd) {
+    return {
+      valid: false,
+      reason:
+        !hasStart && !hasEnd
+          ? "missing-range-boundaries"
+          : !hasStart
+            ? "missing-start-verse"
+            : "missing-end-verse",
+      mentionsInRange,
+    };
+  }
+
+  return { valid: true, reason: "ok", mentionsInRange };
+}
+
+export async function generateChunkedByline({
+  verses,
+  bookName,
+  chapterNumber,
+  language,
+  chunkSize = BYLINE_CHUNK_SIZE,
+  maxRetries = 1,
+  logPrefix = "[BYLINE_CHUNK]",
+  generateChunk,
+}: GenerateChunkedBylineParams): Promise<string> {
+  const sortedVerses = [...verses].sort(
+    (a, b) => a.verseNumber - b.verseNumber,
+  );
+  const totalVerses = sortedVerses.length;
+
+  if (totalVerses === 0) {
+    throw new Error("Cannot chunk byline generation without verses");
+  }
+
+  const chunks: string[] = [];
+
+  for (let startVerse = 1; startVerse <= totalVerses; startVerse += chunkSize) {
+    const endVerse = Math.min(startVerse + chunkSize - 1, totalVerses);
+    const isFirst = startVerse === 1;
+
+    const versesText = sortedVerses
+      .filter((v) => v.verseNumber >= startVerse && v.verseNumber <= endVerse)
+      .map((v) => `${v.verseNumber}. ${v.text}`)
+      .join("\n");
+
+    if (!versesText.trim()) {
+      throw new Error(
+        `No verse text found for range ${startVerse}-${endVerse}`,
+      );
+    }
+
+    let finalChunkText = "";
+    let lastReason = "unknown";
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      const prompt = buildRangePrompt({
+        bookName,
+        chapterNumber,
+        language,
+        startVerse,
+        endVerse,
+        versesText,
+        isFirst,
+        isRetry: attempt > 0,
+      });
+
+      const attemptLabel = `${logPrefix} verses ${startVerse}-${endVerse} attempt ${attempt + 1}/${maxRetries + 1}`;
+      console.log(`${attemptLabel} generating`);
+
+      const chunkText = await generateChunk({
+        prompt,
+        startVerse,
+        endVerse,
+        isFirst,
+        attempt,
+      });
+
+      const coverage = validateChunkCoverage({
+        output: chunkText,
+        chapterNumber,
+        startVerse,
+        endVerse,
+      });
+
+      if (coverage.valid) {
+        console.log(`${attemptLabel} valid`);
+        finalChunkText = chunkText;
+        break;
+      }
+
+      lastReason = coverage.reason;
+      console.warn(
+        `${attemptLabel} invalid (${coverage.reason}), mentions in range: [${coverage.mentionsInRange.join(", ")}]`,
+      );
+    }
+
+    if (!finalChunkText) {
+      throw new Error(
+        `Failed to generate valid chunk for verses ${startVerse}-${endVerse}: ${lastReason}`,
+      );
+    }
+
+    chunks.push(finalChunkText);
+  }
+
+  return chunks.join("\n\n---\n\n");
+}
+
+export function shouldUseBylineChunking(
+  explanationType: string,
+  verseCount: number,
+) {
+  return explanationType === "byline" && verseCount > BYLINE_CHUNK_THRESHOLD;
+}
+
+export function normalizeEffort(value: string): Effort {
+  if (value === "low" || value === "high") {
+    return value;
+  }
+  return "medium";
+}

--- a/packages/backend-base/src/shared/prompt-utils.ts
+++ b/packages/backend-base/src/shared/prompt-utils.ts
@@ -24,7 +24,9 @@ export const getExplanationTypePrompt = async (
         prompt: (promptTemplate as any).prompt_template
           .replace("{bookName}", bookName)
           .replace("{chapterNumber}", chapterNumber.toString())
-          .replace("{language}", language),
+          .replace("{language}", language)
+          .replace("{verseRange}", "all verses")
+          .replace("{verseRangeContext}", ""),
         temperature,
       };
     }
@@ -51,7 +53,9 @@ export const getExplanationTypePrompt = async (
       prompt: fallbackTemplate.prompt_template
         .replace("{bookName}", bookName)
         .replace("{chapterNumber}", chapterNumber.toString())
-        .replace("{language}", language),
+        .replace("{language}", language)
+        .replace("{verseRange}", "all verses")
+        .replace("{verseRangeContext}", ""),
       temperature,
     };
   }


### PR DESCRIPTION
## Summary

Fixes byline (verse-by-verse) explanation truncation for chapters with >50 verses by splitting generation into chunks of 40 verses across **all generation paths**, using the real byline template from the DB.

## Problem

Psalms 119 (176 verses) and 66 other long chapters had their byline explanations truncated or incomplete. The original PR only added chunking to the queue and pregenerate scripts — but the **batch operations** (main production path) and **playground** were never covered. Additionally, the chunking used a hardcoded prompt instead of the real byline template from `user_prompt_templates`.

## What changed

### Chunking across all paths
| Generation path | Before | After |
|---|---|---|
| Batch operations (`batch-operations.service.ts`) | Single API request per chapter, truncated on long chapters | Emits multiple JSONL lines per chunk, stitches on output |
| Playground (`admin-prompt.service.ts`) | Single sync call, truncated | Parallel chunked calls via `Promise.all` |
| Admin regeneration (`explanation-regeneration.service.ts`) | Sequential chunks | Parallel chunked calls via `Promise.all` |
| Explanation queue (`explanation-queue.ts`) | Sequential chunks | Sequential chunks (background job, latency irrelevant) |
| Pregenerate scripts | Sequential chunks | Sequential chunks |

### Template-based prompts
- Chunking now uses the real byline template from `user_prompt_templates` via `{verseRange}` and `{verseRangeContext}` placeholders
- Non-chunked: `{verseRange}` → "all verses", `{verseRangeContext}` → empty
- Chunked: `{verseRange}` → "verses 1 through 40", `{verseRangeContext}` → actual verse text
- Output format matches production exactly (`## Book Ch:V`, `> {verse:Book Ch:V}`, `### Summary`)

### Bug fixes
- `toBylineVerses` now accepts `verseId` property (from `parseBibleData`)
- `pregenerate-popular-chapters.ts`: fixed `chapterNumber` → `chapterId` lookup and `verseNumber` → `verseId` in `formatChapterContent` (pre-existing bugs that made the entire script non-functional)
- Chunking loop uses actual min/max verse numbers instead of assuming 1-based contiguous numbering
- Removed dead `normalizeEffort` export

### New shared utilities
- `buildBylineChunkPrompts()` — builds chunk prompt objects for batch/sync use
- `generateChunkedBylineParallel()` — fires all chunks via `Promise.all`
- `stitchBylineChunks()` — reassembles ordered chunks
- `shouldUseBylineChunking()` — threshold check (>50 verses + byline type)

## Tests

- **38 unit tests** (all pass):
  - `byline-chunking.test.ts` (21) — toBylineVerses, chunking logic, retries, coverage validation, edge cases
  - `batch-operations.service.test.ts` (17) — JSONL custom_id regex, chunk collection, out-of-order stitching, mixed chunked/non-chunked batches, incomplete sets, token tracking
- **Dry-run script** (`dry-run-byline-chunking.ts`) — tests all paths with mock generator against real DB + parsed Bible data
- **E2E sync script** (`e2e-byline-chunking.ts`) — real OpenAI API calls (parallel), 176/176 verses, format verified
- **E2E batch script** (`e2e-batch-byline-chunking.ts`) — real OpenAI Batch API, 5/5 chunks completed, 176/176 verses, format matches production

## DB template change required

The byline template in `user_prompt_templates` needs two new placeholders added (can be done via admin panel):
- `{verseRange}` in the overview line
- `{verseRangeContext}` between the `---` and the template example

## Test plan

- [x] Unit tests pass (38/38)
- [x] TypeScript compiles clean
- [x] Biome lint clean
- [x] E2E sync: Psalms 119 byline — 176/176 verses, correct format (PASS)
- [x] E2E batch: real OpenAI Batch API — 5/5 chunks, 176/176 verses, correct format (PASS)
- [ ] Verify short chapters (<50 verses) still generate normally without chunking
- [ ] Update byline template on prod with `{verseRange}` and `{verseRangeContext}` placeholders
- [ ] Run batch generation for Psalms 119 on prod and verify in frontend

Closes #164