### PR TITLE
feat(db): migration to drop Q&A tables (D-009 part 1)

### DIFF
--- a/packages/database/migrations/20260503130000-drop-qa-tables.ts
+++ b/packages/database/migrations/20260503130000-drop-qa-tables.ts
@@ -1,0 +1,68 @@
+import { type Kysely, sql } from "kysely";
+import type Database from "../src/models/Database";
+
+/**
+ * Drop Q&A (Ask VerseMate) feature tables and supporting enum.
+ *
+ * Per spec feat-domain-model + Phase 1 decision D-009: the Q&A feature is
+ * disabled and never reached production. Removing it entirely from schema,
+ * endpoints, and frontend.
+ *
+ * Tables removed:
+ *   - conversations
+ *   - messages (FK to conversations)
+ *
+ * Enum removed:
+ *   - role_enum (only used by messages.role)
+ *
+ * The down migration recreates these — only useful if Q&A is reactivated.
+ */
+export async function up(db: Kysely<Database>): Promise<void> {
+  console.log("Dropping Q&A tables and role_enum (D-009)...");
+
+  // Drop messages first (FK to conversations)
+  await db.schema.dropTable("messages").ifExists().execute();
+  await db.schema.dropTable("conversations").ifExists().execute();
+
+  // Drop the enum after the tables that referenced it
+  await sql`DROP TYPE IF EXISTS role_enum`.execute(db);
+
+  console.log("Successfully dropped Q&A tables and role_enum.");
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  console.log("Reverting: recreating Q&A tables (debug only)...");
+
+  await sql`CREATE TYPE role_enum AS ENUM ('user', 'assistant')`.execute(db);
+
+  await db.schema
+    .createTable("conversations")
+    .addColumn("conversation_id", "serial", (col) => col.primaryKey())
+    .addColumn("user_id", "uuid", (col) =>
+      col.notNull().references("user.id").onDelete("cascade"),
+    )
+    .addColumn("book_id", "integer", (col) => col.notNull())
+    .addColumn("chapter_number", "integer", (col) => col.notNull())
+    .addColumn("created_at", "timestamp", (col) =>
+      col.defaultTo(sql`now()`).notNull(),
+    )
+    .execute();
+
+  await db.schema
+    .createTable("messages")
+    .addColumn("message_id", "serial", (col) => col.primaryKey())
+    .addColumn("conversation_id", "integer", (col) =>
+      col
+        .notNull()
+        .references("conversations.conversation_id")
+        .onDelete("cascade"),
+    )
+    .addColumn("role", sql`role_enum`, (col) => col.notNull())
+    .addColumn("content", "text", (col) => col.notNull())
+    .addColumn("created_at", "timestamp", (col) =>
+      col.defaultTo(sql`now()`).notNull(),
+    )
+    .execute();
+
+  console.log("Reverted Q&A tables.");
+}


### PR DESCRIPTION
Per spec feat-domain-model + Phase 1 decision **D-009**: Q&A feature is disabled and never reached production. Removing it from schema first.

**This PR (part 1):** DB migration only. Drops `conversations`, `messages` tables and `role_enum`.

**Follow-up PR (part 2):** removes ~30 frontend files (Chat UI, hooks, Header InputBar, Main content, etc.) that reference the removed Eden routes via TS inferred types. Plus removes backend chat.service.ts, chat.repository.ts, chat DTOs, and the 7 endpoints. The frontend cascade is too large to bundle into one reviewable PR.

⚠ **DEPLOYMENT ORDER:** do NOT deploy this migration to prod until the companion frontend cleanup PR is merged. Otherwise the live frontend will fail at runtime querying non-existent tables. Staging deploys fine for testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)