### PR TITLE
fix(audio): drop failed jobs before re-enqueue so retries actually retry

### DIFF
--- a/packages/backend-base/src/bible/audio/audio.service.test.ts
+++ b/packages/backend-base/src/bible/audio/audio.service.test.ts
@@ -160,6 +160,11 @@ class FakeJob {
   async isFailed() {
     return this.state === "failed";
   }
+
+  // Mirror BullMQ's Job.remove(): drops the entry from the queue so a
+  // future `queue.add` with the same jobId is allowed to insert a
+  // brand-new job. The owning FakeQueue calls back via `_remove`.
+  remove?: () => Promise<void>;
 }
 
 class FakeQueue {
@@ -171,7 +176,15 @@ class FakeQueue {
   }[] = [];
 
   async getJob(jobId: string): Promise<FakeJob | undefined> {
-    return this.jobs.get(jobId);
+    const job = this.jobs.get(jobId);
+    if (job) {
+      // Wire `remove()` lazily so each returned job knows how to drop
+      // itself from this queue's map — matching BullMQ's Job.remove().
+      job.remove = async () => {
+        this.jobs.delete(jobId);
+      };
+    }
+    return job;
   }
 
   async add(
@@ -179,6 +192,14 @@ class FakeQueue {
     data: AudioGenerationJobData,
     opts: { jobId: string },
   ): Promise<FakeJob> {
+    // Critical: BullMQ's `Queue.add({ jobId })` is a no-op when a job
+    // with that id already exists in the queue, regardless of state.
+    // The earlier FakeQueue silently overwrote, hiding the prod bug
+    // where a failed deterministic-id job permanently blocks retries.
+    const prior = this.jobs.get(opts.jobId);
+    if (prior) {
+      return prior;
+    }
     this.addCalls.push({ name, data, jobId: opts.jobId });
     const job = new FakeJob(opts.jobId);
     this.jobs.set(opts.jobId, job);

--- a/packages/backend-base/src/bible/audio/audio.service.ts
+++ b/packages/backend-base/src/bible/audio/audio.service.ts
@@ -147,9 +147,27 @@ export class AudioService {
     }
 
     // br-audio-006: dedup via deterministic job id.
+    //
+    // Caveat: BullMQ's `queue.add({ jobId })` is a no-op when a job with
+    // that id already exists in the queue, regardless of state. Combined
+    // with `removeOnFail: 50` (we keep the last 50 failed jobs for
+    // observability), a single failed job permanently blocks retries on
+    // the same (explanation_id, voice, language) variant — every fresh
+    // request gets the cached failed job back, the chip flips to error,
+    // and the user can never recover even after the underlying problem
+    // (e.g., transient OpenAI 5xx) clears. Observed on prod for Genesis
+    // 1 (explanation 10170) on 2026-04-28: any guest hitting the chip
+    // saw "Audio unavailable" for hours.
+    //
+    // Remove the failed job before re-enqueue so the new request gets a
+    // fresh attempt. Completed jobs remain dedup'd as before; in-flight
+    // jobs (waiting/active/delayed) still short-circuit.
     const data: AudioGenerationJobData = variantKey;
     const jobId = audioGenerationJobId(data);
     const existing = await this.queue.getJob(jobId);
+    if (existing && (await existing.isFailed())) {
+      await existing.remove();
+    }
     const stillInFlight =
       existing &&
       !(await existing.isCompleted()) &&
@@ -247,6 +265,10 @@ export class AudioService {
       };
       const jobId = audioGenerationJobId(data);
       const existing = await this.queue.getJob(jobId);
+      // See getOrQueueAudio for why we drop failed jobs before re-add.
+      if (existing && (await existing.isFailed())) {
+        await existing.remove();
+      }
       const stillInFlight =
         existing &&
         !(await existing.isCompleted()) &&


### PR DESCRIPTION
## Summary

A single failed audio-gen job was permanently blocking new attempts for the same (explanation_id, voice, language). Reported by @augusto-chaves on prod 2026-04-28 for `https://app.versemate.org/bible/genesis/1` — users hit the Insight tab and saw "Audio unavailable" for hours, even after the Redis keepalive fix (#193) restored worker throughput.

## Root cause

Three pieces lined up:

1. Jobs use a **deterministic id** `audio-gen:<explanation_id>:<voice>:<lang>` for dedup (br-audio-006).
2. The queue is configured with **`removeOnFail: 50`** to keep the last 50 failed jobs for observability.
3. **BullMQ's `queue.add({ jobId })` is a NO-OP when a job with that id already exists** in the queue, regardless of state.

So once a job failed for any reason (transient OpenAI 5xx, S3 blip, the now-fixed Redis idle reap, the new-found OpenAI 4096-char input limit), every subsequent enqueue request silently returned the same cached failed job. The chip immediately polled, saw `status: failed`, and flipped to error.

Direct repro on prod, signed in or guest, doesn't matter:

```
curl https://api.versemate.org/bible/explanation/audio/10170
→ 202 { job: { job_id: "audio-gen:10170:alloy:en-US", estimated_ready_seconds: 8 } }

curl https://api.versemate.org/bible/explanation/audio/jobs/audio-gen:10170:alloy:en-US
→ 200 { job: { status: "failed", error_code: "GENERATION_FAILED" } }
```

The 202 says "queued" but the next poll returns the leftover failed entry.

## Fix

When an existing job is in `failed` state, call `existing.remove()` before re-enqueue. In-flight jobs (waiting/active/delayed) still short-circuit; completed jobs still dedup; only failed entries get swept. Same pattern applied to the regen path in `enqueueAudioBatch`.

## Test plan

- [x] Existing test "re-enqueues if the previous job failed" was passing because `FakeQueue.add` silently overwrote on duplicate jobId — hiding the prod bug.
- [x] Tightened `FakeQueue` to mirror BullMQ's real contract (no-op on existing jobId, real `Job.remove()` semantics).
- [x] Verified the test **FAILS** against the pre-fix code: `Expected: 2 / Received: 1` (the "re-add" silently dropped).
- [x] Test **PASSES** with the new `existing.remove()` call.
- [x] Full audio.service test suite: 14/14 pass.
- [ ] After deploy: hit `https://app.versemate.org/bible/genesis/1`, click Insight — chip should flip from `loading` to `populated` instead of immediate error.

## Companion issue (not in this PR)

While digging through DO logs we found a second class of failure — explanation 10197 failed at 17:36:48 with `OpenAI 400 string_too_long: input must be ≤ 4096 chars`. This is a real product bug for long explanations and warrants its own fix (chunking the input or splitting per paragraph). Tracking separately. The dedup fix in this PR ensures users CAN retry once the long-input case is handled; without this fix, even a one-off OpenAI failure would lock the chip permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)