### PR TITLE
feat: Add font size setting for scripture text

### DIFF
--- a/packages/frontend-base/src/store/font-size.ts
+++ b/packages/frontend-base/src/store/font-size.ts
@@ -1,0 +1,39 @@
+import { atom } from "nanostores";
+
+const STORAGE_KEY = "versemate-font-size";
+const DEFAULT_FONT_SIZE = 18;
+const MIN_FONT_SIZE = 13;
+const MAX_FONT_SIZE = 26;
+
+function loadFontSize(): number {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = Number(stored);
+      if (
+        Number.isFinite(parsed) &&
+        parsed >= MIN_FONT_SIZE &&
+        parsed <= MAX_FONT_SIZE
+      ) {
+        return parsed;
+      }
+    }
+  } catch {
+    // localStorage not available
+  }
+  return DEFAULT_FONT_SIZE;
+}
+
+export const fontSizeStore = atom<number>(loadFontSize());
+
+export function setFontSize(size: number) {
+  const clamped = Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, size));
+  fontSizeStore.set(clamped);
+  try {
+    localStorage.setItem(STORAGE_KEY, String(clamped));
+  } catch {
+    // localStorage not available
+  }
+}
+
+export { DEFAULT_FONT_SIZE, MIN_FONT_SIZE, MAX_FONT_SIZE };

--- a/packages/frontend-base/src/ui/MainText/Content/Text/text.tsx
+++ b/packages/frontend-base/src/ui/MainText/Content/Text/text.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useStore } from "@nanostores/react";
+import { fontSizeStore } from "../../../../store/font-size";
 import { useAutoHighlights } from "../../../../hooks/useAutoHighlights";
 import { useBookmarks } from "../../../../hooks/useBookmarks";
 import { useGetSearchParams } from "../../../../hooks/useSearchParams";
@@ -42,6 +44,7 @@ export const Text = ({
 }: TextProps) => {
   const searchParams = useGetSearchParams();
   const { session } = userSession();
+  const userFontSize = useStore(fontSizeStore);
   const {
     isBookmarked: checkIfBookmarked,
     addBookmark,
@@ -1036,7 +1039,7 @@ export const Text = ({
                 {subtitle.end_verse})
               </p>
             </div>
-            <div className={styles.versesContainer}>
+            <div className={styles.versesContainer} style={{ fontSize: userFontSize }}>
               {text.verses
                 .filter(
                   (verse) =>
@@ -1065,7 +1068,7 @@ export const Text = ({
       ) : (
         // Fallback: render all verses without subtitle grouping
         <div className={styles.textBox} data-tour="chapter-content">
-          <div className={styles.versesContainer}>
+          <div className={styles.versesContainer} style={{ fontSize: userFontSize }}>
             {text.verses.map((verse) => {
               return (
                 <span

--- a/packages/frontend-base/src/ui/Settings/Settings.tsx
+++ b/packages/frontend-base/src/ui/Settings/Settings.tsx
@@ -4,8 +4,15 @@ import Link from "next/link";
 import { destroyCookie } from "nookies";
 import posthog from "posthog-js";
 import { useEffect, useState } from "react";
+import { useStore } from "@nanostores/react";
 import useMutation from "../../hooks/useMutation";
 import { userSession } from "../../hooks/userSession";
+import {
+  fontSizeStore,
+  setFontSize,
+  MIN_FONT_SIZE,
+  MAX_FONT_SIZE,
+} from "../../store/font-size";
 import { bibleVersions } from "../../utils/bible-versions";
 import { Button } from "../Button/Button";
 import {
@@ -35,6 +42,7 @@ export const Settings = ({
 }: SettingsProps) => {
   const { session, fetchSession } = userSession();
   const queryClient = useQueryClient();
+  const currentFontSize = useStore(fontSizeStore);
   const selectedVersionData = bibleVersions.find(
     (version) => version.key === selectedBibleVersion,
   );
@@ -372,6 +380,47 @@ export const Settings = ({
           </div>
         </div>
       )}
+
+      {/* Font Size Section */}
+      <div className={styles.sectionSpacing}>
+        <label className={styles.sectionLabel}>Display</label>
+        <div className={styles.profileContainer}>
+          <span className={styles.dropdownLabel}>Font size</span>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              marginBottom: 6,
+            }}
+          >
+            <span style={{ fontSize: 14, color: "var(--oil)" }}>Size</span>
+            <span style={{ fontSize: 12, color: "var(--oslo-gray)" }}>
+              {currentFontSize}px
+            </span>
+          </div>
+          <input
+            type="range"
+            min={MIN_FONT_SIZE}
+            max={MAX_FONT_SIZE}
+            value={currentFontSize}
+            onChange={(e) => setFontSize(Number(e.target.value))}
+            style={{ width: "100%", accentColor: "var(--dust)" }}
+          />
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              fontSize: 11,
+              color: "var(--oslo-gray)",
+              marginTop: 4,
+            }}
+          >
+            <span>Small</span>
+            <span>Large</span>
+          </div>
+        </div>
+      </div>
 
       {/* Auto-Highlight Settings Section */}
       {session?.id && <AutoHighlightSettings isLoggedIn={true} />}


### PR DESCRIPTION
## Summary
- Adds a font size slider (13–26px) to the Settings screen that controls verse text size in the reading view
- Preference persists to localStorage across sessions
- Already live and tested in the [Lovable prototype](https://lovable.dev/projects/7f2ca37c-8a1d-4e26-baa4-e92839178242)

## Changes
| File | What |
|---|---|
| `packages/frontend-base/src/store/font-size.ts` | New nanostores atom with localStorage persistence, min/max/default constants |
| `packages/frontend-base/src/ui/Settings/Settings.tsx` | "Display" section with font size slider between Language and Auto-Highlight Settings |
| `packages/frontend-base/src/ui/MainText/Content/Text/text.tsx` | Reads `fontSizeStore` and applies inline `fontSize` on `versesContainer` |

## How it works
1. User opens Settings → Display → Font size slider
2. Dragging the slider updates the nanostores atom + writes to localStorage
3. The MainText verse rendering reads the atom via `useStore(fontSizeStore)` and applies it as an inline style
4. Default is 18px (matching the existing CSS module value)

## Test plan
- [ ] Open Settings, verify "Display" section appears with font size slider
- [ ] Drag slider — verify verse text size changes live
- [ ] Reload page — verify font size persists
- [ ] Reset to default (18px) — verify text matches original size

🤖 Generated with [Claude Code](https://claude.ai/claude-code)