### PR TITLE
fix(audio): chunk OpenAI TTS input so long explanations don't 400

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,4 @@ FIGMA_MIGRATION_SPEC.md
 # Playwright artifacts
 playwright-report/
 test-results/
+.gstack/

--- a/packages/backend-base/src/shared/tts/providers/openai-tts-chunk.test.ts
+++ b/packages/backend-base/src/shared/tts/providers/openai-tts-chunk.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for the OpenAI TTS chunker. The OpenAI audio.speech.create
+ * endpoint rejects inputs > 4096 characters with a 400 string_too_long.
+ * Detailed and By Line explanations regularly run 5000–10000 chars, so
+ * a one-shot synth call fails for those tabs in production. Caught on
+ * 2026-04-28 — Genesis 20 Detailed (explanation 10236) and others
+ * surfaced repeated `string_too_long` failures in DO run logs.
+ *
+ * The chunker is exported separately from the provider so it can be
+ * exercised without instantiating the OpenAI SDK or hitting the API.
+ */
+import { describe, expect, it } from "bun:test";
+import { chunkForOpenAi } from "./openai-tts.provider";
+
+describe("chunkForOpenAi", () => {
+  it("returns the input unchanged when it fits", () => {
+    const text = "In the beginning God created the heavens and the earth.";
+    expect(chunkForOpenAi(text, 4000)).toEqual([text]);
+  });
+
+  it("splits at sentence boundaries when the input exceeds the limit", () => {
+    const sentence = `${"A".repeat(100)}.`;
+    const text = Array(50).fill(sentence).join(" "); // 5050 chars
+    const chunks = chunkForOpenAi(text, 1000);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(c.length).toBeLessThanOrEqual(1000);
+    }
+    // No content lost: re-joining the chunks reconstructs the same
+    // sentences (whitespace normalization aside).
+    const rejoined = chunks.join(" ");
+    expect(rejoined.replace(/\s+/g, " ").trim()).toBe(
+      text.replace(/\s+/g, " ").trim(),
+    );
+  });
+
+  it("respects newline boundaries (paragraph seams)", () => {
+    const para = "B".repeat(900);
+    const text = `${para}\n\n${para}\n\n${para}`;
+    const chunks = chunkForOpenAi(text, 1000);
+
+    expect(chunks.length).toBe(3);
+    for (const c of chunks) {
+      expect(c.length).toBe(900);
+    }
+  });
+
+  it("falls back to word boundaries when a single sentence is too long", () => {
+    const longSentence = `${"word ".repeat(300).trim()}.`; // ~1500 chars, no `.` until end
+    const chunks = chunkForOpenAi(longSentence, 500);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(c.length).toBeLessThanOrEqual(500);
+      // Each chunk should still be made of whole words.
+      expect(c.startsWith(" ")).toBe(false);
+      expect(c.endsWith(" ")).toBe(false);
+    }
+  });
+
+  it("falls back to character slicing for a single oversize token", () => {
+    const giantWord = "X".repeat(8000); // one token, no spaces
+    const chunks = chunkForOpenAi(giantWord, 4000);
+
+    expect(chunks.length).toBe(2);
+    expect(chunks[0].length).toBe(4000);
+    expect(chunks[1].length).toBe(4000);
+    expect(chunks.join("")).toBe(giantWord);
+  });
+
+  it("never produces an empty chunk", () => {
+    const text = `Short.\n\n${"X".repeat(4500)}\n\nAnother sentence here.`;
+    const chunks = chunkForOpenAi(text, 1000);
+
+    for (const c of chunks) {
+      expect(c.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("regression: 8000-char Detailed explanation gets split into ≤4000-char chunks", () => {
+    // Approximates the size class of a Detailed explanation observed
+    // failing in prod logs (genesis 20 / 10236 etc.).
+    const sentence = "This is a moderately long sentence about scripture. ";
+    const text = sentence.repeat(160); // ~8480 chars
+    const chunks = chunkForOpenAi(text, 4000);
+
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    for (const c of chunks) {
+      expect(c.length).toBeLessThanOrEqual(4000);
+    }
+  });
+});

--- a/packages/backend-base/src/shared/tts/providers/openai-tts.provider.ts
+++ b/packages/backend-base/src/shared/tts/providers/openai-tts.provider.ts
@@ -52,7 +52,14 @@ export class OpenAiTtsProvider implements TtsProvider {
     // buffers of each chunk's response produces a valid, playable MP3
     // for the whole text. There can be a barely-perceptible click at
     // the seam, which we accept for narration.
-    const audioBuffers: Buffer[] = [];
+    //
+    // Typed as Uint8Array[] (not Buffer[]) so Buffer.concat's overload
+    // resolves cleanly under both backend (Node) and frontend (DOM)
+    // tsconfigs — the `apps/frontend-next` typecheck pulls in
+    // `backend-base` and trips on the `ArrayBufferLike` vs `ArrayBuffer`
+    // mismatch when the array is declared as Buffer[]. Buffer extends
+    // Uint8Array so the runtime is identical.
+    const audioBuffers: Uint8Array[] = [];
     for (const chunk of chunks) {
       const response = await this.client.audio.speech.create({
         model: this.model,
@@ -61,7 +68,7 @@ export class OpenAiTtsProvider implements TtsProvider {
         response_format: input.format,
       });
       const arrayBuffer = await response.arrayBuffer();
-      audioBuffers.push(Buffer.from(arrayBuffer));
+      audioBuffers.push(new Uint8Array(arrayBuffer));
     }
     const audio = Buffer.concat(audioBuffers);
 

--- a/packages/backend-base/src/shared/tts/providers/openai-tts.provider.ts
+++ b/packages/backend-base/src/shared/tts/providers/openai-tts.provider.ts
@@ -10,6 +10,15 @@ import type {
 const DEFAULT_MODEL = "tts-1-hd";
 const AVG_CHARS_PER_SECOND = 15;
 
+/**
+ * OpenAI's TTS API rejects inputs longer than 4096 characters with a
+ * 400 `string_too_long`. Detailed (and many By Line) explanations
+ * regularly run 5000–10000 chars, which means a one-shot call fails
+ * for those tabs. Split slightly under the limit so trailing spaces
+ * or any future tweak doesn't push us over.
+ */
+const OPENAI_TTS_CHAR_LIMIT = 4000;
+
 const OPENAI_VOICES: Voice[] = [
   { id: "alloy", language: "en", label: "Alloy" },
   { id: "echo", language: "en", label: "Echo" },
@@ -37,15 +46,24 @@ export class OpenAiTtsProvider implements TtsProvider {
   }
 
   async synthesize(input: SynthesizeInput): Promise<SynthesizeOutput> {
-    const response = await this.client.audio.speech.create({
-      model: this.model,
-      voice: input.voice as OpenAI.Audio.SpeechCreateParams["voice"],
-      input: input.text,
-      response_format: input.format,
-    });
+    const chunks = chunkForOpenAi(input.text, OPENAI_TTS_CHAR_LIMIT);
 
-    const arrayBuffer = await response.arrayBuffer();
-    const audio = Buffer.from(arrayBuffer);
+    // MP3 is frame-based and naturally concatenable — joining the
+    // buffers of each chunk's response produces a valid, playable MP3
+    // for the whole text. There can be a barely-perceptible click at
+    // the seam, which we accept for narration.
+    const audioBuffers: Buffer[] = [];
+    for (const chunk of chunks) {
+      const response = await this.client.audio.speech.create({
+        model: this.model,
+        voice: input.voice as OpenAI.Audio.SpeechCreateParams["voice"],
+        input: chunk,
+        response_format: input.format,
+      });
+      const arrayBuffer = await response.arrayBuffer();
+      audioBuffers.push(Buffer.from(arrayBuffer));
+    }
+    const audio = Buffer.concat(audioBuffers);
 
     return {
       audio,
@@ -64,4 +82,89 @@ function estimateDurationSeconds(text: string): number {
   // OpenAI does not return duration; estimate from character count at typical narration pace.
   // This is refined by the worker reading the MP3 header when a precise value is required.
   return Math.max(1, Math.round(text.length / AVG_CHARS_PER_SECOND));
+}
+
+/**
+ * Splits `text` into chunks no longer than `maxChars`, preferring
+ * natural boundaries so the seam between MP3 segments lands at the
+ * end of a sentence (or paragraph) — minimizes the audible click and
+ * keeps narration cadence sensible.
+ *
+ * Strategy, in order:
+ *   1. Greedily pack whole sentences (split on `[.!?]\s+` and `\n`).
+ *   2. If a single sentence is itself longer than `maxChars`, split
+ *      it on word boundaries.
+ *   3. Last-resort character slice — guards against pathological
+ *      inputs (e.g. one giant URL with no spaces).
+ *
+ * Exported so it can be unit-tested without an OpenAI client.
+ */
+export function chunkForOpenAi(text: string, maxChars: number): string[] {
+  if (text.length <= maxChars) return [text];
+
+  // Split into sentence-ish pieces but KEEP the trailing punctuation.
+  // The regex matches "anything ending in . ? ! followed by space" plus
+  // the final tail. We also split on hard newlines so paragraph breaks
+  // remain natural seams.
+  const sentences = text
+    .split(/(?<=[.!?])\s+|\n+/g)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  const chunks: string[] = [];
+  let current = "";
+  for (const sentence of sentences) {
+    if (sentence.length > maxChars) {
+      // Flush whatever we've got, then split this oversize sentence.
+      if (current.length > 0) {
+        chunks.push(current);
+        current = "";
+      }
+      for (const piece of splitOversize(sentence, maxChars)) {
+        chunks.push(piece);
+      }
+      continue;
+    }
+    const next = current.length === 0 ? sentence : `${current} ${sentence}`;
+    if (next.length > maxChars) {
+      chunks.push(current);
+      current = sentence;
+    } else {
+      current = next;
+    }
+  }
+  if (current.length > 0) chunks.push(current);
+  return chunks;
+}
+
+/**
+ * Splits a single oversize "sentence" on word boundaries first, then
+ * falls back to brute-force character slicing if even that fails
+ * (e.g. one giant URL).
+ */
+function splitOversize(sentence: string, maxChars: number): string[] {
+  const out: string[] = [];
+  const words = sentence.split(/\s+/);
+  let current = "";
+  for (const word of words) {
+    if (word.length > maxChars) {
+      if (current.length > 0) {
+        out.push(current);
+        current = "";
+      }
+      for (let i = 0; i < word.length; i += maxChars) {
+        out.push(word.slice(i, i + maxChars));
+      }
+      continue;
+    }
+    const next = current.length === 0 ? word : `${current} ${word}`;
+    if (next.length > maxChars) {
+      out.push(current);
+      current = word;
+    } else {
+      current = next;
+    }
+  }
+  if (current.length > 0) out.push(current);
+  return out;
 }


### PR DESCRIPTION
## Summary

OpenAI's TTS API rejects inputs > 4096 characters with `400 string_too_long`. Detailed and many By Line explanations regularly run 5000–10000 chars, so the one-shot synth call fails for those tabs.

Reported by @augusto-chaves on prod 2026-04-28 for `https://app.versemate.org/bible/genesis/20` — the Detailed tab fails immediately on every chapter. Logs (DO run logs since this morning):

\`\`\`
[AUDIO-GEN] job audio-gen:10154:alloy:en-US failed: 400 string_too_long
[AUDIO-GEN] job audio-gen:10237:alloy:en-US failed: 400 string_too_long
[AUDIO-GEN] job audio-gen:10236:alloy:en-US failed: 400 string_too_long
\`\`\`

The dedup fix (#194) ensures users CAN now retry, but every retry hits the same 400.

## Fix

Split input at natural boundaries before calling OpenAI, call once per chunk, and `Buffer.concat` the resulting MP3 buffers. MP3 is frame-based and naturally concatenable; the seam at chunk boundaries may produce a barely-perceptible click — acceptable for narration.

Chunking strategy (in order):
1. **Sentence boundaries** (`.!?` followed by whitespace, plus hard newlines) — preferred, lands the seam at end of a thought
2. **Word boundaries** — fallback when a single sentence > limit
3. **Character slicing** — last-resort guard for pathological inputs (one giant URL with no spaces)

Limit set at **4000 chars** (under the 4096 ceiling) for safety margin.

## Test plan

- [x] `chunkForOpenAi` exported separately so tests don't need an OpenAI client
- [x] 7 unit tests cover: fits, sentence-split, paragraph-split, word-fallback, char-fallback, no-empty-chunks, regression (8000-char Detailed)
- [x] Full TTS + audio.service test suite: 27/27 pass
- [x] `bun tsc --noEmit` clean
- [ ] After deploy: Genesis 20 Detailed tab on prod, expect chip → loading → populated → playing (instead of immediate error)
- [ ] After deploy: spot-check a few longer Detailed explanations (Numbers 7, Psalms 119) for seam audibility — flag if clicks are objectionable

## Future work

If MP3 seam clicks turn out to be audible at typical listening volume, options:
1. Use `ffmpeg` to re-encode the concatenated buffer (heavier, server-side cost)
2. Switch to OpenAI's streaming response and let the client buffer (frontend rework)

Both are bigger lifts; let's ship the simple concat first and only invest if it sounds bad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)