### PR TITLE
fix(redis): TCP keepAlive on both clients to survive DO 5-min idle reap

### DIFF
--- a/packages/backend-base/src/shared/bullmq-redis.ts
+++ b/packages/backend-base/src/shared/bullmq-redis.ts
@@ -18,6 +18,14 @@ export const bullmqRedisConnection = new IORedis(redisUrl, {
   },
   enableReadyCheck: true,
   lazyConnect: true,
+  // DigitalOcean Managed Redis (and most cloud LBs) reap idle TCP
+  // sockets after ~5 minutes. BullMQ workers hold long-lived blocking
+  // connections (BRPOPLPUSH) that look idle to the LB; without
+  // OS-level TCP keepalives, the worker's socket gets closed mid-job
+  // and any active job is left stuck in `active` state until manual
+  // intervention. Sending a keepalive every 30s keeps the connection
+  // healthy.
+  keepAlive: 30_000,
   reconnectOnError: (err: Error) => {
     const targetError = "READONLY";
     if ((err as any).message?.includes?.(targetError)) {

--- a/packages/backend-base/src/shared/redis-client.ts
+++ b/packages/backend-base/src/shared/redis-client.ts
@@ -12,11 +12,16 @@ class RedisClient {
     const password = url.password || undefined;
     const useSSL = isSSLUrl(redisUrl);
 
-    // For SSL connections, use separate socket config to handle self-signed certs
+    // For SSL connections, use separate socket config to handle self-signed certs.
+    // `keepAlive: 30_000` keeps the connection alive against DigitalOcean's
+    // 5-minute idle TCP timeout; without it the cache client cycles
+    // through "Socket closed unexpectedly → reconnect" every 5 minutes
+    // and the in-flight commands during the reset throw transient errors.
     const socketConfig = useSSL
       ? {
           tls: true as const,
           rejectUnauthorized: false,
+          keepAlive: 30_000,
           reconnectStrategy: (retries: number) => {
             if (retries > 10) {
               console.log(
@@ -29,6 +34,7 @@ class RedisClient {
           },
         }
       : {
+          keepAlive: 30_000,
           reconnectStrategy: (retries: number) => {
             if (retries > 10) {
               console.log(


### PR DESCRIPTION
## Summary

Audio generation has been broken on prod since the explanation-audio backend rolled out: signed-in users see \"Generating…\" → 30s timeout → \"Audio unavailable\" for any non-cached chapter. Cached audio plays fine.

## Root cause (confirmed via DigitalOcean run logs)

Both Redis clients in the backend (`bullmq-redis.ts` for the BullMQ worker, `redis-client.ts` for the cache layer) connect to DigitalOcean Managed Redis with **no TCP keepAlive set**. DO's load balancer reaps idle sockets after ~5 minutes.

Run-log evidence — the cache client cycles every 5 minutes on the dot:

\`\`\`
13:12:13 Redis Client Error … Socket closed unexpectedly … Reconnecting to Redis … Connected
13:17:13 Redis Client Error … Socket closed unexpectedly … Reconnecting to Redis … Connected
13:22:13 Redis Client Error … Socket closed unexpectedly … Reconnecting to Redis … Connected
13:27:13 Redis Client Error … (every 5 min on the dot)
\`\`\`

The BullMQ worker connection holds a long-lived blocking pop (`BRPOPLPUSH`) that looks idle to the LB. When the socket gets reaped mid-job, the worker can no longer update job state in Redis, and any job already pulled is left **stuck in `active` forever** — no \"completed\", no \"failed\". Frontend polls for 30s then gives up.

## Fix

Set `keepAlive: 30_000` on both clients. The OS sends a TCP keepalive every 30s, well inside DO's idle window. Connections stay healthy through long pops + long OpenAI streaming responses.

## Test plan

- [x] `bun tsc --noEmit` clean
- [x] Manually reproduced the bug on prod (Numbers 5 / explanation 11486 → job stuck `active` for >30s)
- [ ] After deploy: verify run logs no longer show the 5-min reconnect cycle
- [ ] After deploy: hit a non-cached chapter, expect job → `completed` and chip → `playing` within ~10s
- [ ] After deploy: leave the backend idle for >5 min, then enqueue a job, expect immediate processing (no \"first job after idle\" stall)

🤖 Generated with [Claude Code](https://claude.com/claude-code)