### PR TITLE
feat(i18n): apply alias + English fallback to bible.service (D-013/D-014)

### DIFF
--- a/packages/backend-base/src/bible/services/bible.service.ts
+++ b/packages/backend-base/src/bible/services/bible.service.ts
@@ -2,6 +2,7 @@ import type ExplanationTypeEnum from "database/src/models/public/ExplanationType
 import type HighlightColorEnum from "database/src/models/public/HighlightColorEnum";
 import type TestamentEnum from "database/src/models/public/TestamentEnum";
 import { NotFoundError, ValidationError } from "../../common/errors";
+import { resolveLanguageCode, withEnglishFallback } from "../../shared/i18n";
 import type { db } from "../../shared/shared.plugin";
 import { parseAndInjectVerses } from "../../shared/verse-parser";
 import type { BookDto } from "../dto/book/book.dto";
@@ -162,16 +163,35 @@ export class BibleService {
       }
     }
 
-    const { explanation } = await this.bibleRepository.getExplanation({
-      book_id,
-      chapter_number,
+    // Per spec feat-i18n br-i18n-002 (D-013) + br-i18n-004 (D-014):
+    //   1) Try the user's language (alias-aware: en ↔ en-US, pt ↔ pt-BR)
+    //   2) Fall back to English with `translated: false` flag if missing
+    const result = await withEnglishFallback(
       language_code,
-      type,
-    });
+      async (lang: string) => {
+        const codes = resolveLanguageCode(lang);
+        // Try each alias form in order of specificity
+        for (const code of codes) {
+          const { explanation } = await this.bibleRepository.getExplanation({
+            book_id,
+            chapter_number,
+            language_code: code,
+            type,
+          });
+          if (explanation?.explanation_id) return explanation;
+        }
+        return null;
+      },
+    );
 
-    if (!explanation?.explanation_id) {
+    if (!result) {
       return null;
     }
+
+    const explanation = result.content;
+    // Attach D-014 translation metadata to the response object
+    (explanation as any).translated = result.translated;
+    (explanation as any).source_language = result.source_language;
 
     if (explanation.explanation) {
       explanation.explanation = await parseAndInjectVerses(

--- a/packages/backend-base/src/shared/i18n/index.ts
+++ b/packages/backend-base/src/shared/i18n/index.ts
@@ -1,0 +1,5 @@
+export {
+  canonicalizeLanguageCode,
+  resolveLanguageCode,
+} from "./resolve-language-code";
+export { type FallbackResult, withEnglishFallback } from "./with-fallback";

--- a/packages/backend-base/src/shared/i18n/resolve-language-code.test.ts
+++ b/packages/backend-base/src/shared/i18n/resolve-language-code.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import {
+  canonicalizeLanguageCode,
+  resolveLanguageCode,
+} from "./resolve-language-code";
+
+describe("resolveLanguageCode (D-013 alias)", () => {
+  it("en-US → [en-US, en]", () => {
+    expect(resolveLanguageCode("en-US")).toEqual(["en-US", "en"]);
+  });
+
+  it("en → [en, en-US]", () => {
+    expect(resolveLanguageCode("en")).toEqual(["en", "en-US"]);
+  });
+
+  it("pt-BR → [pt-BR, pt]", () => {
+    expect(resolveLanguageCode("pt-BR")).toEqual(["pt-BR", "pt"]);
+  });
+
+  it("pt → [pt, pt-BR]", () => {
+    expect(resolveLanguageCode("pt")).toEqual(["pt", "pt-BR"]);
+  });
+
+  it("zh (no canonical region) → [zh]", () => {
+    expect(resolveLanguageCode("zh")).toEqual(["zh"]);
+  });
+
+  it("rejects malformed input", () => {
+    expect(() => resolveLanguageCode("english")).toThrow(/BCP-47/);
+    expect(() => resolveLanguageCode("EN")).toThrow(/BCP-47/);
+    expect(() => resolveLanguageCode("en_US")).toThrow(/BCP-47/);
+    expect(() => resolveLanguageCode("")).toThrow(/BCP-47/);
+  });
+
+  it("most-specific form is first (lookup query benefits from natural IN ordering)", () => {
+    const formsRegional = resolveLanguageCode("en-US");
+    expect(formsRegional[0]).toBe("en-US"); // exact match preferred
+    expect(formsRegional[1]).toBe("en"); // base fallback
+
+    const formsBase = resolveLanguageCode("en");
+    expect(formsBase[0]).toBe("en"); // exact match preferred
+    expect(formsBase[1]).toBe("en-US"); // regional fallback
+  });
+});
+
+describe("canonicalizeLanguageCode", () => {
+  it("strips region", () => {
+    expect(canonicalizeLanguageCode("en-US")).toBe("en");
+    expect(canonicalizeLanguageCode("pt-BR")).toBe("pt");
+    expect(canonicalizeLanguageCode("zh")).toBe("zh");
+  });
+
+  it("rejects malformed input", () => {
+    expect(() => canonicalizeLanguageCode("ZH-CN")).toThrow(/BCP-47/);
+  });
+});

--- a/packages/backend-base/src/shared/i18n/resolve-language-code.ts
+++ b/packages/backend-base/src/shared/i18n/resolve-language-code.ts
@@ -1,0 +1,75 @@
+/**
+ * resolveLanguageCode — alias resolver for BCP-47 language tags.
+ *
+ * Per spec feat-i18n br-i18n (D-013): backend treats `en` and `en-US` as
+ * equivalent in lookups. Same for any future language with a base + region
+ * variant. When looking up content, the alias resolver returns BOTH possible
+ * keys so a single query can match either form.
+ *
+ * Storage layer is free to canonicalize on write (e.g. always store `en`),
+ * but lookups must handle both inputs gracefully.
+ *
+ * Examples:
+ *   resolveLanguageCode('en-US')  → ['en-US', 'en']    // try region first, fall back to base
+ *   resolveLanguageCode('en')     → ['en', 'en-US']    // try base first, also match region
+ *   resolveLanguageCode('pt-BR')  → ['pt-BR', 'pt']
+ *   resolveLanguageCode('pt')     → ['pt', 'pt-BR']
+ *   resolveLanguageCode('zh')     → ['zh']             // no canonical region variant
+ *
+ * The most-specific form is returned first so callers using `IN (...)` queries
+ * naturally prefer the more specific match if both exist.
+ */
+
+/** Default region for each base language code where multiple regions might exist. */
+const DEFAULT_REGIONS: Record<string, string> = {
+  en: "US",
+  pt: "BR",
+  // Add more as needed (zh, fr, es) — currently mobile sends en-US only.
+};
+
+const BCP47_REGEX = /^[a-z]{2}(-[A-Z]{2})?$/;
+
+/**
+ * Resolves a language code into the list of equivalent forms to look up.
+ *
+ * @param input — BCP-47 tag (e.g. "en", "en-US")
+ * @returns ordered array of forms, most-specific first
+ * @throws if input is not BCP-47 compatible
+ */
+export function resolveLanguageCode(input: string): string[] {
+  if (!BCP47_REGEX.test(input)) {
+    throw new Error(
+      `Invalid language code "${input}". Expected BCP-47 format: "en" or "en-US".`,
+    );
+  }
+
+  const hasRegion = input.includes("-");
+  if (hasRegion) {
+    // "en-US" → ["en-US", "en"]
+    const base = input.split("-")[0];
+    return [input, base];
+  }
+
+  // "en" → ["en", "en-US"] if there's a known default region
+  const defaultRegion = DEFAULT_REGIONS[input];
+  if (defaultRegion) {
+    return [input, `${input}-${defaultRegion}`];
+  }
+
+  // "zh" → ["zh"] (no canonical region)
+  return [input];
+}
+
+/**
+ * Returns the canonical (storage-preferred) form: base language without region.
+ * Backend writes use this. Lookups use resolveLanguageCode() to also accept
+ * the regional form.
+ */
+export function canonicalizeLanguageCode(input: string): string {
+  if (!BCP47_REGEX.test(input)) {
+    throw new Error(
+      `Invalid language code "${input}". Expected BCP-47 format: "en" or "en-US".`,
+    );
+  }
+  return input.split("-")[0];
+}

--- a/packages/backend-base/src/shared/i18n/with-fallback.test.ts
+++ b/packages/backend-base/src/shared/i18n/with-fallback.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import { withEnglishFallback } from "./with-fallback";
+
+describe("withEnglishFallback (D-014)", () => {
+  it("returns translated:true when user-language content exists", async () => {
+    const result = await withEnglishFallback("pt-BR", async (lang) => {
+      if (lang === "pt-BR") return { text: "Conteúdo em português" };
+      return null;
+    });
+
+    expect(result).toEqual({
+      content: { text: "Conteúdo em português" },
+      translated: true,
+      source_language: "pt",
+    });
+  });
+
+  it("falls back to English with translated:false when user-language is missing", async () => {
+    const result = await withEnglishFallback("pt-BR", async (lang) => {
+      if (lang === "en") return { text: "English content" };
+      return null;
+    });
+
+    expect(result).toEqual({
+      content: { text: "English content" },
+      translated: false,
+      source_language: "en",
+    });
+  });
+
+  it("returns null when both user-language AND English are missing", async () => {
+    const result = await withEnglishFallback("pt-BR", async () => null);
+    expect(result).toBeNull();
+  });
+
+  it("does NOT fall back when user IS English (translated:true)", async () => {
+    const result = await withEnglishFallback("en", async (lang) => {
+      if (lang === "en") return { text: "English" };
+      return null;
+    });
+
+    expect(result?.translated).toBe(true);
+    expect(result?.source_language).toBe("en");
+  });
+
+  it("does NOT fall back when user is en-US either (alias-aware)", async () => {
+    const result = await withEnglishFallback("en-US", async () => null);
+    expect(result).toBeNull(); // does NOT silently re-query English (would loop)
+  });
+
+  it("source_language is canonicalized (drops region)", async () => {
+    const result = await withEnglishFallback("pt-BR", async () => ({
+      text: "X",
+    }));
+    expect(result?.source_language).toBe("pt"); // canonical, not "pt-BR"
+  });
+
+  it("works with primitive content types", async () => {
+    const result = await withEnglishFallback<string>("pt-BR", async (lang) =>
+      lang === "pt-BR" ? "olá" : null,
+    );
+    expect(result?.content).toBe("olá");
+    expect(result?.translated).toBe(true);
+  });
+});

--- a/packages/backend-base/src/shared/i18n/with-fallback.ts
+++ b/packages/backend-base/src/shared/i18n/with-fallback.ts
@@ -1,0 +1,62 @@
+/**
+ * withEnglishFallback — wrap a content lookup so that when the user's language
+ * has no row, the response falls back to English with a flag.
+ *
+ * Per spec feat-i18n br-i18n-004 (D-014): "When a chapter has no explanation
+ * in the user's language, the API returns the English version with metadata
+ * `{translated: false, source_language: 'en'}`. UI shows 'Showing English (no
+ * translation available)'."
+ *
+ * The wrapper takes:
+ *   - the user's requested language code
+ *   - a `lookup(languageCode)` function that returns content or null
+ * and returns `{ content, translated: boolean, source_language: string }`.
+ *
+ * Returns null only if BOTH user-language AND English have no content.
+ */
+
+import { canonicalizeLanguageCode } from "./resolve-language-code";
+
+export interface FallbackResult<T> {
+  content: T;
+  /** True if the content matches the requested language. False if it fell back to English. */
+  translated: boolean;
+  /** The actual language of the returned content. */
+  source_language: string;
+}
+
+const FALLBACK_LANGUAGE = "en";
+
+export async function withEnglishFallback<T>(
+  requestedLanguageCode: string,
+  lookup: (languageCode: string) => Promise<T | null | undefined>,
+): Promise<FallbackResult<T> | null> {
+  // First try the requested language (alias-aware lookup is the responsibility of `lookup`).
+  const direct = await lookup(requestedLanguageCode);
+  if (direct) {
+    return {
+      content: direct,
+      translated: true,
+      source_language: canonicalizeLanguageCode(requestedLanguageCode),
+    };
+  }
+
+  // Skip fallback if requested IS English (alias-aware comparison)
+  const requestedBase = canonicalizeLanguageCode(requestedLanguageCode);
+  if (requestedBase === FALLBACK_LANGUAGE) {
+    return null;
+  }
+
+  // Fall back to English
+  const fallback = await lookup(FALLBACK_LANGUAGE);
+  if (fallback) {
+    return {
+      content: fallback,
+      translated: false,
+      source_language: FALLBACK_LANGUAGE,
+    };
+  }
+
+  // Neither user-language nor English has content
+  return null;
+}


### PR DESCRIPTION
Per spec feat-i18n br-i18n-002 (D-013) + br-i18n-004 (D-014). Stacked on #203 (i18n helpers).

`bible.service.ts:getExplanation` now:
1. Resolves `language_code` via `resolveLanguageCode()` — alias-aware (en ↔ en-US, pt ↔ pt-BR)
2. Wraps lookup in `withEnglishFallback()` — returns English with `{translated: false, source_language: 'en'}` if user's lang has no row

Response shape additions:
- `explanation.translated` — true if served in user's language
- `explanation.source_language` — canonical code of served content

Mobile can render 'Showing English (no translation available)' banner when `translated === false`.

**Diff base:** `feat/i18n-alias-fallback` (#203). Merge that PR first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)