### PR TITLE
feat(domain): rename FavoriteTypeEnum 'message' → 'insight' (D-019)

### DIFF
--- a/packages/database/migrations/20260503120000-rename-favorite-type-message-to-insight.ts
+++ b/packages/database/migrations/20260503120000-rename-favorite-type-message-to-insight.ts
@@ -1,0 +1,35 @@
+import { type Kysely, sql } from "kysely";
+import type Database from "../src/models/Database";
+
+/**
+ * Rename FavoriteTypeEnum value `'message'` → `'insight'`.
+ *
+ * Per spec feat-domain-model br-domain-011 (Phase 1 decision D-019).
+ *
+ * Mobile UI labels Favorites with `type='message'` as "insight bookmarks";
+ * the DB enum value was misnomered. This migration aligns DB to UI language.
+ *
+ * Postgres allows renaming enum values without rewriting rows: existing rows
+ * automatically read as the new label.
+ */
+export async function up(db: Kysely<Database>): Promise<void> {
+  console.log(
+    "Renaming favorite_type_enum value 'message' → 'insight' (D-019)...",
+  );
+
+  await sql`
+    ALTER TYPE favorite_type_enum RENAME VALUE 'message' TO 'insight'
+  `.execute(db);
+
+  console.log("Renamed favorite_type_enum value successfully.");
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  console.log("Reverting: renaming 'insight' → 'message'...");
+
+  await sql`
+    ALTER TYPE favorite_type_enum RENAME VALUE 'insight' TO 'message'
+  `.execute(db);
+
+  console.log("Reverted favorite_type_enum value rename.");
+}

--- a/packages/database/src/models/public/FavoriteTypeEnum.test.ts
+++ b/packages/database/src/models/public/FavoriteTypeEnum.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import FavoriteTypeEnum from "./FavoriteTypeEnum";
+
+/**
+ * Lock the FavoriteTypeEnum values per spec feat-domain-model br-domain-011 (D-019).
+ *
+ * `message` was renamed to `insight` to align DB enum with mobile UI naming.
+ *
+ * Migration: `migrations/20260503120000-rename-favorite-type-message-to-insight.ts`.
+ */
+describe("FavoriteTypeEnum (post-D-019 rename)", () => {
+  it("has exactly 2 values: chapter, insight", () => {
+    const values = Object.values(FavoriteTypeEnum);
+    expect(values).toHaveLength(2);
+    expect(values).toContain("chapter");
+    expect(values).toContain("insight");
+  });
+
+  it("does NOT contain the legacy 'message' value", () => {
+    const values = Object.values(FavoriteTypeEnum);
+    expect(values).not.toContain("message");
+  });
+
+  it("string values match key names (TypeScript convention)", () => {
+    expect(FavoriteTypeEnum.chapter).toBe(FavoriteTypeEnum.chapter);
+    expect(FavoriteTypeEnum.insight).toBe(FavoriteTypeEnum.insight);
+    expect(String(FavoriteTypeEnum.chapter)).toBe("chapter");
+    expect(String(FavoriteTypeEnum.insight)).toBe("insight");
+  });
+});

--- a/packages/database/src/models/public/FavoriteTypeEnum.ts
+++ b/packages/database/src/models/public/FavoriteTypeEnum.ts
@@ -4,7 +4,7 @@
 /** Represents the enum public.favorite_type_enum */
 enum FavoriteTypeEnum {
   chapter = "chapter",
-  message = "message",
+  insight = "insight",
 }
 
 export default FavoriteTypeEnum;


### PR DESCRIPTION
## Summary

Split from epic #208. Renames `FavoriteTypeEnum.message` → `insight` to align with product vocabulary.

## Commits

- `1db2b9b` feat(domain): rename FavoriteTypeEnum 'message' → 'insight' (D-019)

## Risk

Low — enum + DB migration + unit test only. Migration is forward-only; verify it runs cleanly on staging before merge.

## Test plan

- [ ] CI green.
- [ ] Run migration on a staging DB, confirm existing `message` rows become `insight`.
- [ ] No remaining string literal `'message'` referencing this enum in app code.