### PR TITLE
feat: migrate staging domain to staging.versemate.org

### DIFF
--- a/apps/frontend-next/wrangler.jsonc
+++ b/apps/frontend-next/wrangler.jsonc
@@ -85,7 +85,7 @@
       "name": "verse-mate-staging-app",
       "vars": {
         "API_URL": "https://api.versemate.org",
-        "APP_URL": "https://staging.app.verse-mate.xyz",
+        "APP_URL": "https://staging.versemate.org",
         "NEXT_PUBLIC_ASK_VERSE_MATE": "false",
         "NEXT_PUBLIC_SSO_GOOGLE_ENABLED": "true",
         "NEXT_PUBLIC_SSO_APPLE_ENABLED": "true",
@@ -95,7 +95,7 @@
       },
       "routes": [
         {
-          "pattern": "staging.app.verse-mate.xyz",
+          "pattern": "staging.versemate.org",
           "custom_domain": true
         }
       ]

--- a/packages/frontend-base/src/utils/sharing.ts
+++ b/packages/frontend-base/src/utils/sharing.ts
@@ -12,11 +12,7 @@ interface ShareablePassageParams {
 }
 
 // Allowed hosts for security validation
-const ALLOWED_HOSTS = [
-  "localhost",
-  "app.versemate.org",
-  "versemate.com", // Add production domain when available
-];
+const ALLOWED_HOSTS = ["localhost", "versemate.org", "versemate.com"];
 
 /**
  * Validates and sanitizes a URL origin


### PR DESCRIPTION
## Summary
- Update Cloudflare Workers staging config to use `staging.versemate.org` instead of `staging.app.verse-mate.xyz`
- Fix `ALLOWED_HOSTS` in `sharing.ts` to use `versemate.org` (covers all subdomains including `staging.versemate.org` and `app.versemate.org`)

Closes #182

## Changes
| File | Change |
|------|--------|
| `apps/frontend-next/wrangler.jsonc` | Staging `APP_URL` and route pattern → `staging.versemate.org` |
| `packages/frontend-base/src/utils/sharing.ts` | `ALLOWED_HOSTS`: `app.versemate.org` → `versemate.org` |

## Test plan
- [ ] Merge to `main` → CI deploys to staging via `wrangler deploy --env staging`
- [ ] Verify `staging.versemate.org` resolves (Cloudflare auto-provisions DNS/SSL)
- [ ] Verify the app loads and functions at `staging.versemate.org`
- [ ] Verify share URLs generate correctly with the staging domain