### PR TITLE
feat: add Cloudflare Workers deployment for Lovable app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,6 +197,37 @@ jobs:
           fi
         continue-on-error: true
 
+  build-lovable:
+    name: Build Lovable App
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.2.23
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build lovable app
+        working-directory: ./apps/lovable
+        env:
+          VITE_API_URL: https://api.versemate.org
+          VITE_GOOGLE_CLIENT_ID: 94126503648-2fb9dakdfi8pmi8ep78bk5nsrv94db6o.apps.googleusercontent.com
+        run: bun run build
+
+      - name: Run lovable linting
+        working-directory: ./apps/lovable
+        run: |
+          if ! bun run lint; then
+            echo "::warning::Lovable linting failed but continuing build"
+          fi
+        continue-on-error: true
+
   frontend-cloudflare-deploy:
     name: Frontend CloudFlare Deploy
     runs-on: ubuntu-latest
@@ -347,4 +378,85 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `🚀 Website preview deployment is ready! Check it out at: ${previewUrl}`
+            })
+
+  lovable-cloudflare-deploy:
+    name: Lovable App CloudFlare Deploy
+    runs-on: ubuntu-latest
+    needs: [build-lovable]
+    if: github.event_name != 'pull_request'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.2.23
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build lovable app for deployment
+        working-directory: ./apps/lovable
+        env:
+          VITE_API_URL: https://api.versemate.org
+          VITE_GOOGLE_CLIENT_ID: 94126503648-2fb9dakdfi8pmi8ep78bk5nsrv94db6o.apps.googleusercontent.com
+        run: bun run build
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: ./apps/lovable
+          command: deploy --env ${{ env.CLOUDFLARE_ENV }}
+
+  lovable-cloudflare-deploy-preview:
+    name: Lovable App CloudFlare PR Preview
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    needs: [build-lovable]
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.2.23
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build lovable app for deployment
+        working-directory: ./apps/lovable
+        env:
+          VITE_API_URL: https://api.versemate.org
+          VITE_GOOGLE_CLIENT_ID: 94126503648-2fb9dakdfi8pmi8ep78bk5nsrv94db6o.apps.googleusercontent.com
+        run: bun run build
+
+      - name: Deploy Preview to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: ./apps/lovable
+          command: versions upload --env ${{ env.CLOUDFLARE_ENV }} --preview-alias pr-${{ github.event.number }}
+
+      - name: Comment PR with preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const previewUrl = `https://pr-${{ github.event.number }}-verse-mate-lovable-preview.verse-mate.workers.dev`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `🚀 Lovable app preview deployment is ready! Check it out at: ${previewUrl}`
             })

--- a/apps/lovable/worker.js
+++ b/apps/lovable/worker.js
@@ -1,0 +1,32 @@
+/**
+ * Cloudflare Worker for serving VerseMate Lovable app (Vite SPA)
+ *
+ * Unlike the website worker (which looks for per-directory index.html files),
+ * this worker always falls back to the root /index.html for any non-asset
+ * request, letting React Router handle client-side routing.
+ */
+
+export default {
+  async fetch(request, env) {
+    // Try to serve the static asset first
+    const response = await env.ASSETS.fetch(request);
+
+    // If the asset was found, return it
+    if (response.status !== 404) {
+      return response;
+    }
+
+    // For paths without file extensions, serve root /index.html (SPA fallback)
+    const url = new URL(request.url);
+    if (!url.pathname.includes(".")) {
+      const indexRequest = new Request(
+        new URL("/index.html", request.url).toString(),
+        request,
+      );
+      return env.ASSETS.fetch(indexRequest);
+    }
+
+    // For missing files with extensions (e.g. /missing.js), return 404
+    return response;
+  },
+};

--- a/apps/lovable/wrangler.jsonc
+++ b/apps/lovable/wrangler.jsonc
@@ -1,0 +1,47 @@
+{
+  // Wrangler configuration for VerseMate Lovable app (Vite SPA) deployment using Workers
+  "$schema": "https://raw.githubusercontent.com/cloudflare/wrangler/main/config-schema.json",
+  "name": "verse-mate-lovable",
+  "main": "worker.js",
+  "compatibility_date": "2025-08-06",
+  "account_id": "e8f0b566ba1c8227a25e3784def4300e",
+
+  /**
+   * Workers.dev route enabled for development/testing
+   */
+  "workers_dev": true,
+
+  // Static assets configuration for Workers
+  "assets": {
+    "directory": "./dist",  // Vite build output directory
+    "binding": "ASSETS",
+    "run_worker_first": false  // Serve static assets directly
+  },
+
+  // Development settings
+  "dev": {
+    "ip": "localhost",
+    "port": 8789,
+    "local_protocol": "http"
+  },
+
+  // Environment configurations
+  "env": {
+    "preview": {
+      "name": "verse-mate-lovable-preview"
+    },
+    "staging": {
+      "name": "verse-mate-lovable-staging",
+      "routes": [
+        {
+          "pattern": "staging.versemate.org",
+          "custom_domain": true
+        }
+      ]
+    },
+    "production": {
+      "name": "verse-mate-lovable-production"
+      // Production domain TBD — add routes here when ready
+    }
+  }
+}

--- a/packages/frontend-base/src/utils/sharing.ts
+++ b/packages/frontend-base/src/utils/sharing.ts
@@ -12,11 +12,7 @@ interface ShareablePassageParams {
 }
 
 // Allowed hosts for security validation
-const ALLOWED_HOSTS = [
-  "localhost",
-  "app.versemate.org",
-  "versemate.com", // Add production domain when available
-];
+const ALLOWED_HOSTS = ["localhost", "versemate.org", "versemate.com"];
 
 /**
  * Validates and sanitizes a URL origin


### PR DESCRIPTION
## Summary
- Add Cloudflare Workers deployment config for the Lovable app (`apps/lovable`)
- Staging domain: `staging.versemate.org`
- CI/CD: auto-deploys on push to `main`, PR previews on pull requests

Closes #182
Stacks on #181

## Changes

| File | What |
|------|------|
| `apps/lovable/wrangler.jsonc` | **New** — CF Workers config (staging: `staging.versemate.org`) |
| `apps/lovable/worker.js` | **New** — SPA routing worker (falls back to root `/index.html` for React Router) |
| `.github/workflows/build.yml` | **Modified** — Added `build-lovable`, `lovable-cloudflare-deploy`, and preview jobs |
| `packages/frontend-base/src/utils/sharing.ts` | **Modified** — ALLOWED_HOSTS: `app.versemate.org` → `versemate.org` (covers all subdomains) |

## How it works

1. Push to `main` → CI builds Vite app with `VITE_API_URL=https://api.versemate.org` → deploys to `staging` env
2. Version tag (`v*.*.*`) → deploys to `production` env
3. PR → builds and uploads preview to `*.verse-mate.workers.dev`
4. Cloudflare auto-provisions DNS/SSL for `staging.versemate.org`

## Manual step required after merge
- Add `staging.versemate.org` to **Google Cloud Console** → "Authorized JavaScript origins" for OAuth client ID `94126503648-...`, otherwise Google Sign-In will fail on staging

## Test plan
- [ ] Merge #181 first, then this PR on top
- [ ] After merge to `main`: verify CI runs `build-lovable` + `lovable-cloudflare-deploy` jobs
- [ ] Verify `staging.versemate.org` resolves and serves the Lovable app
- [ ] Verify API calls to `api.versemate.org` work (CORS allows all origins)
- [ ] Verify Google Sign-In works (after adding JS origin in console)