### PR TITLE
chore(frontend-next): repoint production to admin.versemate.org

### DIFF
--- a/apps/frontend-next/wrangler.jsonc
+++ b/apps/frontend-next/wrangler.jsonc
@@ -104,7 +104,12 @@
       "name": "verse-mate-production",
       "vars": {
         "API_URL": "https://api.versemate.org",
-        "APP_URL": "https://app.versemate.org",
+        // Repointed from app.versemate.org → admin.versemate.org. The
+        // admin dashboard (/admin, gated by AdminGuard) is the only
+        // surface that stays on this Next.js Worker — the user-facing
+        // app moves to verse-mate-web. See verse-mate-web PR #28 +
+        // its docs/CUTOVER.md for the full handoff plan.
+        "APP_URL": "https://admin.versemate.org",
         "NEXT_PUBLIC_ASK_VERSE_MATE": "false",
         "NEXT_PUBLIC_SSO_GOOGLE_ENABLED": "true",
         "NEXT_PUBLIC_SSO_APPLE_ENABLED": "true",
@@ -114,7 +119,7 @@
       },
       "routes": [
         {
-          "pattern": "app.versemate.org",
+          "pattern": "admin.versemate.org",
           "custom_domain": true
         }
       ]


### PR DESCRIPTION
## Summary

Hands off \`app.versemate.org\` so the new \`verse-mate-web\` repo can take over the user-facing app. \`frontend-next\` stays alive in the monorepo solely to serve \`/admin\` (gated by \`AdminGuard\`) at \`admin.versemate.org\`.

## Why

\`verse-mate-web\` is the new home of the user-facing app, with the Lovable-designed UI and same plumbing as today (cookie auth, SEO redirects, PostHog). See [verse-mate-web PR #28](https://github.com/verse-mate/verse-mate-web/pull/28) for the full migration. Admin is the only surface that doesn't get re-skinned, so it stays here.

## ⚠️ Coordinated cutover

Cloudflare allows one Worker per custom domain. This PR + deploy **must complete before** \`verse-mate-web\` can claim \`app.versemate.org\`. Otherwise its prod deploy fails with \`domain already bound to another Worker\`.

## Prerequisites

- [ ] DNS: \`admin.versemate.org\` must resolve (proxied A/CNAME in CF) before this deploy succeeds. One-time setup in the CF dashboard. **Add this BEFORE merging.**

## Cutover order

1. **(this PR)** merge + deploy → \`app.versemate.org\` route freed, \`admin.versemate.org\` bound to this Worker
2. **verse-mate-web/main:** \`bunx wrangler deploy --env production\` → binds \`app.versemate.org\` to \`verse-mate-web-production\` Worker
3. Both deploys complete; CF cuts over near-instantly

## What survives the cutover (no user-visible change)

| | |
|---|---|
| User sessions | Same \`accessToken\` / \`refreshToken\` cookies — verified compatible by live-API tests in verse-mate-web |
| SEO | \`/bible/<slug>/<chapter>\` URL shape preserved + same legacy \`?bookId=&verseId=\` 301s |
| PostHog analytics | Same project key continues firing |
| Admin | Only surface that stays here. Admins access at the new domain |

## Rollback

If anything is wrong post-deploy:

1. Revert this PR (restore \`app.versemate.org\` route here)
2. Revert/skip the verse-mate-web prod deploy
3. CF re-routes within seconds

\`docs/CUTOVER.md\` in verse-mate-web has the full rollback procedure.

## Changes

Single file: \`apps/frontend-next/wrangler.jsonc\`
- \`production.routes[0].pattern\`: \`app.versemate.org\` → \`admin.versemate.org\`
- \`production.vars.APP_URL\`: \`https://app.versemate.org\` → \`https://admin.versemate.org\`

## Test plan

- [ ] DNS for \`admin.versemate.org\` is configured in Cloudflare
- [ ] Merge this PR
- [ ] CI deploys production (or run \`bunx wrangler deploy --env production\` from \`apps/frontend-next/\` manually)
- [ ] \`curl -I https://admin.versemate.org/admin\` returns 200 (or 302 to login if not signed in)
- [ ] \`curl -I https://app.versemate.org\` no longer routes to this Worker (404 or whatever CF default)
- [ ] Now safe to deploy \`verse-mate-web\` production