### PR TITLE
fix(auth): restore login rate limit to 5/min/email

### DIFF
--- a/packages/backend-base/src/common/rate-limit.middleware.ts
+++ b/packages/backend-base/src/common/rate-limit.middleware.ts
@@ -66,11 +66,12 @@ export const createRateLimit = (options: RateLimitOptions) => {
 // Predefined rate limiters
 export const authRateLimiters = {
   /**
-   * Login rate limiter: 10000 attempts per email per minute (TEMPORARILY INCREASED)
+   * Login rate limiter: 5 attempts per email per minute.
+   * Per spec feat-auth-platform br-auth-006b (D-004 — restored from "TEMPORARILY INCREASED" 10000).
    */
   login: createRateLimit({
     windowSeconds: 60,
-    max: 10000,
+    max: 5,
     keyGenerator: (context) => `login:${context.body.email}`,
     message: "Too many login attempts, please try again in a minute",
   }),


### PR DESCRIPTION
## Summary

Restores the login rate limit from `10000/min/email` (marked "TEMPORARILY INCREASED" in code comment, never reverted) to **5/min/email** — industry-standard credential-stuffing defense.

Per spec [`feat-auth-platform`](https://github.com/verse-mate/verse-mate/blob/main/../versemate-meta/specs/feat-auth-platform/spec.md) br-auth-006b, Phase 1 decision D-004.

## Test plan

- [ ] Backend tests pass (`cd packages/backend-base && bun test`)
- [ ] Manual: 6 failed login attempts within 60s for the same email → 6th attempt → `429 TOO_MANY_REQUESTS`
- [ ] Manual: legitimate user with correct password on 1st attempt → 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)