### PR TITLE
fix(api): CORS allowlist + restore login rate limit

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -28,19 +28,34 @@ const app = new Elysia()
   .use(adminPlugin)
   .use(offlinePlugin)
   .use(healthCheckPlugin)
-  .use(cors())
+  .use(
+    cors({
+      // Per spec feat-api-contract br-api (D-028): production allowlist; dev permissive.
+      // App.versemate.org (mobile web export, future), admin.versemate.org (admin web),
+      // versemate.org and www.versemate.org (marketing). Native apps don't need CORS.
+      origin:
+        process.env.ENVIRONMENT === "production"
+          ? [
+              "https://app.versemate.org",
+              "https://admin.versemate.org",
+              "https://versemate.org",
+              "https://www.versemate.org",
+            ]
+          : true, // dev/test: allow all (mobile dev client uses dynamic ports)
+    }),
+  )
   .use(
     openapi({
       documentation: {
         info: {
           title: "VerseMate API",
           version: "1.0.0",
-          description:
-            "Bible reading platform API with AI-driven translations and interactive Q&A",
+          description: "Bible reading platform API with AI-driven translations",
         },
         servers: [
           { url: "http://localhost:4000", description: "Development" },
-          { url: "https://api.versemate.com", description: "Production" },
+          // Per spec feat-api-contract D-027: canonical production host is .org (matches mobile)
+          { url: "https://api.versemate.org", description: "Production" },
         ],
       },
     }),

--- a/packages/backend-base/src/common/rate-limit.middleware.ts
+++ b/packages/backend-base/src/common/rate-limit.middleware.ts
@@ -66,11 +66,12 @@ export const createRateLimit = (options: RateLimitOptions) => {
 // Predefined rate limiters
 export const authRateLimiters = {
   /**
-   * Login rate limiter: 10000 attempts per email per minute (TEMPORARILY INCREASED)
+   * Login rate limiter: 5 attempts per email per minute.
+   * Per spec feat-auth-platform br-auth-006b (D-004 — restored from "TEMPORARILY INCREASED" 10000).
    */
   login: createRateLimit({
     windowSeconds: 60,
-    max: 10000,
+    max: 5,
     keyGenerator: (context) => `login:${context.body.email}`,
     message: "Too many login attempts, please try again in a minute",
   }),


### PR DESCRIPTION
## Summary

Split from epic #208. Two isolated security fixes:

- Restore login rate limit to 5/min/email (was accidentally 10000).
- Lock CORS to an explicit allowlist incl. canonical `.org` host.

## Commits

- `df4d89e` fix(auth): restore login rate limit to 5/min/email (was 10000)
- `ee626a1` fix(api): lock CORS to allowlist + canonical .org host

## Risk

Low — two scoped fixes, no cross-cutting changes.

## Test plan

- [ ] CI green.
- [ ] Verify allowed origins still receive responses; non-allowlisted origins are blocked.
- [ ] Hit `/auth/login` 6 times from same email within a minute; 6th request 429s.