### PR TITLE
fix: use replaceAll for template placeholders

### DIFF
--- a/packages/backend-base/src/admin/services/admin-prompt.service.ts
+++ b/packages/backend-base/src/admin/services/admin-prompt.service.ts
@@ -211,10 +211,10 @@ export class AdminPromptService {
     } else {
       finalUserPrompt = this.getUserPrompt({
         explanationPrompt: user_prompt
-          .replace("{bookName}", book_name)
-          .replace("{chapterNumber}", chapter_number.toString())
-          .replace("{verseRange}", "all verses")
-          .replace("{verseRangeContext}", ""),
+          .replaceAll("{bookName}", book_name)
+          .replaceAll("{chapterNumber}", chapter_number.toString())
+          .replaceAll("{verseRange}", "all verses")
+          .replaceAll("{verseRangeContext}", ""),
         language,
       });
 
@@ -296,8 +296,8 @@ export class AdminPromptService {
               bookName: book_name,
               chapterNumber: chapter_number,
               bylineTemplate: user_prompt
-                .replace("{bookName}", book_name)
-                .replace("{chapterNumber}", chapter_number.toString()),
+                .replaceAll("{bookName}", book_name)
+                .replaceAll("{chapterNumber}", chapter_number.toString()),
               logPrefix: "[PLAYGROUND_BYLINE]",
               generateChunk: async ({ prompt }) =>
                 this.gpt5Text({

--- a/packages/backend-base/src/admin/services/batch-operations.service.ts
+++ b/packages/backend-base/src/admin/services/batch-operations.service.ts
@@ -81,7 +81,10 @@ const getUserPrompt = ({
   explanationPrompt,
   language,
 }: { explanationPrompt: string; language: string }) => {
-  return `${explanationPrompt}\n\nThe response should be in ${language} using Markdown format only.`;
+  const cleaned = explanationPrompt
+    .replaceAll("{verseRange}", "all verses")
+    .replaceAll("{verseRangeContext}", "");
+  return `${cleaned}\n\nThe response should be in ${language} using Markdown format only.`;
 };
 
 export class BatchOperationService {

--- a/packages/backend-base/src/admin/services/explanation-regeneration.service.ts
+++ b/packages/backend-base/src/admin/services/explanation-regeneration.service.ts
@@ -54,7 +54,10 @@ export class ExplanationRegenerationService {
     explanationPrompt,
     language,
   }: { explanationPrompt: string; language: string }) {
-    return `${explanationPrompt}\n\nThe response should be in ${language} using Markdown format only.`;
+    const cleaned = explanationPrompt
+      .replaceAll("{verseRange}", "all verses")
+      .replaceAll("{verseRangeContext}", "");
+    return `${cleaned}\n\nThe response should be in ${language} using Markdown format only.`;
   }
 
   async generateNewExplanation({

--- a/packages/backend-base/src/bible/explanation-queue.ts
+++ b/packages/backend-base/src/bible/explanation-queue.ts
@@ -194,10 +194,13 @@ explanationQueue.process("generate-explanation", 1, async (job: any) => {
           }),
       });
     } else {
+      const cleanedPrompt = explanationConfig.prompt
+        .replaceAll("{verseRange}", "all verses")
+        .replaceAll("{verseRangeContext}", "");
       const userPrompt = `# Reference
 ${reference}
 
-${explanationConfig.prompt}
+${cleanedPrompt}
 
 CRITICAL: Your response will be evaluated on:
 1. Proper blockquote usage for Scripture (>)

--- a/packages/backend-base/src/bible/pregenerate-hebrews.ts
+++ b/packages/backend-base/src/bible/pregenerate-hebrews.ts
@@ -247,10 +247,13 @@ async function pregenerateHebrewsChapters() {
               }),
           });
         } else {
+          const cleanedPrompt = explanationConfig.prompt
+            .replaceAll("{verseRange}", "all verses")
+            .replaceAll("{verseRangeContext}", "");
           const userPrompt = `# Reference
 ${reference}
 
-${explanationConfig.prompt}
+${cleanedPrompt}
 
 CRITICAL: Your response will be evaluated on:
 1. Proper blockquote usage for Scripture (>)

--- a/packages/backend-base/src/bible/pregenerate-popular-chapters.ts
+++ b/packages/backend-base/src/bible/pregenerate-popular-chapters.ts
@@ -265,10 +265,13 @@ async function pregeneratePopularChapters() {
                 }),
             });
           } else {
+            const cleanedPrompt = explanationConfig.prompt
+              .replaceAll("{verseRange}", "all verses")
+              .replaceAll("{verseRangeContext}", "");
             const userPrompt = `# Reference
 ${reference}
 
-${explanationConfig.prompt}
+${cleanedPrompt}
 
 CRITICAL: Your response will be evaluated on:
 1. Proper blockquote usage for Scripture (>)

--- a/packages/backend-base/src/shared/byline-chunking.ts
+++ b/packages/backend-base/src/shared/byline-chunking.ts
@@ -72,8 +72,8 @@ function buildRangePrompt({
   bylineTemplate: string;
 }) {
   let prompt = bylineTemplate
-    .replace("{verseRange}", `verses ${startVerse} through ${endVerse}`)
-    .replace(
+    .replaceAll("{verseRange}", `verses ${startVerse} through ${endVerse}`)
+    .replaceAll(
       "{verseRangeContext}",
       `Biblical Text (${bookName} ${chapterNumber} verses ${startVerse}-${endVerse}):\n${versesText}`,
     );

--- a/packages/backend-base/src/shared/prompt-utils.ts
+++ b/packages/backend-base/src/shared/prompt-utils.ts
@@ -24,9 +24,7 @@ export const getExplanationTypePrompt = async (
         prompt: (promptTemplate as any).prompt_template
           .replaceAll("{bookName}", bookName)
           .replaceAll("{chapterNumber}", chapterNumber.toString())
-          .replaceAll("{language}", language)
-          .replaceAll("{verseRange}", "all verses")
-          .replaceAll("{verseRangeContext}", ""),
+          .replaceAll("{language}", language),
         temperature,
       };
     }
@@ -53,9 +51,7 @@ export const getExplanationTypePrompt = async (
       prompt: fallbackTemplate.prompt_template
         .replaceAll("{bookName}", bookName)
         .replaceAll("{chapterNumber}", chapterNumber.toString())
-        .replaceAll("{language}", language)
-        .replaceAll("{verseRange}", "all verses")
-        .replaceAll("{verseRangeContext}", ""),
+        .replaceAll("{language}", language),
       temperature,
     };
   }

--- a/packages/backend-base/src/shared/prompt-utils.ts
+++ b/packages/backend-base/src/shared/prompt-utils.ts
@@ -22,11 +22,11 @@ export const getExplanationTypePrompt = async (
             : 0.3;
       return {
         prompt: (promptTemplate as any).prompt_template
-          .replace("{bookName}", bookName)
-          .replace("{chapterNumber}", chapterNumber.toString())
-          .replace("{language}", language)
-          .replace("{verseRange}", "all verses")
-          .replace("{verseRangeContext}", ""),
+          .replaceAll("{bookName}", bookName)
+          .replaceAll("{chapterNumber}", chapterNumber.toString())
+          .replaceAll("{language}", language)
+          .replaceAll("{verseRange}", "all verses")
+          .replaceAll("{verseRangeContext}", ""),
         temperature,
       };
     }
@@ -51,11 +51,11 @@ export const getExplanationTypePrompt = async (
           : 0.3;
     return {
       prompt: fallbackTemplate.prompt_template
-        .replace("{bookName}", bookName)
-        .replace("{chapterNumber}", chapterNumber.toString())
-        .replace("{language}", language)
-        .replace("{verseRange}", "all verses")
-        .replace("{verseRangeContext}", ""),
+        .replaceAll("{bookName}", bookName)
+        .replaceAll("{chapterNumber}", chapterNumber.toString())
+        .replaceAll("{language}", language)
+        .replaceAll("{verseRange}", "all verses")
+        .replaceAll("{verseRangeContext}", ""),
       temperature,
     };
   }


### PR DESCRIPTION
## Summary

`String.replace()` only replaces the first occurrence. The byline template has `{bookName}` and `{chapterNumber}` in multiple places (title, overview bullet, formatting instructions), so chunked prompts were sent with unreplaced placeholders like:

> "verses 41 through 80 of {bookName} {chapterNumber}"

This caused the model to ignore the verse range and generate from verse 1 every time.

## Fix

Changed all `.replace()` calls to `.replaceAll()` in:
- `prompt-utils.ts` (getExplanationTypePrompt)
- `byline-chunking.ts` (buildRangePrompt)
- `admin-prompt.service.ts` (playground)

## Verified locally

```
Chunk 2 (v41-80) unreplaced placeholders: NONE
Overview: * Provide a verse-by-verse explanation of verses 41 through 80 of Psalms 119...
```