### PR TITLE
ci: Slack-to-GitHub issues auto-sync

### DIFF
--- a/.github/workflows/slack-to-github-issues.yml
+++ b/.github/workflows/slack-to-github-issues.yml
@@ -20,13 +20,19 @@ jobs:
       - name: Sync Slack messages to GitHub issues
         shell: python3 {0}
         run: |
-          import json, os, re, subprocess, urllib.request, urllib.error
+          import json, os, re, subprocess, sys, urllib.request, urllib.error, urllib.parse
           from datetime import datetime, timezone
 
-          SLACK_TOKEN = os.environ["SLACK_BOT_TOKEN"]
-          REPO = os.environ["GITHUB_REPOSITORY"]  # verse-mate/verse-mate
+          SLACK_TOKEN = os.environ.get("SLACK_BOT_TOKEN")
+          if not SLACK_TOKEN:
+              print("ERROR: SLACK_BOT_TOKEN secret is not set. Add it in repo Settings > Secrets.")
+              sys.exit(1)
+
+          REPO = os.environ["GITHUB_REPOSITORY"]
 
           # Channel -> repo mapping
+          # This workflow only processes channels mapped to THIS repo.
+          # verse-mate/verse-mate-mobile has its own copy for #bugs-mobile and #features.
           CHANNEL_MAP = {
               "C09PJ8QGWJK": {"name": "#bugs-mobile", "repo": "verse-mate/verse-mate-mobile"},
               "C090DUA9GTF": {"name": "#features", "repo": "verse-mate/verse-mate-mobile"},
@@ -36,7 +42,7 @@ jobs:
           def slack_api(method, params=None):
               url = f"https://slack.com/api/{method}"
               if params:
-                  url += "?" + "&".join(f"{k}={v}" for k, v in params.items())
+                  url += "?" + urllib.parse.urlencode(params)
               req = urllib.request.Request(url, headers={"Authorization": f"Bearer {SLACK_TOKEN}"})
               with urllib.request.urlopen(req) as resp:
                   return json.loads(resp.read())
@@ -46,12 +52,16 @@ jobs:
               return result.stdout.strip(), result.returncode
 
           def get_existing_issue_titles(repo):
-              out, rc = gh_run(["gh", "issue", "list", "--repo", repo, "--state", "all",
-                                "--limit", "500", "--json", "title,state"])
-              if rc != 0:
-                  return {}
-              issues = json.loads(out)
-              return {i["title"].lower().strip(): i["state"] for i in issues}
+              """Fetch up to 1000 issue titles for dedup. Paginates via gh CLI."""
+              all_issues = {}
+              for state in ["open", "closed"]:
+                  out, rc = gh_run(["gh", "issue", "list", "--repo", repo, "--state", state,
+                                    "--limit", "500", "--json", "title"])
+                  if rc != 0:
+                      continue
+                  for i in json.loads(out):
+                      all_issues[i["title"].lower().strip()] = state
+              return all_issues
 
           def categorize(text, channel_name):
               text_lower = text.lower()
@@ -67,8 +77,9 @@ jobs:
                   return "bug", "Bug"
               return "triage", "Needs Triage"
 
-          def make_title(text):
-              first_line = text.split("\n")[0].strip()
+          def make_title(clean_text):
+              """Generate issue title from already-cleaned text (no raw Slack user IDs)."""
+              first_line = clean_text.split("\n")[0].strip()
               title = re.sub(r'^(Bug|UX|UI|Feature|Awesome feature|Key feature|Topic feature|Depth|Context)\s*[(:]\s*',
                              '', first_line, flags=re.IGNORECASE).strip()
               title = re.sub(r'^(from user|by user|from power user)\s*[-:]\s*', '', title, flags=re.IGNORECASE).strip()
@@ -77,7 +88,7 @@ jobs:
                   title = title[:72] + "..."
               if title and title[0].islower():
                   title = title[0].upper() + title[1:]
-              return title or text[:72] + "..."
+              return title or clean_text[:72] + "..."
 
           def is_actionable(text, subtype):
               if subtype in ("channel_join", "channel_leave", "channel_topic", "channel_purpose"):
@@ -98,6 +109,7 @@ jobs:
               channel_name = config["name"]
               target_repo = config["repo"]
 
+              # Only process channels that belong to THIS repo
               if target_repo != REPO:
                   continue
 
@@ -134,10 +146,12 @@ jobs:
                   if not is_actionable(text, subtype):
                       continue
 
+                  # Clean user mentions before generating title or body
                   clean_text = re.sub(r'<@[A-Z0-9]+>', '@team-member', text)
                   title = make_title(clean_text)
                   label, category = categorize(clean_text, channel_name)
 
+                  # Dedup: exact or 75%+ word overlap with existing issues
                   title_lower = title.lower().strip()
                   is_dup = False
                   for existing_title in existing:

--- a/.github/workflows/slack-to-github-issues.yml
+++ b/.github/workflows/slack-to-github-issues.yml
@@ -1,0 +1,183 @@
+name: Slack to GitHub Issues Sync
+
+on:
+  schedule:
+    - cron: '*/15 * * * *' # Every 15 minutes
+  workflow_dispatch: # Manual trigger
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Sync Slack messages to GitHub issues
+        shell: python3 {0}
+        run: |
+          import json, os, re, subprocess, urllib.request, urllib.error
+          from datetime import datetime, timezone
+
+          SLACK_TOKEN = os.environ["SLACK_BOT_TOKEN"]
+          REPO = os.environ["GITHUB_REPOSITORY"]  # verse-mate/verse-mate
+
+          # Channel -> repo mapping
+          CHANNEL_MAP = {
+              "C09PJ8QGWJK": {"name": "#bugs-mobile", "repo": "verse-mate/verse-mate-mobile"},
+              "C090DUA9GTF": {"name": "#features", "repo": "verse-mate/verse-mate-mobile"},
+              "C092G4WKF9S": {"name": "#bugs", "repo": "verse-mate/verse-mate"},
+          }
+
+          def slack_api(method, params=None):
+              url = f"https://slack.com/api/{method}"
+              if params:
+                  url += "?" + "&".join(f"{k}={v}" for k, v in params.items())
+              req = urllib.request.Request(url, headers={"Authorization": f"Bearer {SLACK_TOKEN}"})
+              with urllib.request.urlopen(req) as resp:
+                  return json.loads(resp.read())
+
+          def gh_run(cmd):
+              result = subprocess.run(cmd, capture_output=True, text=True)
+              return result.stdout.strip(), result.returncode
+
+          def get_existing_issue_titles(repo):
+              out, rc = gh_run(["gh", "issue", "list", "--repo", repo, "--state", "all",
+                                "--limit", "500", "--json", "title,state"])
+              if rc != 0:
+                  return {}
+              issues = json.loads(out)
+              return {i["title"].lower().strip(): i["state"] for i in issues}
+
+          def categorize(text, channel_name):
+              text_lower = text.lower()
+              if channel_name == "#features":
+                  return "enhancement", "Feature Request"
+              if any(k in text_lower[:20] for k in ["depth", "redo ", "context:"]):
+                  return "content", "Content Quality"
+              if text_lower.startswith("ux") or text_lower.startswith("ui"):
+                  return "enhancement", "UX/UI Improvement"
+              if "bug" in text_lower[:15] or "broke" in text_lower or "crash" in text_lower:
+                  return "bug", "Bug"
+              if "missing" in text_lower or "no verse" in text_lower:
+                  return "bug", "Bug"
+              return "triage", "Needs Triage"
+
+          def make_title(text):
+              first_line = text.split("\n")[0].strip()
+              title = re.sub(r'^(Bug|UX|UI|Feature|Awesome feature|Key feature|Topic feature|Depth|Context)\s*[(:]\s*',
+                             '', first_line, flags=re.IGNORECASE).strip()
+              title = re.sub(r'^(from user|by user|from power user)\s*[-:]\s*', '', title, flags=re.IGNORECASE).strip()
+              title = re.sub(r'^[-:]\s*', '', title).strip()
+              if len(title) > 75:
+                  title = title[:72] + "..."
+              if title and title[0].islower():
+                  title = title[0].upper() + title[1:]
+              return title or text[:72] + "..."
+
+          def is_actionable(text, subtype):
+              if subtype in ("channel_join", "channel_leave", "channel_topic", "channel_purpose"):
+                  return False
+              if not text or len(text.strip()) < 15:
+                  return False
+              skip = ["has joined", "has left", "here is a quick video", "i like this suggestion"]
+              text_lower = text.lower()
+              return not any(s in text_lower for s in skip)
+
+          oldest_ts = str(int(datetime.now(timezone.utc).timestamp()) - 1200)
+
+          total_created = 0
+          total_closed = 0
+          total_skipped = 0
+
+          for channel_id, config in CHANNEL_MAP.items():
+              channel_name = config["name"]
+              target_repo = config["repo"]
+
+              if target_repo != REPO:
+                  continue
+
+              print(f"\n{'='*50}")
+              print(f"Processing {channel_name} ({channel_id}) -> {target_repo}")
+
+              data = slack_api("conversations.history", {
+                  "channel": channel_id,
+                  "oldest": oldest_ts,
+                  "limit": "50"
+              })
+
+              if not data.get("ok"):
+                  print(f"  Error: {data.get('error')}")
+                  continue
+
+              messages = data.get("messages", [])
+              print(f"  Found {len(messages)} messages in last 20 minutes")
+
+              if not messages:
+                  continue
+
+              existing = get_existing_issue_titles(target_repo)
+              print(f"  Loaded {len(existing)} existing issue titles for dedup")
+
+              for msg in messages:
+                  text = msg.get("text", "").strip()
+                  subtype = msg.get("subtype", "")
+                  reactions = [r["name"] for r in msg.get("reactions", [])]
+                  has_checkmark = "white_check_mark" in reactions
+                  ts = float(msg.get("ts", 0))
+                  date = datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d")
+
+                  if not is_actionable(text, subtype):
+                      continue
+
+                  clean_text = re.sub(r'<@[A-Z0-9]+>', '@team-member', text)
+                  title = make_title(clean_text)
+                  label, category = categorize(clean_text, channel_name)
+
+                  title_lower = title.lower().strip()
+                  is_dup = False
+                  for existing_title in existing:
+                      if title_lower == existing_title:
+                          is_dup = True
+                          break
+                      w1 = set(title_lower.split())
+                      w2 = set(existing_title.split())
+                      union = len(w1 | w2)
+                      if union > 0 and len(w1 & w2) / union > 0.75:
+                          is_dup = True
+                          break
+
+                  if is_dup:
+                      print(f"  SKIP (dup): {title[:60]}")
+                      total_skipped += 1
+                      continue
+
+                  body = f"**Category:** {category}\n**Reported:** {date}\n**Source:** Slack {channel_name}\n\n## Description\n\n{clean_text}"
+
+                  out, rc = gh_run([
+                      "gh", "issue", "create",
+                      "--repo", target_repo,
+                      "--title", title,
+                      "--body", body,
+                      "--label", label,
+                  ])
+
+                  if rc != 0:
+                      print(f"  ERROR creating: {out}")
+                      continue
+
+                  print(f"  CREATED: {out}")
+                  total_created += 1
+                  existing[title_lower] = "OPEN"
+
+                  if has_checkmark:
+                      gh_run(["gh", "issue", "close", out, "--reason", "completed"])
+                      print(f"    -> CLOSED (checkmark)")
+                      total_closed += 1
+
+          print(f"\n{'='*50}")
+          print(f"DONE: Created {total_created}, Closed {total_closed}, Skipped {total_skipped} duplicates")


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that polls Slack every 15 minutes
- Monitors **#bugs** channel for new messages
- Auto-creates GitHub issues with labels (bug, enhancement, triage)
- Deduplicates against all existing issues (open + closed)
- Closes issues that have a checkmark reaction in Slack

## How it works
1. Cron runs every 15 min (also supports manual trigger)
2. Fetches messages from last 20 min (overlap window for reliability)
3. Filters out joins, short messages, conversations
4. Compares titles against existing issues (75%+ word overlap = duplicate)
5. Creates issue with category, date, source, and full description
6. If message has checkmark reaction, auto-closes the issue

## Secrets required
- `SLACK_BOT_TOKEN` — already configured

## Test plan
- [ ] Merge and trigger manually via Actions tab
- [ ] Post a test bug in #bugs, verify issue appears within 15 min
- [ ] Add checkmark to a message, verify issue gets closed on next run