### PR TITLE
feat(ai): expand AiProvider with responsesCreate (D-001 follow-up)

### DIFF
--- a/packages/backend-base/src/admin/services/admin-prompt.service.ts
+++ b/packages/backend-base/src/admin/services/admin-prompt.service.ts
@@ -1,13 +1,9 @@
 import type ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import PromptStatusEnum from "database/src/models/public/PromptStatusEnum";
-// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
-// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
-// as follow-up to feat-integrations br-int-001.
-
-import OpenAI from "openai";
 import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { UserPromptRepository } from "../../bible/repository/user-prompt.repository";
 import { ForbiddenError, NotFoundError } from "../../common/errors";
+import { type AiProvider, getAiProvider } from "../../shared/ai";
 import {
   generateChunkedBylineParallel,
   shouldUseBylineChunking,
@@ -33,18 +29,13 @@ interface PlaygroundRequest {
 export class AdminPromptService {
   private promptRepository: PromptRepository;
   private userPromptRepository: UserPromptRepository;
-  private openai: OpenAI;
+  private ai: AiProvider;
 
   constructor(private readonly db: db) {
     this.promptRepository = new PromptRepository(this.db);
     this.userPromptRepository = new UserPromptRepository(this.db);
-    const apiKey = process.env.OPEN_AI_KEY;
-    if (!apiKey) {
-      console.error(
-        "ERROR: OPEN_AI_KEY is not set. OpenAI client will not be initialized.",
-      );
-    }
-    this.openai = new OpenAI({ apiKey });
+    // Per spec feat-integrations br-int-001 (D-001): consume AI through abstraction.
+    this.ai = getAiProvider();
   }
 
   // --- System Prompt Methods ---
@@ -347,14 +338,14 @@ export class AdminPromptService {
     effort?: "low" | "medium" | "high";
     max_output_tokens?: number;
   }) {
-    const response = await this.openai.responses.create({
+    const response = await this.ai.responsesCreate({
       model,
-      reasoning: { effort },
+      reasoningEffort: effort,
       instructions,
       input,
-      max_output_tokens: max_output_tokens || 50000,
+      maxOutputTokens: max_output_tokens || 50000,
     });
-    return response.output_text || "";
+    return response.outputText;
   }
 
   private getLanguageName(code: string, locale = "en"): string {

--- a/packages/backend-base/src/admin/services/admin-prompt.service.ts
+++ b/packages/backend-base/src/admin/services/admin-prompt.service.ts
@@ -1,5 +1,9 @@
 import type ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import PromptStatusEnum from "database/src/models/public/PromptStatusEnum";
+// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
+// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
+// as follow-up to feat-integrations br-int-001.
+
 import OpenAI from "openai";
 import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { UserPromptRepository } from "../../bible/repository/user-prompt.repository";

--- a/packages/backend-base/src/admin/services/batch-operations.service.ts
+++ b/packages/backend-base/src/admin/services/batch-operations.service.ts
@@ -1,6 +1,10 @@
 import type { Queue } from "bullmq";
 import type ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import PromptStatusEnum from "database/src/models/public/PromptStatusEnum";
+// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
+// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
+// as follow-up to feat-integrations br-int-001.
+
 import OpenAI, { APIError } from "openai";
 import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { UserPromptRepository } from "../../bible/repository/user-prompt.repository";

--- a/packages/backend-base/src/admin/services/explanation-regeneration.service.ts
+++ b/packages/backend-base/src/admin/services/explanation-regeneration.service.ts
@@ -1,11 +1,7 @@
 import type ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
-// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
-// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
-// as follow-up to feat-integrations br-int-001.
-
-import OpenAI from "openai";
 import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { NotFoundError } from "../../common/errors";
+import { type AiProvider, getAiProvider } from "../../shared/ai";
 import {
   generateChunkedBylineParallel,
   shouldUseBylineChunking,
@@ -15,13 +11,12 @@ import { getExplanationTypePrompt } from "../../shared/prompt-utils";
 import type { db } from "../../shared/shared.plugin";
 
 export class ExplanationRegenerationService {
-  private readonly openai: OpenAI;
+  private readonly ai: AiProvider;
   private readonly promptRepository: PromptRepository;
 
   constructor(private readonly db: db) {
-    this.openai = new OpenAI({
-      apiKey: process.env.OPEN_AI_KEY,
-    });
+    // Per spec feat-integrations br-int-001 (D-001): consume AI through abstraction.
+    this.ai = getAiProvider();
     this.promptRepository = new PromptRepository(this.db);
   }
 
@@ -38,15 +33,15 @@ export class ExplanationRegenerationService {
     effort?: "low" | "medium" | "high";
     maxTokens?: number;
   }) {
-    const response = await this.openai.responses.create({
+    const response = await this.ai.responsesCreate({
       model,
-      reasoning: { effort },
+      reasoningEffort: effort,
       instructions,
       input,
-      max_output_tokens: maxTokens,
+      maxOutputTokens: maxTokens,
     });
 
-    return response.output_text || "";
+    return response.outputText;
   }
 
   private getLanguageName(code: string, locale = "en"): string {

--- a/packages/backend-base/src/admin/services/explanation-regeneration.service.ts
+++ b/packages/backend-base/src/admin/services/explanation-regeneration.service.ts
@@ -1,4 +1,8 @@
 import type ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
+// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
+// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
+// as follow-up to feat-integrations br-int-001.
+
 import OpenAI from "openai";
 import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { NotFoundError } from "../../common/errors";

--- a/packages/backend-base/src/bible/explanation-queue.ts
+++ b/packages/backend-base/src/bible/explanation-queue.ts
@@ -1,16 +1,16 @@
 import Queue from "bull";
 import { db } from "database";
 import ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
-import OpenAI from "openai";
+import { type AiChatMessage, getAiProvider } from "../shared/ai";
 import {
   generateChunkedByline,
   shouldUseBylineChunking,
   toBylineVerses,
 } from "../shared/byline-chunking";
 
-const openai = new OpenAI({
-  apiKey: process.env.OPEN_AI_KEY,
-});
+// Per spec feat-integrations br-int-001 (D-001): use the provider abstraction.
+// Resolved per AI_PROVIDER env (default: openai).
+const ai = getAiProvider();
 
 const getExplanationTypePrompt = (
   type: ExplanationTypeEnum,
@@ -100,20 +100,18 @@ async function gpt5Text({
   user: string;
   maxTokens?: number;
 }) {
-  const messages: OpenAI.ChatCompletionMessageParam[] = [];
+  const messages: AiChatMessage[] = [];
   if (system) {
     messages.push({ role: "system", content: system });
   }
   messages.push({ role: "user", content: user });
 
-  const options: any = {
+  const response = await ai.chatComplete({
     model: "gpt-5",
     messages,
-    max_completion_tokens: maxTokens,
-  };
-
-  const chat = await openai.chat.completions.create(options);
-  return chat.choices[0].message.content || "";
+    maxTokens,
+  });
+  return response.content;
 }
 
 // Create explanation generation queue

--- a/packages/backend-base/src/queue/consumers/batch-monitoring.consumer.ts
+++ b/packages/backend-base/src/queue/consumers/batch-monitoring.consumer.ts
@@ -2,6 +2,10 @@
 import * as fs from "node:fs";
 import type { Job } from "bullmq";
 import { db } from "database";
+// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
+// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
+// as follow-up to feat-integrations br-int-001.
+
 import OpenAI from "openai";
 import { BatchOperationService } from "../../admin/services/batch-operations.service";
 import { replaceExplanationWithAudioHook } from "../../bible/audio/audio-regen-hook";

--- a/packages/backend-base/src/shared/ai/ai-provider.factory.ts
+++ b/packages/backend-base/src/shared/ai/ai-provider.factory.ts
@@ -1,0 +1,43 @@
+import type { AiProvider } from "./ai-provider.interface";
+import { OpenAiProvider } from "./openai.provider";
+import { StubAiProvider } from "./stub.provider";
+
+/**
+ * Factory that resolves an AiProvider based on the `AI_PROVIDER` env var.
+ *
+ *   AI_PROVIDER=openai   (default)
+ *   AI_PROVIDER=stub     (tests / dev without OpenAI key)
+ *
+ * Returns a singleton per process for the resolved provider.
+ *
+ * Per spec feat-integrations br-int-001 (D-001).
+ */
+let cached: AiProvider | null = null;
+
+export function getAiProvider(name?: string): AiProvider {
+  if (cached && !name) return cached;
+
+  const resolved = (name ?? process.env.AI_PROVIDER ?? "openai").toLowerCase();
+  let provider: AiProvider;
+
+  switch (resolved) {
+    case "openai":
+      provider = new OpenAiProvider();
+      break;
+    case "stub":
+      provider = new StubAiProvider();
+      break;
+    default:
+      throw new Error(
+        `Unknown AI_PROVIDER "${resolved}" — supported: openai, stub`,
+      );
+  }
+
+  if (!name) cached = provider;
+  return provider;
+}
+
+/** For tests: reset the singleton. */
+export function resetAiProviderCache(): void {
+  cached = null;
+}

--- a/packages/backend-base/src/shared/ai/ai-provider.interface.ts
+++ b/packages/backend-base/src/shared/ai/ai-provider.interface.ts
@@ -47,10 +47,42 @@ export interface AiChatResponse {
   };
 }
 
+/**
+ * Options for the Responses API (newer Assistants-style API).
+ * Used by admin prompt playground + explanation regeneration + topic
+ * translation where instruction-style input is preferred over messages.
+ */
+export interface AiResponseOptions {
+  /** Model identifier (e.g. "gpt-5", "gpt-5-nano"). */
+  model: string;
+  /** Free-form instruction string (system role equivalent). */
+  instructions?: string;
+  /** Free-form input (user role equivalent). */
+  input: string;
+  /** Reasoning effort hint: "low" | "medium" | "high". */
+  reasoningEffort?: "low" | "medium" | "high";
+  /** Max output tokens. */
+  maxOutputTokens?: number;
+}
+
+export interface AiResponseResult {
+  /** Generated text content. */
+  outputText: string;
+  /** Provider/model that generated this. */
+  model: string;
+}
+
 export interface AiProvider {
   /** Provider identifier (e.g. "openai", "stub"). */
   readonly name: string;
 
   /** Send a chat completion request. */
   chatComplete(opts: AiChatOptions): Promise<AiChatResponse>;
+
+  /**
+   * Send a Responses-API style request (instructions + input). Used by admin
+   * prompt iteration + regeneration + topic translation flows. On OpenAI maps
+   * to the Responses API; on stub returns a deterministic fixture.
+   */
+  responsesCreate(opts: AiResponseOptions): Promise<AiResponseResult>;
 }

--- a/packages/backend-base/src/shared/ai/ai-provider.interface.ts
+++ b/packages/backend-base/src/shared/ai/ai-provider.interface.ts
@@ -1,0 +1,56 @@
+/**
+ * AI Provider Interface
+ *
+ * Provider-agnostic contract for chat completions. Per spec feat-integrations
+ * br-int-001 (D-001): consumer code MUST go through this interface, never
+ * `new OpenAI(...)` directly.
+ *
+ * Initial implementations:
+ *  - openai (OpenAiProvider) — production, uses `openai` SDK
+ *  - stub (StubAiProvider) — tests / dev, returns deterministic fixture
+ *
+ * Future providers (Anthropic, Vertex, Bedrock, etc.) plug in here without
+ * touching consumer code. Selected via `AI_PROVIDER` env (default: openai).
+ */
+
+export interface AiChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export interface AiChatOptions {
+  /** Model identifier — provider-specific. e.g. "gpt-5", "gpt-5-nano", "stub". */
+  model: string;
+  /** Conversation messages in order. */
+  messages: AiChatMessage[];
+  /** 0..2 — sampling randomness. Provider may clamp. */
+  temperature?: number;
+  /** Optional max tokens for the response. */
+  maxTokens?: number;
+  /**
+   * Optional response_format for providers that support it (e.g. OpenAI JSON mode).
+   * Pass-through; not all providers honor this.
+   */
+  responseFormat?: { type: "text" | "json_object" };
+}
+
+export interface AiChatResponse {
+  /** Generated text content. */
+  content: string;
+  /** Provider/model that generated this (for audit). */
+  model: string;
+  /** Token usage if reported by provider. */
+  usage?: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+}
+
+export interface AiProvider {
+  /** Provider identifier (e.g. "openai", "stub"). */
+  readonly name: string;
+
+  /** Send a chat completion request. */
+  chatComplete(opts: AiChatOptions): Promise<AiChatResponse>;
+}

--- a/packages/backend-base/src/shared/ai/ai-provider.test.ts
+++ b/packages/backend-base/src/shared/ai/ai-provider.test.ts
@@ -98,3 +98,47 @@ describe("StubAiProvider", () => {
     expect(a.model).toBe(b.model);
   });
 });
+
+describe("StubAiProvider responsesCreate", () => {
+  const provider = new StubAiProvider();
+
+  it("returns deterministic output for given input", async () => {
+    const response = await provider.responsesCreate({
+      model: "gpt-5",
+      input: "Tell me about Genesis 1.",
+    });
+
+    expect(response.outputText).toContain("[stub-responses:gpt-5]");
+    expect(response.outputText).toContain("Tell me about Genesis 1.");
+    expect(response.model).toBe("stub-gpt-5");
+  });
+
+  it("identical input produces identical output", async () => {
+    const opts = {
+      model: "gpt-5",
+      input: "test input",
+      instructions: "follow these instructions",
+      reasoningEffort: "medium" as const,
+      maxOutputTokens: 1000,
+    };
+    const a = await provider.responsesCreate(opts);
+    const b = await provider.responsesCreate(opts);
+    expect(a.outputText).toBe(b.outputText);
+    expect(a.model).toBe(b.model);
+  });
+
+  it("ignores instructions/reasoningEffort/maxOutputTokens for output (deterministic)", async () => {
+    const a = await provider.responsesCreate({
+      model: "gpt-5",
+      input: "same input",
+    });
+    const b = await provider.responsesCreate({
+      model: "gpt-5",
+      input: "same input",
+      instructions: "different",
+      reasoningEffort: "high",
+      maxOutputTokens: 5000,
+    });
+    expect(a.outputText).toBe(b.outputText);
+  });
+});

--- a/packages/backend-base/src/shared/ai/ai-provider.test.ts
+++ b/packages/backend-base/src/shared/ai/ai-provider.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { getAiProvider, resetAiProviderCache } from "./ai-provider.factory";
+import { StubAiProvider } from "./stub.provider";
+
+describe("AiProvider factory", () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.AI_PROVIDER;
+    resetAiProviderCache();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      process.env.AI_PROVIDER = undefined;
+    } else {
+      process.env.AI_PROVIDER = originalEnv;
+    }
+    resetAiProviderCache();
+  });
+
+  it("returns stub provider when AI_PROVIDER=stub", () => {
+    process.env.AI_PROVIDER = "stub";
+    const provider = getAiProvider();
+    expect(provider.name).toBe("stub");
+  });
+
+  it("throws on unknown provider name", () => {
+    expect(() => getAiProvider("not-a-real-provider")).toThrow(
+      /Unknown AI_PROVIDER/,
+    );
+  });
+
+  it("caches the singleton between calls", () => {
+    process.env.AI_PROVIDER = "stub";
+    const a = getAiProvider();
+    const b = getAiProvider();
+    expect(a).toBe(b);
+  });
+
+  it("explicit name bypasses cache", () => {
+    process.env.AI_PROVIDER = "stub";
+    const cached = getAiProvider();
+    const explicit = getAiProvider("stub");
+    expect(cached).toBeInstanceOf(StubAiProvider);
+    expect(explicit).toBeInstanceOf(StubAiProvider);
+    // Different instances because explicit name skips cache
+    expect(cached).not.toBe(explicit);
+  });
+});
+
+describe("StubAiProvider", () => {
+  const provider = new StubAiProvider();
+
+  it("returns deterministic response keyed on user message", async () => {
+    const response = await provider.chatComplete({
+      model: "gpt-5",
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "What is the meaning of life?" },
+      ],
+    });
+
+    expect(response.content).toContain("[stub:gpt-5]");
+    expect(response.content).toContain("What is the meaning of life?");
+    expect(response.model).toBe("stub-gpt-5");
+  });
+
+  it("reports token usage estimate", async () => {
+    const response = await provider.chatComplete({
+      model: "gpt-5",
+      messages: [{ role: "user", content: "hello world" }],
+    });
+
+    expect(response.usage).toBeDefined();
+    expect(response.usage?.promptTokens).toBeGreaterThan(0);
+    expect(response.usage?.completionTokens).toBe(16);
+  });
+
+  it("handles empty messages array", async () => {
+    const response = await provider.chatComplete({
+      model: "gpt-5",
+      messages: [],
+    });
+
+    expect(response.content).toContain("[stub:gpt-5]");
+    expect(response.usage?.promptTokens).toBe(0);
+  });
+
+  it("identical input produces identical output (deterministic)", async () => {
+    const opts = {
+      model: "gpt-5",
+      messages: [{ role: "user" as const, content: "test prompt" }],
+    };
+    const a = await provider.chatComplete(opts);
+    const b = await provider.chatComplete(opts);
+    expect(a.content).toBe(b.content);
+    expect(a.model).toBe(b.model);
+  });
+});

--- a/packages/backend-base/src/shared/ai/index.ts
+++ b/packages/backend-base/src/shared/ai/index.ts
@@ -1,0 +1,12 @@
+export type {
+  AiChatMessage,
+  AiChatOptions,
+  AiChatResponse,
+  AiProvider,
+} from "./ai-provider.interface";
+export {
+  getAiProvider,
+  resetAiProviderCache,
+} from "./ai-provider.factory";
+export { OpenAiProvider } from "./openai.provider";
+export { StubAiProvider } from "./stub.provider";

--- a/packages/backend-base/src/shared/ai/openai.provider.ts
+++ b/packages/backend-base/src/shared/ai/openai.provider.ts
@@ -3,6 +3,8 @@ import type {
   AiChatOptions,
   AiChatResponse,
   AiProvider,
+  AiResponseOptions,
+  AiResponseResult,
 } from "./ai-provider.interface";
 
 /**
@@ -48,6 +50,28 @@ export class OpenAiProvider implements AiProvider {
           totalTokens: completion.usage.total_tokens,
         },
       }),
+    };
+  }
+
+  async responsesCreate(opts: AiResponseOptions): Promise<AiResponseResult> {
+    // biome-ignore lint/suspicious/noExplicitAny: OpenAI Responses API types lag SDK
+    const response = await (this.client as any).responses.create({
+      model: opts.model,
+      ...(opts.instructions !== undefined && {
+        instructions: opts.instructions,
+      }),
+      input: opts.input,
+      ...(opts.reasoningEffort && {
+        reasoning: { effort: opts.reasoningEffort },
+      }),
+      ...(opts.maxOutputTokens !== undefined && {
+        max_output_tokens: opts.maxOutputTokens,
+      }),
+    });
+
+    return {
+      outputText: response.output_text || "",
+      model: response.model || opts.model,
     };
   }
 }

--- a/packages/backend-base/src/shared/ai/openai.provider.ts
+++ b/packages/backend-base/src/shared/ai/openai.provider.ts
@@ -1,0 +1,53 @@
+import OpenAI from "openai";
+import type {
+  AiChatOptions,
+  AiChatResponse,
+  AiProvider,
+} from "./ai-provider.interface";
+
+/**
+ * OpenAI implementation of AiProvider. Uses the `openai` SDK + chat completions API.
+ *
+ * Apikey from `OPEN_AI_KEY` env. Models passed through as-is.
+ */
+export class OpenAiProvider implements AiProvider {
+  readonly name = "openai";
+  private readonly client: OpenAI;
+
+  constructor(apiKey?: string) {
+    const key = apiKey ?? process.env.OPEN_AI_KEY;
+    if (!key) {
+      throw new Error(
+        "OPEN_AI_KEY env not set; cannot construct OpenAiProvider",
+      );
+    }
+    this.client = new OpenAI({ apiKey: key });
+  }
+
+  async chatComplete(opts: AiChatOptions): Promise<AiChatResponse> {
+    const completion = await this.client.chat.completions.create({
+      model: opts.model,
+      messages: opts.messages,
+      ...(opts.temperature !== undefined && { temperature: opts.temperature }),
+      ...(opts.maxTokens !== undefined && { max_tokens: opts.maxTokens }),
+      ...(opts.responseFormat && { response_format: opts.responseFormat }),
+    });
+
+    const choice = completion.choices[0];
+    if (!choice?.message?.content) {
+      throw new Error(`OpenAI returned no content for model=${opts.model}`);
+    }
+
+    return {
+      content: choice.message.content,
+      model: completion.model,
+      ...(completion.usage && {
+        usage: {
+          promptTokens: completion.usage.prompt_tokens,
+          completionTokens: completion.usage.completion_tokens,
+          totalTokens: completion.usage.total_tokens,
+        },
+      }),
+    };
+  }
+}

--- a/packages/backend-base/src/shared/ai/stub.provider.ts
+++ b/packages/backend-base/src/shared/ai/stub.provider.ts
@@ -2,6 +2,8 @@ import type {
   AiChatOptions,
   AiChatResponse,
   AiProvider,
+  AiResponseOptions,
+  AiResponseResult,
 } from "./ai-provider.interface";
 
 /**
@@ -30,8 +32,15 @@ export class StubAiProvider implements AiProvider {
           0,
         ),
         completionTokens: 16,
-        totalTokens: 0, // recomputed below
+        totalTokens: 0,
       },
+    };
+  }
+
+  async responsesCreate(opts: AiResponseOptions): Promise<AiResponseResult> {
+    return {
+      outputText: `[stub-responses:${opts.model}] ${opts.input.slice(0, 80)}`,
+      model: `stub-${opts.model}`,
     };
   }
 }

--- a/packages/backend-base/src/shared/ai/stub.provider.ts
+++ b/packages/backend-base/src/shared/ai/stub.provider.ts
@@ -1,0 +1,37 @@
+import type {
+  AiChatOptions,
+  AiChatResponse,
+  AiProvider,
+} from "./ai-provider.interface";
+
+/**
+ * Stub AI provider for tests and dev environments.
+ *
+ * Returns a deterministic, low-cost response so tests don't burn OpenAI billing
+ * and don't depend on network. The output is keyed on the last user message so
+ * snapshot tests are stable.
+ */
+export class StubAiProvider implements AiProvider {
+  readonly name = "stub";
+
+  async chatComplete(opts: AiChatOptions): Promise<AiChatResponse> {
+    const lastUserMessage = opts.messages
+      .slice()
+      .reverse()
+      .find((m) => m.role === "user");
+    const echo = lastUserMessage?.content ?? "";
+
+    return {
+      content: `[stub:${opts.model}] ${echo.slice(0, 80)}`,
+      model: `stub-${opts.model}`,
+      usage: {
+        promptTokens: opts.messages.reduce(
+          (acc, m) => acc + Math.ceil(m.content.length / 4),
+          0,
+        ),
+        completionTokens: 16,
+        totalTokens: 0, // recomputed below
+      },
+    };
+  }
+}

--- a/packages/backend-base/src/topics/services/topic.service.ts
+++ b/packages/backend-base/src/topics/services/topic.service.ts
@@ -1,4 +1,8 @@
 import type { Static } from "elysia";
+// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
+// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
+// as follow-up to feat-integrations br-int-001.
+
 import OpenAI from "openai";
 import { BibleRepository } from "../../bible/repository/bible.repository";
 import { PromptRepository } from "../../bible/repository/prompt.repository";


### PR DESCRIPTION
Per spec feat-integrations br-int-001 (D-001). Builds on PR #201.

Adds `responsesCreate` to `AiProvider` interface (maps to OpenAI Responses API for instruction-style prompts). Refactors:
- `admin/services/explanation-regeneration.service.ts` — drops direct `new OpenAI(...)`
- `admin/services/admin-prompt.service.ts` — drops direct `new OpenAI(...)`

Tests: 11 unit tests pass (was 8; +3 for responsesCreate stub).

Remaining 3 deferred sites use OpenAI Batch + Files APIs which need their own provider abstractions (FilesProvider, BatchProvider). Documented in commit message + spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)