### PR TITLE
fix(ai): biome lint cleanup on AiProvider impls (D-001 follow-up)

### DIFF
--- a/packages/backend-base/src/bible/bible.plugin.ts
+++ b/packages/backend-base/src/bible/bible.plugin.ts
@@ -2,7 +2,6 @@ import type ExplanationTypeEnum from "database/src/models/public/ExplanationType
 import HighlightColorEnum from "database/src/models/public/HighlightColorEnum";
 import { Elysia, t } from "elysia";
 import { authDerive } from "../auth/auth.utils";
-import { type AiProvider, getAiProvider } from "../shared/ai";
 import { createErrorHandler } from "../common/error-handler";
 import {
   NotFoundError,
@@ -10,6 +9,7 @@ import {
   ValidationError,
 } from "../common/errors";
 import { StandardErrorResponses } from "../common/response-schemas";
+import { type AiProvider, getAiProvider } from "../shared/ai";
 import shared from "../shared/shared.plugin";
 import { parseBibleData } from "./bible";
 import { RatingDto } from "./dto/book/rating.dto";

--- a/packages/backend-base/src/shared/ai/openai.provider.ts
+++ b/packages/backend-base/src/shared/ai/openai.provider.ts
@@ -59,7 +59,6 @@ export class OpenAiProvider implements AiProvider {
   }
 
   async responsesCreate(opts: AiResponseOptions): Promise<AiResponseResult> {
-    // biome-ignore lint/suspicious/noExplicitAny: OpenAI Responses API types lag SDK
     const response = await (this.client as any).responses.create({
       model: opts.model,
       ...(opts.instructions !== undefined && {
@@ -118,7 +117,6 @@ export class OpenAiProvider implements AiProvider {
   }
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: openai SDK types vary by version
 function mapOpenAiFile(file: any): AiFileResult {
   return {
     id: file.id,
@@ -130,7 +128,6 @@ function mapOpenAiFile(file: any): AiFileResult {
   };
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: openai SDK types vary by version
 function mapOpenAiBatch(batch: any): AiBatchResult {
   return {
     id: batch.id,

--- a/packages/backend-base/src/shared/ai/stub.provider.ts
+++ b/packages/backend-base/src/shared/ai/stub.provider.ts
@@ -53,7 +53,10 @@ export class StubAiProvider implements AiProvider {
   // should mock this provider directly rather than rely on these stubs.
   private fileCounter = 0;
   private batchCounter = 0;
-  private files = new Map<string, { name: string; bytes: number; content: string }>();
+  private files = new Map<
+    string,
+    { name: string; bytes: number; content: string }
+  >();
   private batches = new Map<string, AiBatchResult>();
 
   async filesCreate(opts: AiFileCreateOptions): Promise<AiFileResult> {


### PR DESCRIPTION
## Summary

Unblocks CI on epic/spec-implementation-2026-05-03 (backend umbrella PR #208). Three issues in the AiProvider impls landed in #216:

- **stub.provider.ts:56** — formatter wanted the `Map<string, {...}>` private field broken across multiple lines.
- **bible.plugin.ts** — import order changed when D-001 dropped `import OpenAI from "openai"`.
- **openai.provider.ts** — 3 `// biome-ignore lint/suspicious/noExplicitAny` comments turned out to be unused suppressions.

## Test plan

- [x] `bun lint` exits 0 (15 warnings remaining, all pre-existing/unrelated)
- [x] `bun tsc` clean (excluding pre-existing storage.service.ts AWS SDK errors that resolve when bun-s3-cutover lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)