### PR TITLE
refactor(ai): expand AiProvider with Files+Batch APIs and migrate all consumers (D-001 follow-up)

### DIFF
--- a/packages/backend-base/src/admin/admin.plugin.ts
+++ b/packages/backend-base/src/admin/admin.plugin.ts
@@ -575,11 +575,11 @@ const plugin = new Elysia()
                   id: batchStatus.id,
                   status: batchStatus.status,
                   progress:
-                    (batchStatus.request_counts?.completed || 0) /
-                    (batchStatus.request_counts?.total || 1),
-                  total: batchStatus.request_counts?.total || 0,
-                  completed: batchStatus.request_counts?.completed || 0,
-                  failed: batchStatus.request_counts?.failed || 0,
+                    (batchStatus.requestCounts?.completed || 0) /
+                    (batchStatus.requestCounts?.total || 1),
+                  total: batchStatus.requestCounts?.total || 0,
+                  completed: batchStatus.requestCounts?.completed || 0,
+                  failed: batchStatus.requestCounts?.failed || 0,
                 };
               },
               {

--- a/packages/backend-base/src/admin/services/batch-operations.service.ts
+++ b/packages/backend-base/src/admin/services/batch-operations.service.ts
@@ -1,15 +1,12 @@
 import type { Queue } from "bullmq";
 import type ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import PromptStatusEnum from "database/src/models/public/PromptStatusEnum";
-// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
-// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
-// as follow-up to feat-integrations br-int-001.
-
-import OpenAI, { APIError } from "openai";
+import { APIError } from "openai";
 import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { UserPromptRepository } from "../../bible/repository/user-prompt.repository";
 import { ValidationError } from "../../common/errors";
 import { BATCH_MONITORING_QUEUE } from "../../queue/batch-monitoring.queue";
+import { type AiProvider, getAiProvider } from "../../shared/ai";
 import {
   buildBylineChunkPrompts,
   shouldUseBylineChunking,
@@ -33,10 +30,6 @@ interface BatchJobRequest {
     max_output_tokens: number;
   };
 }
-
-const openai = new OpenAI({
-  apiKey: process.env.OPEN_AI_KEY,
-});
 
 export const DEFAULT_MAX_OUTPUT_TOKENS = 50000;
 
@@ -94,6 +87,14 @@ const getUserPrompt = ({
 
 export class BatchOperationService {
   private promptRepository: PromptRepository;
+  // Lazy: BatchOperationService instantiates eagerly via admin.plugin state
+  // wiring; OpenAiProvider's constructor demands OPEN_AI_KEY which is empty
+  // in test envs. Resolve on first use to keep test bootstrap working.
+  private _ai: AiProvider | null = null;
+  private get ai(): AiProvider {
+    if (!this._ai) this._ai = getAiProvider();
+    return this._ai;
+  }
 
   constructor(
     private readonly db: db,
@@ -147,7 +148,7 @@ export class BatchOperationService {
     }
 
     // Create a proper File object for OpenAI API
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `topic_discovery_${discoveryTopicType}_${Date.now()}.jsonl`,
@@ -155,10 +156,10 @@ export class BatchOperationService {
       purpose: "batch",
     });
 
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     await this.db
@@ -265,7 +266,7 @@ export class BatchOperationService {
     }
 
     // Create a proper File object for OpenAI API
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `topic_references_${Date.now()}.jsonl`,
@@ -273,10 +274,10 @@ export class BatchOperationService {
       purpose: "batch",
     });
 
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     await this.db
@@ -534,7 +535,7 @@ export class BatchOperationService {
     }
 
     // Create a proper File object for OpenAI API
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `topic_explanations_${topic.topic_id}_${languageCode}_${Date.now()}.jsonl`,
@@ -542,10 +543,10 @@ export class BatchOperationService {
       purpose: "batch",
     });
 
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     await this.db
@@ -664,7 +665,7 @@ export class BatchOperationService {
     }
 
     // Create a proper File object for OpenAI API
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `batch_${bookId}_${bibleVersion}_${Date.now()}.jsonl`,
@@ -672,10 +673,10 @@ export class BatchOperationService {
       purpose: "batch",
     });
 
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     console.log(
@@ -1143,7 +1144,7 @@ export class BatchOperationService {
     }
 
     // Create a proper File object for OpenAI API
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `rephrase_batch_${book.book_id}_${Date.now()}.jsonl`,
@@ -1151,10 +1152,10 @@ export class BatchOperationService {
       purpose: "batch",
     });
 
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     await connection
@@ -1528,7 +1529,7 @@ export class BatchOperationService {
     }
 
     // Create a proper File object for OpenAI API
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `translate_batch_${book.book_id}_${Date.now()}.jsonl`,
@@ -1538,10 +1539,10 @@ export class BatchOperationService {
 
     console.log(`[BATCH] Created OpenAI file: ${file.id}`);
 
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     console.log(`[BATCH] Created OpenAI batch: ${batch.id}`);
@@ -1581,7 +1582,7 @@ export class BatchOperationService {
   }
 
   async getBatchStatus(batchId: string) {
-    const batchStatus = await openai.batches.retrieve(batchId);
+    const batchStatus = await this.ai.batchesRetrieve(batchId);
 
     if (batchStatus.status === "failed" && batchStatus.errors) {
       console.error(
@@ -1615,8 +1616,8 @@ export class BatchOperationService {
       ])
       .executeTakeFirst();
 
-    if (currentBatchJob && batchStatus.request_counts) {
-      const { total, completed, failed } = batchStatus.request_counts;
+    if (currentBatchJob && batchStatus.requestCounts) {
+      const { total, completed, failed } = batchStatus.requestCounts;
 
       let correctStatus: string = batchStatus.status;
 
@@ -1665,7 +1666,7 @@ export class BatchOperationService {
         );
         await this.batchProcessingQueue.add("process-batch", {
           batchId,
-          outputFileId: batchStatus.output_file_id,
+          outputFileId: batchStatus.outputFileId,
         });
       }
     }
@@ -1676,16 +1677,16 @@ export class BatchOperationService {
   async processBatch(batchId: string, outputFileId: string) {
     console.log(`[BATCH] Processing batch ${batchId} from queue.`);
 
-    const batchStatus = await openai.batches.retrieve(batchId);
+    const batchStatus = await this.ai.batchesRetrieve(batchId);
 
     if (
-      batchStatus.request_counts &&
-      batchStatus.request_counts.failed > 0 &&
-      batchStatus.error_file_id
+      batchStatus.requestCounts &&
+      batchStatus.requestCounts.failed > 0 &&
+      batchStatus.errorFileId
     ) {
       try {
-        const errorFileContent = await openai.files.content(
-          batchStatus.error_file_id,
+        const errorFileContent = await this.ai.filesContent(
+          batchStatus.errorFileId,
         );
         const errorText = await errorFileContent.text();
         await this.db
@@ -1696,7 +1697,7 @@ export class BatchOperationService {
           .execute();
       } catch (error) {
         console.error(
-          `[BATCH] Could not download error file ${batchStatus.error_file_id}:`,
+          `[BATCH] Could not download error file ${batchStatus.errorFileId}:`,
           error,
         );
       }
@@ -1742,7 +1743,7 @@ export class BatchOperationService {
             child.status === "finalizing")
         ) {
           try {
-            const openaiBatch = await openai.batches.cancel(
+            const openaiBatch = await this.ai.batchesCancel(
               child.openai_batch_id,
             );
             console.log(
@@ -1837,7 +1838,7 @@ export class BatchOperationService {
         `Book batch ${batchId} does not have an OpenAI batch ID.`,
       );
     }
-    const openaiBatch = await openai.batches.cancel(batchJob.openai_batch_id);
+    const openaiBatch = await this.ai.batchesCancel(batchJob.openai_batch_id);
     console.log(
       `[BATCH] Successfully cancelled single book batch ${batchJob.openai_batch_id}`,
     );
@@ -2491,7 +2492,7 @@ export class BatchOperationService {
         return;
       }
 
-      const fileContent = await openai.files.content(outputFileId);
+      const fileContent = await this.ai.filesContent(outputFileId);
       const jsonl = await fileContent.text();
       const lines = jsonl.split("\n").filter((line) => line.trim() !== "");
 
@@ -2887,7 +2888,7 @@ export class BatchOperationService {
     outputFileId: string,
     batchJob: { model: string },
   ) {
-    const fileContent = await openai.files.content(outputFileId);
+    const fileContent = await this.ai.filesContent(outputFileId);
     const jsonData =
       typeof (fileContent as any).text === "function"
         ? await (fileContent as any).text()
@@ -3166,7 +3167,7 @@ export class BatchOperationService {
       book_id?: number | null;
     },
   ) {
-    const fileContent = await openai.files.content(outputFileId);
+    const fileContent = await this.ai.filesContent(outputFileId);
     const jsonData =
       typeof (fileContent as any).text === "function"
         ? await (fileContent as any).text()
@@ -3530,7 +3531,7 @@ export class BatchOperationService {
     );
 
     try {
-      const fileContent = await openai.files.content(outputFileId);
+      const fileContent = await this.ai.filesContent(outputFileId);
       const jsonl = await fileContent.text();
       const lines = jsonl.split("\n").filter((line) => line.trim() !== "");
 
@@ -3619,7 +3620,7 @@ export class BatchOperationService {
     );
 
     try {
-      const fileContent = await openai.files.content(outputFileId);
+      const fileContent = await this.ai.filesContent(outputFileId);
       const jsonl = await fileContent.text();
       const lines = jsonl.split("\n").filter((line) => line.trim() !== "");
 
@@ -3791,7 +3792,7 @@ export class BatchOperationService {
     );
 
     try {
-      const fileContent = await openai.files.content(outputFileId);
+      const fileContent = await this.ai.filesContent(outputFileId);
       const jsonl = await fileContent.text();
       const lines = jsonl.split("\n").filter((line) => line.trim() !== "");
 
@@ -3933,7 +3934,7 @@ export class BatchOperationService {
       `[BATCH] Processing topic name translation output for batch ${batchId}`,
     );
 
-    const fileContent = await openai.files.content(outputFileId);
+    const fileContent = await this.ai.filesContent(outputFileId);
     const jsonData =
       typeof (fileContent as any).text === "function"
         ? await (fileContent as any).text()
@@ -4148,7 +4149,7 @@ export class BatchOperationService {
       `[BATCH] Processing topic explanation translation output for batch ${batchId}`,
     );
 
-    const fileContent = await openai.files.content(outputFileId);
+    const fileContent = await this.ai.filesContent(outputFileId);
     const jsonData =
       typeof (fileContent as any).text === "function"
         ? await (fileContent as any).text()
@@ -4361,7 +4362,7 @@ export class BatchOperationService {
       const connection = this.db.getOrCreateConnection();
 
       // Parse custom_id to get book name: "auto-highlight-Genesis-1234567890"
-      const fileContent = await openai.files.content(outputFileId);
+      const fileContent = await this.ai.filesContent(outputFileId);
       const jsonl = await fileContent.text();
       const lines = jsonl.split("\n").filter((line) => line.trim() !== "");
 
@@ -4939,7 +4940,7 @@ export class BatchOperationService {
     }
 
     // Create OpenAI file
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `translate_topic_names_${target_language_code}_${Date.now()}.jsonl`,
@@ -4950,10 +4951,10 @@ export class BatchOperationService {
     console.log(`[BATCH] Created OpenAI file: ${file.id}`);
 
     // Create OpenAI batch
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     console.log(`[BATCH] Created OpenAI batch: ${batch.id}`);
@@ -5149,7 +5150,7 @@ export class BatchOperationService {
       throw new ValidationError("Batch file size exceeds OpenAI's 100MB limit");
     }
 
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `translate_topic_explanations_${target_language_code}_${Date.now()}.jsonl`,
@@ -5159,10 +5160,10 @@ export class BatchOperationService {
 
     console.log(`[BATCH] Created OpenAI file: ${file.id}`);
 
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     console.log(`[BATCH] Created OpenAI batch: ${batch.id}`);
@@ -5563,7 +5564,7 @@ export class BatchOperationService {
       );
     }
 
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `auto_highlight_${book.book_id}_${Date.now()}.jsonl`,
@@ -5571,10 +5572,10 @@ export class BatchOperationService {
       purpose: "batch",
     });
 
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     await connection
@@ -5645,15 +5646,15 @@ export class BatchOperationService {
 
     try {
       // Retrieve batch status from OpenAI
-      const batchStatus = await openai.batches.retrieve(
+      const batchStatus = await this.ai.batchesRetrieve(
         batchJob.openai_batch_id,
       );
 
       console.log(
-        `[BATCH] Batch ${batchJob.openai_batch_id} status: ${batchStatus.status}, has error_file_id: ${!!batchStatus.error_file_id}`,
+        `[BATCH] Batch ${batchJob.openai_batch_id} status: ${batchStatus.status}, has error_file_id: ${!!batchStatus.errorFileId}`,
       );
 
-      if (!batchStatus.error_file_id) {
+      if (!batchStatus.errorFileId) {
         return {
           success: false,
           message: `Batch ${batchJobId} (${batchJob.openai_batch_id}) does not have an error file. Status: ${batchStatus.status}`,
@@ -5662,10 +5663,10 @@ export class BatchOperationService {
 
       // Download the error file
       console.log(
-        `[BATCH] Downloading error file ${batchStatus.error_file_id}...`,
+        `[BATCH] Downloading error file ${batchStatus.errorFileId}...`,
       );
-      const errorFileContent = await openai.files.content(
-        batchStatus.error_file_id,
+      const errorFileContent = await this.ai.filesContent(
+        batchStatus.errorFileId,
       );
       const errorText = await errorFileContent.text();
 

--- a/packages/backend-base/src/bible/bible.plugin.ts
+++ b/packages/backend-base/src/bible/bible.plugin.ts
@@ -1,8 +1,8 @@
 import type ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import HighlightColorEnum from "database/src/models/public/HighlightColorEnum";
 import { Elysia, t } from "elysia";
-import OpenAI from "openai";
 import { authDerive } from "../auth/auth.utils";
+import { type AiProvider, getAiProvider } from "../shared/ai";
 import { createErrorHandler } from "../common/error-handler";
 import {
   NotFoundError,
@@ -42,10 +42,15 @@ import { AutoHighlightService } from "./services/auto-highlight.service";
 import { BibleService } from "./services/bible.service";
 import { PromptService } from "./services/prompt.service";
 
-const openai = new OpenAI({
-  apiKey: process.env.OPEN_AI_KEY, // This is the default and can be omitted
-});
 const model = "gpt-5-nano";
+
+// Lazy AiProvider singleton — module-level use means we can't construct in
+// the constructor body; eager init would fail in test envs without OPEN_AI_KEY.
+let _ai: AiProvider | null = null;
+function ai(): AiProvider {
+  if (!_ai) _ai = getAiProvider();
+  return _ai;
+}
 
 async function gpt5Text({
   system,
@@ -54,15 +59,15 @@ async function gpt5Text({
   system?: string;
   user: string;
 }) {
-  const response = await openai.responses.create({
+  const response = await ai().responsesCreate({
     model,
-    reasoning: { effort: "medium" },
+    reasoningEffort: "medium",
     instructions: system,
     input: user,
-    max_output_tokens: 20000,
+    maxOutputTokens: 20000,
   });
 
-  return response.output_text ?? "oopsies";
+  return response.outputText || "oopsies";
 }
 
 /**

--- a/packages/backend-base/src/queue/consumers/batch-monitoring.consumer.ts
+++ b/packages/backend-base/src/queue/consumers/batch-monitoring.consumer.ts
@@ -2,13 +2,9 @@
 import * as fs from "node:fs";
 import type { Job } from "bullmq";
 import { db } from "database";
-// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
-// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
-// as follow-up to feat-integrations br-int-001.
-
-import OpenAI from "openai";
 import { BatchOperationService } from "../../admin/services/batch-operations.service";
 import { replaceExplanationWithAudioHook } from "../../bible/audio/audio-regen-hook";
+import { type AiProvider, getAiProvider } from "../../shared/ai";
 import { stitchBylineChunks } from "../../shared/byline-chunking";
 import {
   BATCH_MONITORING_QUEUE,
@@ -16,9 +12,13 @@ import {
 } from "../batch-monitoring.queue";
 import { batchProcessingQueue } from "../batch-processing.queue";
 
-const openai = new OpenAI({
-  apiKey: process.env.OPEN_AI_KEY,
-});
+// Lazy: OpenAiProvider's constructor demands OPEN_AI_KEY which is empty in
+// test envs. Resolve on first call so the module loads cleanly.
+let _ai: AiProvider | null = null;
+function ai(): AiProvider {
+  if (!_ai) _ai = getAiProvider();
+  return _ai;
+}
 
 async function calculateActualCost(
   promptTokens: number,
@@ -239,7 +239,7 @@ export const batchMonitoringConsumer = async (job: Job) => {
       return; // Don't re-queue if already finished
     }
 
-    const batch = await openai.batches.retrieve(batchId);
+    const batch = await ai().batchesRetrieve(batchId);
 
     console.log(`[BATCH_MONITORING] Batch ${batchId} status: ${batch.status}`);
 
@@ -253,11 +253,11 @@ export const batchMonitoringConsumer = async (job: Job) => {
 
     if (batch.status === "completed") {
       console.log(`[BATCH_MONITORING] Batch ${batchId} completed.`);
-      const outputFileId = batch.output_file_id;
+      const outputFileId = batch.outputFileId;
       if (outputFileId) {
         let fileContent: Response;
         try {
-          fileContent = await openai.files.content(outputFileId);
+          fileContent = await ai().filesContent(outputFileId);
         } catch (fileError) {
           console.error(
             `[BATCH_MONITORING] Failed to retrieve output file ${outputFileId} for batch ${batchId}:`,
@@ -772,18 +772,18 @@ export const batchMonitoringConsumer = async (job: Job) => {
       }
 
       // If validating for more than 10 minutes, log additional debug info
-      const timeSinceCreation = Date.now() - batch.created_at * 1000;
+      const timeSinceCreation = Date.now() - (batch.createdAt ?? 0) * 1000;
       if (batch.status === "validating" && timeSinceCreation > 10 * 60 * 1000) {
         console.warn(
           `[BATCH_MONITORING] Batch ${batchId} has been validating for ${Math.round(timeSinceCreation / 60000)} minutes`,
         );
         console.warn(
-          `[BATCH_MONITORING] This may indicate a file format issue. Check input file: ${batch.input_file_id}`,
+          `[BATCH_MONITORING] This may indicate a file format issue. Check input file: ${batch.inputFileId}`,
         );
 
         // Try to get file info for debugging
         try {
-          const fileInfo = await openai.files.retrieve(batch.input_file_id);
+          const fileInfo = await ai().filesRetrieve(batch.inputFileId);
           console.warn(
             `[BATCH_MONITORING] Input file status: ${fileInfo.status}, size: ${fileInfo.bytes} bytes`,
           );

--- a/packages/backend-base/src/shared/ai/ai-provider.interface.ts
+++ b/packages/backend-base/src/shared/ai/ai-provider.interface.ts
@@ -72,6 +72,88 @@ export interface AiResponseResult {
   model: string;
 }
 
+/**
+ * Files API — used by admin batch operations to upload JSONL request files
+ * and download result files. Per OpenAI semantics: upload returns a file_id
+ * which is then referenced by Batch operations.
+ */
+export interface AiFileCreateOptions {
+  /** Web `File` object (or a Buffer the provider knows how to wrap). */
+  file: File;
+  /** Provider-specific purpose. For OpenAI batch, must be `"batch"`. */
+  purpose: "batch" | "assistants" | "fine-tune" | "vision";
+}
+
+export interface AiFileResult {
+  /** File ID assigned by the provider. */
+  id: string;
+  /** Original filename, if reported by provider. */
+  filename?: string;
+  /** Size in bytes. */
+  bytes?: number;
+  /** Status string (e.g. "uploaded", "processed", "error"). */
+  status?: string;
+  /** Purpose this file was created with. */
+  purpose?: string;
+  /** Creation timestamp (provider's epoch). */
+  createdAt?: number;
+}
+
+/**
+ * Batch API — used by admin to enqueue large JSONL request batches against
+ * OpenAI's batch endpoint. Per OpenAI semantics: batch references an uploaded
+ * input_file_id and produces an output_file_id (and possibly an error_file_id).
+ */
+export interface AiBatchCreateOptions {
+  /** File ID returned from a prior `filesCreate({purpose: "batch"})` call. */
+  inputFileId: string;
+  /** Endpoint the batched requests target. */
+  endpoint: "/v1/responses" | "/v1/chat/completions" | "/v1/embeddings";
+  /** Completion window — currently OpenAI only accepts "24h". */
+  completionWindow?: "24h";
+  /** Optional metadata (echoed back on retrieve). */
+  metadata?: Record<string, string>;
+}
+
+export type AiBatchStatus =
+  | "validating"
+  | "failed"
+  | "in_progress"
+  | "finalizing"
+  | "completed"
+  | "expired"
+  | "cancelling"
+  | "cancelled";
+
+export interface AiBatchResult {
+  /** Batch ID assigned by the provider. */
+  id: string;
+  /** Current batch status. */
+  status: AiBatchStatus;
+  /** Input file id referenced when the batch was created. */
+  inputFileId: string;
+  /** Output file id once the batch completes (results JSONL). */
+  outputFileId?: string;
+  /** Error file id if the batch produced per-row errors. */
+  errorFileId?: string;
+  /** Endpoint the batch targets. */
+  endpoint?: string;
+  /** Per-status request counts. */
+  requestCounts?: { total: number; completed: number; failed: number };
+  /** Creation timestamp (epoch seconds). */
+  createdAt?: number;
+  /** Completion timestamp (epoch seconds). */
+  completedAt?: number;
+  /** Cancellation timestamp (epoch seconds). */
+  cancelledAt?: number;
+  /** Failure timestamp (epoch seconds). */
+  failedAt?: number;
+  /** Optional metadata echoed back. */
+  metadata?: Record<string, string> | null;
+  /** Errors object (provider-specific shape). */
+  errors?: { object: string; data: unknown[] } | null;
+}
+
 export interface AiProvider {
   /** Provider identifier (e.g. "openai", "stub"). */
   readonly name: string;
@@ -85,4 +167,22 @@ export interface AiProvider {
    * to the Responses API; on stub returns a deterministic fixture.
    */
   responsesCreate(opts: AiResponseOptions): Promise<AiResponseResult>;
+
+  /** Upload a file (used to feed batched JSONL requests). */
+  filesCreate(opts: AiFileCreateOptions): Promise<AiFileResult>;
+
+  /** Retrieve metadata for a previously uploaded file. */
+  filesRetrieve(fileId: string): Promise<AiFileResult>;
+
+  /** Download the bytes of a previously uploaded/produced file. */
+  filesContent(fileId: string): Promise<Response>;
+
+  /** Submit a batch job referencing a previously uploaded input file. */
+  batchesCreate(opts: AiBatchCreateOptions): Promise<AiBatchResult>;
+
+  /** Retrieve current state of a batch job. */
+  batchesRetrieve(batchId: string): Promise<AiBatchResult>;
+
+  /** Cancel an in-progress batch job. */
+  batchesCancel(batchId: string): Promise<AiBatchResult>;
 }

--- a/packages/backend-base/src/shared/ai/openai.provider.ts
+++ b/packages/backend-base/src/shared/ai/openai.provider.ts
@@ -1,7 +1,12 @@
 import OpenAI from "openai";
 import type {
+  AiBatchCreateOptions,
+  AiBatchResult,
+  AiBatchStatus,
   AiChatOptions,
   AiChatResponse,
+  AiFileCreateOptions,
+  AiFileResult,
   AiProvider,
   AiResponseOptions,
   AiResponseResult,
@@ -74,4 +79,78 @@ export class OpenAiProvider implements AiProvider {
       model: response.model || opts.model,
     };
   }
+
+  async filesCreate(opts: AiFileCreateOptions): Promise<AiFileResult> {
+    const file = await this.client.files.create({
+      file: opts.file,
+      purpose: opts.purpose,
+    });
+    return mapOpenAiFile(file);
+  }
+
+  async filesRetrieve(fileId: string): Promise<AiFileResult> {
+    const file = await this.client.files.retrieve(fileId);
+    return mapOpenAiFile(file);
+  }
+
+  async filesContent(fileId: string): Promise<Response> {
+    return this.client.files.content(fileId);
+  }
+
+  async batchesCreate(opts: AiBatchCreateOptions): Promise<AiBatchResult> {
+    const batch = await this.client.batches.create({
+      input_file_id: opts.inputFileId,
+      endpoint: opts.endpoint,
+      completion_window: opts.completionWindow ?? "24h",
+      ...(opts.metadata && { metadata: opts.metadata }),
+    });
+    return mapOpenAiBatch(batch);
+  }
+
+  async batchesRetrieve(batchId: string): Promise<AiBatchResult> {
+    const batch = await this.client.batches.retrieve(batchId);
+    return mapOpenAiBatch(batch);
+  }
+
+  async batchesCancel(batchId: string): Promise<AiBatchResult> {
+    const batch = await this.client.batches.cancel(batchId);
+    return mapOpenAiBatch(batch);
+  }
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: openai SDK types vary by version
+function mapOpenAiFile(file: any): AiFileResult {
+  return {
+    id: file.id,
+    filename: file.filename,
+    bytes: file.bytes,
+    status: file.status,
+    purpose: file.purpose,
+    createdAt: file.created_at,
+  };
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: openai SDK types vary by version
+function mapOpenAiBatch(batch: any): AiBatchResult {
+  return {
+    id: batch.id,
+    status: batch.status as AiBatchStatus,
+    inputFileId: batch.input_file_id,
+    outputFileId: batch.output_file_id ?? undefined,
+    errorFileId: batch.error_file_id ?? undefined,
+    endpoint: batch.endpoint,
+    requestCounts: batch.request_counts
+      ? {
+          total: batch.request_counts.total,
+          completed: batch.request_counts.completed,
+          failed: batch.request_counts.failed,
+        }
+      : undefined,
+    createdAt: batch.created_at,
+    completedAt: batch.completed_at ?? undefined,
+    cancelledAt: batch.cancelled_at ?? undefined,
+    failedAt: batch.failed_at ?? undefined,
+    metadata: batch.metadata ?? null,
+    errors: batch.errors ?? null,
+  };
 }

--- a/packages/backend-base/src/shared/ai/stub.provider.ts
+++ b/packages/backend-base/src/shared/ai/stub.provider.ts
@@ -1,6 +1,10 @@
 import type {
+  AiBatchCreateOptions,
+  AiBatchResult,
   AiChatOptions,
   AiChatResponse,
+  AiFileCreateOptions,
+  AiFileResult,
   AiProvider,
   AiResponseOptions,
   AiResponseResult,
@@ -42,5 +46,90 @@ export class StubAiProvider implements AiProvider {
       outputText: `[stub-responses:${opts.model}] ${opts.input.slice(0, 80)}`,
       model: `stub-${opts.model}`,
     };
+  }
+
+  // Files / Batch — deterministic in-memory fakes. Keyed on input id so the
+  // same id consistently round-trips. Tests that need real OpenAI semantics
+  // should mock this provider directly rather than rely on these stubs.
+  private fileCounter = 0;
+  private batchCounter = 0;
+  private files = new Map<string, { name: string; bytes: number; content: string }>();
+  private batches = new Map<string, AiBatchResult>();
+
+  async filesCreate(opts: AiFileCreateOptions): Promise<AiFileResult> {
+    const id = `stub-file-${++this.fileCounter}`;
+    const bytes = await opts.file
+      .arrayBuffer()
+      .then((b) => b.byteLength)
+      .catch(() => 0);
+    const content = await opts.file.text().catch(() => "");
+    this.files.set(id, { name: opts.file.name, bytes, content });
+    return {
+      id,
+      filename: opts.file.name,
+      bytes,
+      status: "processed",
+      purpose: opts.purpose,
+      createdAt: Math.floor(Date.now() / 1000),
+    };
+  }
+
+  async filesRetrieve(fileId: string): Promise<AiFileResult> {
+    const file = this.files.get(fileId);
+    if (!file) {
+      throw new Error(`stub: file ${fileId} not found`);
+    }
+    return {
+      id: fileId,
+      filename: file.name,
+      bytes: file.bytes,
+      status: "processed",
+      createdAt: Math.floor(Date.now() / 1000),
+    };
+  }
+
+  async filesContent(fileId: string): Promise<Response> {
+    const file = this.files.get(fileId);
+    if (!file) {
+      throw new Error(`stub: file ${fileId} not found`);
+    }
+    return new Response(file.content);
+  }
+
+  async batchesCreate(opts: AiBatchCreateOptions): Promise<AiBatchResult> {
+    const id = `stub-batch-${++this.batchCounter}`;
+    const result: AiBatchResult = {
+      id,
+      status: "validating",
+      inputFileId: opts.inputFileId,
+      endpoint: opts.endpoint,
+      requestCounts: { total: 0, completed: 0, failed: 0 },
+      createdAt: Math.floor(Date.now() / 1000),
+      metadata: opts.metadata ?? null,
+    };
+    this.batches.set(id, result);
+    return result;
+  }
+
+  async batchesRetrieve(batchId: string): Promise<AiBatchResult> {
+    const batch = this.batches.get(batchId);
+    if (!batch) {
+      throw new Error(`stub: batch ${batchId} not found`);
+    }
+    return batch;
+  }
+
+  async batchesCancel(batchId: string): Promise<AiBatchResult> {
+    const batch = this.batches.get(batchId);
+    if (!batch) {
+      throw new Error(`stub: batch ${batchId} not found`);
+    }
+    const cancelled: AiBatchResult = {
+      ...batch,
+      status: "cancelled",
+      cancelledAt: Math.floor(Date.now() / 1000),
+    };
+    this.batches.set(batchId, cancelled);
+    return cancelled;
   }
 }


### PR DESCRIPTION
## Summary

Closes the D-001 production sweep. After this PR, **zero** `new OpenAI(...)` constructions or direct `openai.X.Y` calls remain in `packages/backend-base/src/`.

Three commits, in dependency order:

### 1. Expand `AiProvider` interface with Files + Batch APIs

Adds 6 new methods to cover the admin batch-operations surface:
- `filesCreate(opts)` — upload (used to feed batched JSONL requests)
- `filesRetrieve(fileId)` — metadata
- `filesContent(fileId)` — bytes
- `batchesCreate(opts)` — submit a batch job
- `batchesRetrieve(batchId)` — current state
- `batchesCancel(batchId)`

`OpenAiProvider` impl: thin passthrough to `client.files.*` / `client.batches.*` with `mapOpenAiFile` / `mapOpenAiBatch` helpers translating snake_case SDK shapes into provider-agnostic camelCase result types.

`StubAiProvider` impl: deterministic in-memory file + batch stores. Files are keyed on auto-incrementing ids and round-trip through `filesContent`; batches start in `validating` state and `batchesCancel` flips them to `cancelled`.

### 2. Migrate batch operations + monitoring consumers

37 call sites converted:
- `batch-operations.service.ts` (34 sites): `openai.{files,batches}.*` → `this.ai.{files,batches}*`. Field accesses converted: `input_file_id` → `inputFileId`, `output_file_id` → `outputFileId`, `error_file_id` → `errorFileId`, `request_counts` → `requestCounts` (across both this file and `admin.plugin.ts`).
- `batch-monitoring.consumer.ts` (3 sites): same conversion, but uses a module-level lazy `ai()` function instead of a class member because the consumer is a free function, not a class.

`this.ai` getter pattern matches `topic.service.ts` (PR #215) — lazy resolution keeps test bootstrap working with empty `OPEN_AI_KEY` because the consumer plugins instantiate `BatchOperationService` eagerly. Drops the module-level `const openai = new OpenAI(...)` and the `TODO(D-001)` comments from both files.

### 3. Migrate `bible.plugin.ts` chat helper

`bible.plugin.ts` had its own `gpt5Text` helper that constructed `new OpenAI(...)` and called `client.responses.create(...)` directly (3 call sites: two chat-completion paths, one title-generation path). Same lazy-singleton pattern as `batch-monitoring.consumer.ts` because `gpt5Text` is a free module-level function.

Drops the `import OpenAI from "openai"` line. Adjusts param mapping (`effort` → `reasoningEffort`, `max_output_tokens` → `maxOutputTokens`) and response field (`response.output_text` → `response.outputText`).

## Out of scope

Direct OpenAI imports remaining in `packages/backend-base/src/bible/` are all in **one-off scripts** (`e2e-byline-chunking`, `pregenerate-popular-chapters`, `pregenerate-hebrews`, `reprocess-translate-batch`, `verify-translate-batch`) — those are batch jobs run manually, not production code, and migrating them is out of scope for the D-001 production sweep.

## Test plan

- [x] `bun tsc` clean
- [x] `bun test src/shared/ai/` — 11 pass (interface, stub round-trips, factory)
- [x] `bun test src/admin/` — 27 pass / 1 fail; the 1 fail (`Failed to create test user`) is a pre-existing bootstrap issue unrelated to this change (verified via stash + retest on parent commit)
- [x] `bible.test.ts` failure is a pre-existing env-var issue (`Missing EmailNotificationConsumer environment variables`), unchanged on parent commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)