### PR TITLE
docs: scope apps/frontend-next to admin-only (Epic 12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,9 +66,21 @@ cd apps/frontend-next && bun build  # Build frontend
 **All public-facing marketing pages go in `apps/website`, not `apps/frontend-next`.**
 
 - `apps/website` → `versemate.org` (marketing, landing pages, `/give`, `/about`, `/coach`, `/privacy`, etc.). Next.js with `output: "export"`, static export served by a Cloudflare Worker. Drop new static HTML into `apps/website/public/<route>/index.html` or add a page in `apps/website/src/pages/`.
-- `apps/frontend-next` → `app.versemate.org` (the logged-in product: Bible reader, chat, coaching reports). This app has the `MyMainPage` chrome wrapper in the root layout; it is NOT the right home for marketing content.
+- `apps/frontend-next` → **`admin.versemate.org` (admin-only — staff content management).** Per [versemate-meta constitution CONST-002 "mobile-first"](../versemate-meta/constitution.md), the canonical user-facing surface is `verse-mate-mobile` (iOS, Android, web export). frontend-next is no longer a user product. New user-facing features go in mobile, NOT here.
 
-If you're unsure, the rule is: "Would this URL make sense on versemate.org?" If yes → `apps/website`.
+  Allowed in `apps/frontend-next`:
+  - `(admin)/admin` — admin dashboard, content management, prompts editor, batch ops
+  - `(auth)` — admin login + SSO callbacks (admins authenticate here)
+  - `(bible)` — read-only Bible preview for admin QA (per spec [feat-admin-bible-preview](../versemate-meta/specs/feat-admin-bible-preview/spec.md))
+  - `topic/[category]/[slug]` — read-only topic preview for admin QA
+
+  **NOT allowed in `apps/frontend-next`** (deprecated, removal pending):
+  - User signup flows (mobile owns signup; admin gets `is_admin = true` via manual SQL per D-014 in feat-auth-platform)
+  - Chat / Q&A UI (Q&A feature removed entirely per D-009)
+  - User input bars / Bible reader composing tools
+  - Anything wrapped by `useChat`, `useConversationManager`, `useInput`, `Chat`, `ConversationHistory`, `InputBar`
+
+If you're unsure, the rule is: "Would this URL make sense on versemate.org?" If yes → `apps/website`. "Would a user (not admin) need this?" If yes → mobile, not frontend-next.
 
 ### Key Technologies
 - **Runtime**: Bun (replaces Node.js, npm, and more)

--- a/packages/frontend-base/src/hooks/useChat.ts
+++ b/packages/frontend-base/src/hooks/useChat.ts
@@ -1,3 +1,17 @@
+/**
+ * @deprecated D-009 + D-014 — Q&A feature removed; frontend-next is admin-only.
+ *
+ * This file is part of the user-facing Bible reader Chat / Q&A flow that has
+ * been deprecated per Phase 1 decision D-009 (Q&A removed entirely) AND
+ * Epic 12 (frontend-next scoped to admin-only).
+ *
+ * Removal is pending — companion PR to "feat: drop Q&A entirely" (#204) will
+ * delete this file along with the Chat UI and migrate consumers in
+ * main-content.tsx, RightPanel, Header.
+ *
+ * Do NOT add new code here; do NOT add new callers.
+ */
+
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "backend-api";
 import { useCallback, useState } from "react";

--- a/packages/frontend-base/src/hooks/useConversationManager.ts
+++ b/packages/frontend-base/src/hooks/useConversationManager.ts
@@ -1,3 +1,17 @@
+/**
+ * @deprecated D-009 + D-014 — Q&A feature removed; frontend-next is admin-only.
+ *
+ * This file is part of the user-facing Bible reader Chat / Q&A flow that has
+ * been deprecated per Phase 1 decision D-009 (Q&A removed entirely) AND
+ * Epic 12 (frontend-next scoped to admin-only).
+ *
+ * Removal is pending — companion PR to "feat: drop Q&A entirely" (#204) will
+ * delete this file along with the Chat UI and migrate consumers in
+ * main-content.tsx, RightPanel, Header.
+ *
+ * Do NOT add new code here; do NOT add new callers.
+ */
+
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "backend-api";
 import type TestamentEnum from "database/src/models/public/TestamentEnum";

--- a/packages/frontend-base/src/hooks/useInput.ts
+++ b/packages/frontend-base/src/hooks/useInput.ts
@@ -1,3 +1,17 @@
+/**
+ * @deprecated D-009 + D-014 — Q&A feature removed; frontend-next is admin-only.
+ *
+ * This file is part of the user-facing Bible reader Chat / Q&A flow that has
+ * been deprecated per Phase 1 decision D-009 (Q&A removed entirely) AND
+ * Epic 12 (frontend-next scoped to admin-only).
+ *
+ * Removal is pending — companion PR to "feat: drop Q&A entirely" (#204) will
+ * delete this file along with the Chat UI and migrate consumers in
+ * main-content.tsx, RightPanel, Header.
+ *
+ * Do NOT add new code here; do NOT add new callers.
+ */
+
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";

--- a/packages/frontend-base/src/ui/Chat/content.tsx
+++ b/packages/frontend-base/src/ui/Chat/content.tsx
@@ -1,3 +1,17 @@
+/**
+ * @deprecated D-009 + D-014 — Q&A feature removed; frontend-next is admin-only.
+ *
+ * This file is part of the user-facing Bible reader Chat / Q&A flow that has
+ * been deprecated per Phase 1 decision D-009 (Q&A removed entirely) AND
+ * Epic 12 (frontend-next scoped to admin-only).
+ *
+ * Removal is pending — companion PR to "feat: drop Q&A entirely" (#204) will
+ * delete this file along with the Chat UI and migrate consumers in
+ * main-content.tsx, RightPanel, Header.
+ *
+ * Do NOT add new code here; do NOT add new callers.
+ */
+
 import * as RadixTabs from "@radix-ui/react-tabs";
 import { useIsMutating } from "@tanstack/react-query";
 import type TestamentEnum from "database/src/models/public/TestamentEnum";

--- a/packages/frontend-base/src/ui/Chat/form.tsx
+++ b/packages/frontend-base/src/ui/Chat/form.tsx
@@ -1,3 +1,17 @@
+/**
+ * @deprecated D-009 + D-014 — Q&A feature removed; frontend-next is admin-only.
+ *
+ * This file is part of the user-facing Bible reader Chat / Q&A flow that has
+ * been deprecated per Phase 1 decision D-009 (Q&A removed entirely) AND
+ * Epic 12 (frontend-next scoped to admin-only).
+ *
+ * Removal is pending — companion PR to "feat: drop Q&A entirely" (#204) will
+ * delete this file along with the Chat UI and migrate consumers in
+ * main-content.tsx, RightPanel, Header.
+ *
+ * Do NOT add new code here; do NOT add new callers.
+ */
+
 import { useChat } from "../../hooks/useChat";
 import * as Icons from "../Icons";
 import { Button } from "./button";

--- a/packages/frontend-base/src/ui/Chat/index.ts
+++ b/packages/frontend-base/src/ui/Chat/index.ts
@@ -1,3 +1,17 @@
+/**
+ * @deprecated D-009 + D-014 — Q&A feature removed; frontend-next is admin-only.
+ *
+ * This file is part of the user-facing Bible reader Chat / Q&A flow that has
+ * been deprecated per Phase 1 decision D-009 (Q&A removed entirely) AND
+ * Epic 12 (frontend-next scoped to admin-only).
+ *
+ * Removal is pending — companion PR to "feat: drop Q&A entirely" (#204) will
+ * delete this file along with the Chat UI and migrate consumers in
+ * main-content.tsx, RightPanel, Header.
+ *
+ * Do NOT add new code here; do NOT add new callers.
+ */
+
 import { Card } from "./card";
 import { CardContent } from "./content";
 import { ChatHeader } from "./header";

--- a/packages/frontend-base/src/ui/ConversationHistory/HistoryButton/history-button.tsx
+++ b/packages/frontend-base/src/ui/ConversationHistory/HistoryButton/history-button.tsx
@@ -1,3 +1,17 @@
+/**
+ * @deprecated D-009 + D-014 — Q&A feature removed; frontend-next is admin-only.
+ *
+ * This file is part of the user-facing Bible reader Chat / Q&A flow that has
+ * been deprecated per Phase 1 decision D-009 (Q&A removed entirely) AND
+ * Epic 12 (frontend-next scoped to admin-only).
+ *
+ * Removal is pending — companion PR to "feat: drop Q&A entirely" (#204) will
+ * delete this file along with the Chat UI and migrate consumers in
+ * main-content.tsx, RightPanel, Header.
+ *
+ * Do NOT add new code here; do NOT add new callers.
+ */
+
 import { useQueryClient } from "@tanstack/react-query";
 import { api } from "backend-api";
 import {

--- a/packages/frontend-base/src/ui/ConversationHistory/index.ts
+++ b/packages/frontend-base/src/ui/ConversationHistory/index.ts
@@ -1,3 +1,17 @@
+/**
+ * @deprecated D-009 + D-014 — Q&A feature removed; frontend-next is admin-only.
+ *
+ * This file is part of the user-facing Bible reader Chat / Q&A flow that has
+ * been deprecated per Phase 1 decision D-009 (Q&A removed entirely) AND
+ * Epic 12 (frontend-next scoped to admin-only).
+ *
+ * Removal is pending — companion PR to "feat: drop Q&A entirely" (#204) will
+ * delete this file along with the Chat UI and migrate consumers in
+ * main-content.tsx, RightPanel, Header.
+ *
+ * Do NOT add new code here; do NOT add new callers.
+ */
+
 import { Content } from "./Content/content";
 import { HistoryButton } from "./HistoryButton/history-button";
 import { HistoryLabel } from "./HistoryLabel/history-label";

--- a/packages/frontend-base/src/utils/user-ai-messages.ts
+++ b/packages/frontend-base/src/utils/user-ai-messages.ts
@@ -1,3 +1,17 @@
+/**
+ * @deprecated D-009 + D-014 — Q&A feature removed; frontend-next is admin-only.
+ *
+ * This file is part of the user-facing Bible reader Chat / Q&A flow that has
+ * been deprecated per Phase 1 decision D-009 (Q&A removed entirely) AND
+ * Epic 12 (frontend-next scoped to admin-only).
+ *
+ * Removal is pending — companion PR to "feat: drop Q&A entirely" (#204) will
+ * delete this file along with the Chat UI and migrate consumers in
+ * main-content.tsx, RightPanel, Header.
+ *
+ * Do NOT add new code here; do NOT add new callers.
+ */
+
 import type { Message } from "../hooks/useInput";
 
 export const messages: Message[] = [


### PR DESCRIPTION
Per [versemate-meta CONST-002 'mobile-first'](../versemate-meta/constitution.md): canonical user surface is mobile. `apps/frontend-next` is admin-only at `admin.versemate.org` going forward.

**Changes:**
- `CLAUDE.md` updated with explicit admin-only scope (allowed: admin dashboard, login, read-only Bible/topic preview for QA — deprecated: user signup flows, Chat/Q&A UI, user input bars)
- `@deprecated D-009` markers on user-facing Q&A files in `frontend-base` (useChat, useConversationManager, useInput, Chat UI, ConversationHistory, user-ai-messages) — flagging for removal in companion PR

**Why this PR matters:**
This documentation + deprecation step unblocks the Q&A removal cascade (#204) and refresh-token cascade (#206) — by clarifying scope, the follow-up PRs that delete code can move faster without ambiguity about "do we keep this for users?"

**No runtime change.** TS compiles clean. Tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)