### PR TITLE
refactor(ai): introduce AiProvider abstraction + migrate consumers (D-001)

### DIFF
--- a/packages/backend-base/src/admin/admin.plugin.ts
+++ b/packages/backend-base/src/admin/admin.plugin.ts
@@ -575,11 +575,11 @@ const plugin = new Elysia()
                   id: batchStatus.id,
                   status: batchStatus.status,
                   progress:
-                    (batchStatus.request_counts?.completed || 0) /
-                    (batchStatus.request_counts?.total || 1),
-                  total: batchStatus.request_counts?.total || 0,
-                  completed: batchStatus.request_counts?.completed || 0,
-                  failed: batchStatus.request_counts?.failed || 0,
+                    (batchStatus.requestCounts?.completed || 0) /
+                    (batchStatus.requestCounts?.total || 1),
+                  total: batchStatus.requestCounts?.total || 0,
+                  completed: batchStatus.requestCounts?.completed || 0,
+                  failed: batchStatus.requestCounts?.failed || 0,
                 };
               },
               {

--- a/packages/backend-base/src/admin/services/admin-prompt.service.ts
+++ b/packages/backend-base/src/admin/services/admin-prompt.service.ts
@@ -1,13 +1,9 @@
 import type ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import PromptStatusEnum from "database/src/models/public/PromptStatusEnum";
-// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
-// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
-// as follow-up to feat-integrations br-int-001.
-
-import OpenAI from "openai";
 import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { UserPromptRepository } from "../../bible/repository/user-prompt.repository";
 import { ForbiddenError, NotFoundError } from "../../common/errors";
+import { type AiProvider, getAiProvider } from "../../shared/ai";
 import {
   generateChunkedBylineParallel,
   shouldUseBylineChunking,
@@ -33,18 +29,13 @@ interface PlaygroundRequest {
 export class AdminPromptService {
   private promptRepository: PromptRepository;
   private userPromptRepository: UserPromptRepository;
-  private openai: OpenAI;
+  private ai: AiProvider;
 
   constructor(private readonly db: db) {
     this.promptRepository = new PromptRepository(this.db);
     this.userPromptRepository = new UserPromptRepository(this.db);
-    const apiKey = process.env.OPEN_AI_KEY;
-    if (!apiKey) {
-      console.error(
-        "ERROR: OPEN_AI_KEY is not set. OpenAI client will not be initialized.",
-      );
-    }
-    this.openai = new OpenAI({ apiKey });
+    // Per spec feat-integrations br-int-001 (D-001): consume AI through abstraction.
+    this.ai = getAiProvider();
   }
 
   // --- System Prompt Methods ---
@@ -347,14 +338,14 @@ export class AdminPromptService {
     effort?: "low" | "medium" | "high";
     max_output_tokens?: number;
   }) {
-    const response = await this.openai.responses.create({
+    const response = await this.ai.responsesCreate({
       model,
-      reasoning: { effort },
+      reasoningEffort: effort,
       instructions,
       input,
-      max_output_tokens: max_output_tokens || 50000,
+      maxOutputTokens: max_output_tokens || 50000,
     });
-    return response.output_text || "";
+    return response.outputText;
   }
 
   private getLanguageName(code: string, locale = "en"): string {

--- a/packages/backend-base/src/admin/services/admin-prompt.service.ts
+++ b/packages/backend-base/src/admin/services/admin-prompt.service.ts
@@ -1,5 +1,9 @@
 import type ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import PromptStatusEnum from "database/src/models/public/PromptStatusEnum";
+// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
+// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
+// as follow-up to feat-integrations br-int-001.
+
 import OpenAI from "openai";
 import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { UserPromptRepository } from "../../bible/repository/user-prompt.repository";

--- a/packages/backend-base/src/admin/services/batch-operations.service.ts
+++ b/packages/backend-base/src/admin/services/batch-operations.service.ts
@@ -1,6 +1,10 @@
 import type { Queue } from "bullmq";
 import type ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import PromptStatusEnum from "database/src/models/public/PromptStatusEnum";
+// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
+// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
+// as follow-up to feat-integrations br-int-001.
+
 import OpenAI, { APIError } from "openai";
 import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { UserPromptRepository } from "../../bible/repository/user-prompt.repository";

--- a/packages/backend-base/src/admin/services/batch-operations.service.ts
+++ b/packages/backend-base/src/admin/services/batch-operations.service.ts
@@ -1,15 +1,12 @@
 import type { Queue } from "bullmq";
 import type ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import PromptStatusEnum from "database/src/models/public/PromptStatusEnum";
-// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
-// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
-// as follow-up to feat-integrations br-int-001.
-
-import OpenAI, { APIError } from "openai";
+import { APIError } from "openai";
 import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { UserPromptRepository } from "../../bible/repository/user-prompt.repository";
 import { ValidationError } from "../../common/errors";
 import { BATCH_MONITORING_QUEUE } from "../../queue/batch-monitoring.queue";
+import { type AiProvider, getAiProvider } from "../../shared/ai";
 import {
   buildBylineChunkPrompts,
   shouldUseBylineChunking,
@@ -33,10 +30,6 @@ interface BatchJobRequest {
     max_output_tokens: number;
   };
 }
-
-const openai = new OpenAI({
-  apiKey: process.env.OPEN_AI_KEY,
-});
 
 export const DEFAULT_MAX_OUTPUT_TOKENS = 50000;
 
@@ -94,6 +87,14 @@ const getUserPrompt = ({
 
 export class BatchOperationService {
   private promptRepository: PromptRepository;
+  // Lazy: BatchOperationService instantiates eagerly via admin.plugin state
+  // wiring; OpenAiProvider's constructor demands OPEN_AI_KEY which is empty
+  // in test envs. Resolve on first use to keep test bootstrap working.
+  private _ai: AiProvider | null = null;
+  private get ai(): AiProvider {
+    if (!this._ai) this._ai = getAiProvider();
+    return this._ai;
+  }
 
   constructor(
     private readonly db: db,
@@ -147,7 +148,7 @@ export class BatchOperationService {
     }
 
     // Create a proper File object for OpenAI API
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `topic_discovery_${discoveryTopicType}_${Date.now()}.jsonl`,
@@ -155,10 +156,10 @@ export class BatchOperationService {
       purpose: "batch",
     });
 
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     await this.db
@@ -265,7 +266,7 @@ export class BatchOperationService {
     }
 
     // Create a proper File object for OpenAI API
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `topic_references_${Date.now()}.jsonl`,
@@ -273,10 +274,10 @@ export class BatchOperationService {
       purpose: "batch",
     });
 
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     await this.db
@@ -534,7 +535,7 @@ export class BatchOperationService {
     }
 
     // Create a proper File object for OpenAI API
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `topic_explanations_${topic.topic_id}_${languageCode}_${Date.now()}.jsonl`,
@@ -542,10 +543,10 @@ export class BatchOperationService {
       purpose: "batch",
     });
 
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     await this.db
@@ -664,7 +665,7 @@ export class BatchOperationService {
     }
 
     // Create a proper File object for OpenAI API
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `batch_${bookId}_${bibleVersion}_${Date.now()}.jsonl`,
@@ -672,10 +673,10 @@ export class BatchOperationService {
       purpose: "batch",
     });
 
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     console.log(
@@ -1143,7 +1144,7 @@ export class BatchOperationService {
     }
 
     // Create a proper File object for OpenAI API
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `rephrase_batch_${book.book_id}_${Date.now()}.jsonl`,
@@ -1151,10 +1152,10 @@ export class BatchOperationService {
       purpose: "batch",
     });
 
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     await connection
@@ -1528,7 +1529,7 @@ export class BatchOperationService {
     }
 
     // Create a proper File object for OpenAI API
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `translate_batch_${book.book_id}_${Date.now()}.jsonl`,
@@ -1538,10 +1539,10 @@ export class BatchOperationService {
 
     console.log(`[BATCH] Created OpenAI file: ${file.id}`);
 
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     console.log(`[BATCH] Created OpenAI batch: ${batch.id}`);
@@ -1581,7 +1582,7 @@ export class BatchOperationService {
   }
 
   async getBatchStatus(batchId: string) {
-    const batchStatus = await openai.batches.retrieve(batchId);
+    const batchStatus = await this.ai.batchesRetrieve(batchId);
 
     if (batchStatus.status === "failed" && batchStatus.errors) {
       console.error(
@@ -1615,8 +1616,8 @@ export class BatchOperationService {
       ])
       .executeTakeFirst();
 
-    if (currentBatchJob && batchStatus.request_counts) {
-      const { total, completed, failed } = batchStatus.request_counts;
+    if (currentBatchJob && batchStatus.requestCounts) {
+      const { total, completed, failed } = batchStatus.requestCounts;
 
       let correctStatus: string = batchStatus.status;
 
@@ -1665,7 +1666,7 @@ export class BatchOperationService {
         );
         await this.batchProcessingQueue.add("process-batch", {
           batchId,
-          outputFileId: batchStatus.output_file_id,
+          outputFileId: batchStatus.outputFileId,
         });
       }
     }
@@ -1676,16 +1677,16 @@ export class BatchOperationService {
   async processBatch(batchId: string, outputFileId: string) {
     console.log(`[BATCH] Processing batch ${batchId} from queue.`);
 
-    const batchStatus = await openai.batches.retrieve(batchId);
+    const batchStatus = await this.ai.batchesRetrieve(batchId);
 
     if (
-      batchStatus.request_counts &&
-      batchStatus.request_counts.failed > 0 &&
-      batchStatus.error_file_id
+      batchStatus.requestCounts &&
+      batchStatus.requestCounts.failed > 0 &&
+      batchStatus.errorFileId
     ) {
       try {
-        const errorFileContent = await openai.files.content(
-          batchStatus.error_file_id,
+        const errorFileContent = await this.ai.filesContent(
+          batchStatus.errorFileId,
         );
         const errorText = await errorFileContent.text();
         await this.db
@@ -1696,7 +1697,7 @@ export class BatchOperationService {
           .execute();
       } catch (error) {
         console.error(
-          `[BATCH] Could not download error file ${batchStatus.error_file_id}:`,
+          `[BATCH] Could not download error file ${batchStatus.errorFileId}:`,
           error,
         );
       }
@@ -1742,7 +1743,7 @@ export class BatchOperationService {
             child.status === "finalizing")
         ) {
           try {
-            const openaiBatch = await openai.batches.cancel(
+            const openaiBatch = await this.ai.batchesCancel(
               child.openai_batch_id,
             );
             console.log(
@@ -1837,7 +1838,7 @@ export class BatchOperationService {
         `Book batch ${batchId} does not have an OpenAI batch ID.`,
       );
     }
-    const openaiBatch = await openai.batches.cancel(batchJob.openai_batch_id);
+    const openaiBatch = await this.ai.batchesCancel(batchJob.openai_batch_id);
     console.log(
       `[BATCH] Successfully cancelled single book batch ${batchJob.openai_batch_id}`,
     );
@@ -2491,7 +2492,7 @@ export class BatchOperationService {
         return;
       }
 
-      const fileContent = await openai.files.content(outputFileId);
+      const fileContent = await this.ai.filesContent(outputFileId);
       const jsonl = await fileContent.text();
       const lines = jsonl.split("\n").filter((line) => line.trim() !== "");
 
@@ -2887,7 +2888,7 @@ export class BatchOperationService {
     outputFileId: string,
     batchJob: { model: string },
   ) {
-    const fileContent = await openai.files.content(outputFileId);
+    const fileContent = await this.ai.filesContent(outputFileId);
     const jsonData =
       typeof (fileContent as any).text === "function"
         ? await (fileContent as any).text()
@@ -3166,7 +3167,7 @@ export class BatchOperationService {
       book_id?: number | null;
     },
   ) {
-    const fileContent = await openai.files.content(outputFileId);
+    const fileContent = await this.ai.filesContent(outputFileId);
     const jsonData =
       typeof (fileContent as any).text === "function"
         ? await (fileContent as any).text()
@@ -3530,7 +3531,7 @@ export class BatchOperationService {
     );
 
     try {
-      const fileContent = await openai.files.content(outputFileId);
+      const fileContent = await this.ai.filesContent(outputFileId);
       const jsonl = await fileContent.text();
       const lines = jsonl.split("\n").filter((line) => line.trim() !== "");
 
@@ -3619,7 +3620,7 @@ export class BatchOperationService {
     );
 
     try {
-      const fileContent = await openai.files.content(outputFileId);
+      const fileContent = await this.ai.filesContent(outputFileId);
       const jsonl = await fileContent.text();
       const lines = jsonl.split("\n").filter((line) => line.trim() !== "");
 
@@ -3791,7 +3792,7 @@ export class BatchOperationService {
     );
 
     try {
-      const fileContent = await openai.files.content(outputFileId);
+      const fileContent = await this.ai.filesContent(outputFileId);
       const jsonl = await fileContent.text();
       const lines = jsonl.split("\n").filter((line) => line.trim() !== "");
 
@@ -3933,7 +3934,7 @@ export class BatchOperationService {
       `[BATCH] Processing topic name translation output for batch ${batchId}`,
     );
 
-    const fileContent = await openai.files.content(outputFileId);
+    const fileContent = await this.ai.filesContent(outputFileId);
     const jsonData =
       typeof (fileContent as any).text === "function"
         ? await (fileContent as any).text()
@@ -4148,7 +4149,7 @@ export class BatchOperationService {
       `[BATCH] Processing topic explanation translation output for batch ${batchId}`,
     );
 
-    const fileContent = await openai.files.content(outputFileId);
+    const fileContent = await this.ai.filesContent(outputFileId);
     const jsonData =
       typeof (fileContent as any).text === "function"
         ? await (fileContent as any).text()
@@ -4361,7 +4362,7 @@ export class BatchOperationService {
       const connection = this.db.getOrCreateConnection();
 
       // Parse custom_id to get book name: "auto-highlight-Genesis-1234567890"
-      const fileContent = await openai.files.content(outputFileId);
+      const fileContent = await this.ai.filesContent(outputFileId);
       const jsonl = await fileContent.text();
       const lines = jsonl.split("\n").filter((line) => line.trim() !== "");
 
@@ -4939,7 +4940,7 @@ export class BatchOperationService {
     }
 
     // Create OpenAI file
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `translate_topic_names_${target_language_code}_${Date.now()}.jsonl`,
@@ -4950,10 +4951,10 @@ export class BatchOperationService {
     console.log(`[BATCH] Created OpenAI file: ${file.id}`);
 
     // Create OpenAI batch
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     console.log(`[BATCH] Created OpenAI batch: ${batch.id}`);
@@ -5149,7 +5150,7 @@ export class BatchOperationService {
       throw new ValidationError("Batch file size exceeds OpenAI's 100MB limit");
     }
 
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `translate_topic_explanations_${target_language_code}_${Date.now()}.jsonl`,
@@ -5159,10 +5160,10 @@ export class BatchOperationService {
 
     console.log(`[BATCH] Created OpenAI file: ${file.id}`);
 
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     console.log(`[BATCH] Created OpenAI batch: ${batch.id}`);
@@ -5563,7 +5564,7 @@ export class BatchOperationService {
       );
     }
 
-    const file = await openai.files.create({
+    const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
         `auto_highlight_${book.book_id}_${Date.now()}.jsonl`,
@@ -5571,10 +5572,10 @@ export class BatchOperationService {
       purpose: "batch",
     });
 
-    const batch = await openai.batches.create({
-      input_file_id: file.id,
+    const batch = await this.ai.batchesCreate({
+      inputFileId: file.id,
       endpoint: "/v1/responses",
-      completion_window: "24h",
+      completionWindow: "24h",
     });
 
     await connection
@@ -5645,15 +5646,15 @@ export class BatchOperationService {
 
     try {
       // Retrieve batch status from OpenAI
-      const batchStatus = await openai.batches.retrieve(
+      const batchStatus = await this.ai.batchesRetrieve(
         batchJob.openai_batch_id,
       );
 
       console.log(
-        `[BATCH] Batch ${batchJob.openai_batch_id} status: ${batchStatus.status}, has error_file_id: ${!!batchStatus.error_file_id}`,
+        `[BATCH] Batch ${batchJob.openai_batch_id} status: ${batchStatus.status}, has error_file_id: ${!!batchStatus.errorFileId}`,
       );
 
-      if (!batchStatus.error_file_id) {
+      if (!batchStatus.errorFileId) {
         return {
           success: false,
           message: `Batch ${batchJobId} (${batchJob.openai_batch_id}) does not have an error file. Status: ${batchStatus.status}`,
@@ -5662,10 +5663,10 @@ export class BatchOperationService {
 
       // Download the error file
       console.log(
-        `[BATCH] Downloading error file ${batchStatus.error_file_id}...`,
+        `[BATCH] Downloading error file ${batchStatus.errorFileId}...`,
       );
-      const errorFileContent = await openai.files.content(
-        batchStatus.error_file_id,
+      const errorFileContent = await this.ai.filesContent(
+        batchStatus.errorFileId,
       );
       const errorText = await errorFileContent.text();
 

--- a/packages/backend-base/src/admin/services/explanation-regeneration.service.ts
+++ b/packages/backend-base/src/admin/services/explanation-regeneration.service.ts
@@ -1,11 +1,7 @@
 import type ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
-// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
-// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
-// as follow-up to feat-integrations br-int-001.
-
-import OpenAI from "openai";
 import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { NotFoundError } from "../../common/errors";
+import { type AiProvider, getAiProvider } from "../../shared/ai";
 import {
   generateChunkedBylineParallel,
   shouldUseBylineChunking,
@@ -15,13 +11,12 @@ import { getExplanationTypePrompt } from "../../shared/prompt-utils";
 import type { db } from "../../shared/shared.plugin";
 
 export class ExplanationRegenerationService {
-  private readonly openai: OpenAI;
+  private readonly ai: AiProvider;
   private readonly promptRepository: PromptRepository;
 
   constructor(private readonly db: db) {
-    this.openai = new OpenAI({
-      apiKey: process.env.OPEN_AI_KEY,
-    });
+    // Per spec feat-integrations br-int-001 (D-001): consume AI through abstraction.
+    this.ai = getAiProvider();
     this.promptRepository = new PromptRepository(this.db);
   }
 
@@ -38,15 +33,15 @@ export class ExplanationRegenerationService {
     effort?: "low" | "medium" | "high";
     maxTokens?: number;
   }) {
-    const response = await this.openai.responses.create({
+    const response = await this.ai.responsesCreate({
       model,
-      reasoning: { effort },
+      reasoningEffort: effort,
       instructions,
       input,
-      max_output_tokens: maxTokens,
+      maxOutputTokens: maxTokens,
     });
 
-    return response.output_text || "";
+    return response.outputText;
   }
 
   private getLanguageName(code: string, locale = "en"): string {

--- a/packages/backend-base/src/admin/services/explanation-regeneration.service.ts
+++ b/packages/backend-base/src/admin/services/explanation-regeneration.service.ts
@@ -1,4 +1,8 @@
 import type ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
+// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
+// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
+// as follow-up to feat-integrations br-int-001.
+
 import OpenAI from "openai";
 import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { NotFoundError } from "../../common/errors";

--- a/packages/backend-base/src/bible/bible.plugin.ts
+++ b/packages/backend-base/src/bible/bible.plugin.ts
@@ -3,7 +3,6 @@ import HighlightColorEnum from "database/src/models/public/HighlightColorEnum";
 import RoleEnum from "database/src/models/public/RoleEnum";
 import { Elysia, t } from "elysia";
 import { authDerive } from "../auth/auth.utils";
-import { type AiProvider, getAiProvider } from "../shared/ai";
 import { createErrorHandler } from "../common/error-handler";
 import {
   NotFoundError,
@@ -11,6 +10,7 @@ import {
   ValidationError,
 } from "../common/errors";
 import { StandardErrorResponses } from "../common/response-schemas";
+import { type AiProvider, getAiProvider } from "../shared/ai";
 import shared from "../shared/shared.plugin";
 import { parseBibleData } from "./bible";
 import { ChapterDto } from "./dto/book/chapter.dto";

--- a/packages/backend-base/src/bible/bible.plugin.ts
+++ b/packages/backend-base/src/bible/bible.plugin.ts
@@ -2,8 +2,8 @@ import type ExplanationTypeEnum from "database/src/models/public/ExplanationType
 import HighlightColorEnum from "database/src/models/public/HighlightColorEnum";
 import RoleEnum from "database/src/models/public/RoleEnum";
 import { Elysia, t } from "elysia";
-import OpenAI from "openai";
 import { authDerive } from "../auth/auth.utils";
+import { type AiProvider, getAiProvider } from "../shared/ai";
 import { createErrorHandler } from "../common/error-handler";
 import {
   NotFoundError,
@@ -56,10 +56,15 @@ import { BibleService } from "./services/bible.service";
 import { ChatService } from "./services/chat.service";
 import { PromptService } from "./services/prompt.service";
 
-const openai = new OpenAI({
-  apiKey: process.env.OPEN_AI_KEY, // This is the default and can be omitted
-});
 const model = "gpt-5-nano";
+
+// Lazy AiProvider singleton — module-level use means we can't construct in
+// the constructor body; eager init would fail in test envs without OPEN_AI_KEY.
+let _ai: AiProvider | null = null;
+function ai(): AiProvider {
+  if (!_ai) _ai = getAiProvider();
+  return _ai;
+}
 
 async function gpt5Text({
   system,
@@ -68,15 +73,15 @@ async function gpt5Text({
   system?: string;
   user: string;
 }) {
-  const response = await openai.responses.create({
+  const response = await ai().responsesCreate({
     model,
-    reasoning: { effort: "medium" },
+    reasoningEffort: "medium",
     instructions: system,
     input: user,
-    max_output_tokens: 20000,
+    maxOutputTokens: 20000,
   });
 
-  return response.output_text ?? "oopsies";
+  return response.outputText || "oopsies";
 }
 
 /**

--- a/packages/backend-base/src/bible/explanation-queue.ts
+++ b/packages/backend-base/src/bible/explanation-queue.ts
@@ -1,16 +1,16 @@
 import Queue from "bull";
 import { db } from "database";
 import ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
-import OpenAI from "openai";
+import { type AiChatMessage, getAiProvider } from "../shared/ai";
 import {
   generateChunkedByline,
   shouldUseBylineChunking,
   toBylineVerses,
 } from "../shared/byline-chunking";
 
-const openai = new OpenAI({
-  apiKey: process.env.OPEN_AI_KEY,
-});
+// Per spec feat-integrations br-int-001 (D-001): use the provider abstraction.
+// Resolved per AI_PROVIDER env (default: openai).
+const ai = getAiProvider();
 
 const getExplanationTypePrompt = (
   type: ExplanationTypeEnum,
@@ -100,20 +100,18 @@ async function gpt5Text({
   user: string;
   maxTokens?: number;
 }) {
-  const messages: OpenAI.ChatCompletionMessageParam[] = [];
+  const messages: AiChatMessage[] = [];
   if (system) {
     messages.push({ role: "system", content: system });
   }
   messages.push({ role: "user", content: user });
 
-  const options: any = {
+  const response = await ai.chatComplete({
     model: "gpt-5",
     messages,
-    max_completion_tokens: maxTokens,
-  };
-
-  const chat = await openai.chat.completions.create(options);
-  return chat.choices[0].message.content || "";
+    maxTokens,
+  });
+  return response.content;
 }
 
 // Create explanation generation queue

--- a/packages/backend-base/src/queue/consumers/batch-monitoring.consumer.ts
+++ b/packages/backend-base/src/queue/consumers/batch-monitoring.consumer.ts
@@ -2,6 +2,10 @@
 import * as fs from "node:fs";
 import type { Job } from "bullmq";
 import { db } from "database";
+// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
+// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
+// as follow-up to feat-integrations br-int-001.
+
 import OpenAI from "openai";
 import { BatchOperationService } from "../../admin/services/batch-operations.service";
 import { replaceExplanationWithAudioHook } from "../../bible/audio/audio-regen-hook";

--- a/packages/backend-base/src/queue/consumers/batch-monitoring.consumer.ts
+++ b/packages/backend-base/src/queue/consumers/batch-monitoring.consumer.ts
@@ -2,13 +2,9 @@
 import * as fs from "node:fs";
 import type { Job } from "bullmq";
 import { db } from "database";
-// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
-// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
-// as follow-up to feat-integrations br-int-001.
-
-import OpenAI from "openai";
 import { BatchOperationService } from "../../admin/services/batch-operations.service";
 import { replaceExplanationWithAudioHook } from "../../bible/audio/audio-regen-hook";
+import { type AiProvider, getAiProvider } from "../../shared/ai";
 import { stitchBylineChunks } from "../../shared/byline-chunking";
 import {
   BATCH_MONITORING_QUEUE,
@@ -16,9 +12,13 @@ import {
 } from "../batch-monitoring.queue";
 import { batchProcessingQueue } from "../batch-processing.queue";
 
-const openai = new OpenAI({
-  apiKey: process.env.OPEN_AI_KEY,
-});
+// Lazy: OpenAiProvider's constructor demands OPEN_AI_KEY which is empty in
+// test envs. Resolve on first call so the module loads cleanly.
+let _ai: AiProvider | null = null;
+function ai(): AiProvider {
+  if (!_ai) _ai = getAiProvider();
+  return _ai;
+}
 
 async function calculateActualCost(
   promptTokens: number,
@@ -239,7 +239,7 @@ export const batchMonitoringConsumer = async (job: Job) => {
       return; // Don't re-queue if already finished
     }
 
-    const batch = await openai.batches.retrieve(batchId);
+    const batch = await ai().batchesRetrieve(batchId);
 
     console.log(`[BATCH_MONITORING] Batch ${batchId} status: ${batch.status}`);
 
@@ -253,11 +253,11 @@ export const batchMonitoringConsumer = async (job: Job) => {
 
     if (batch.status === "completed") {
       console.log(`[BATCH_MONITORING] Batch ${batchId} completed.`);
-      const outputFileId = batch.output_file_id;
+      const outputFileId = batch.outputFileId;
       if (outputFileId) {
         let fileContent: Response;
         try {
-          fileContent = await openai.files.content(outputFileId);
+          fileContent = await ai().filesContent(outputFileId);
         } catch (fileError) {
           console.error(
             `[BATCH_MONITORING] Failed to retrieve output file ${outputFileId} for batch ${batchId}:`,
@@ -772,18 +772,18 @@ export const batchMonitoringConsumer = async (job: Job) => {
       }
 
       // If validating for more than 10 minutes, log additional debug info
-      const timeSinceCreation = Date.now() - batch.created_at * 1000;
+      const timeSinceCreation = Date.now() - (batch.createdAt ?? 0) * 1000;
       if (batch.status === "validating" && timeSinceCreation > 10 * 60 * 1000) {
         console.warn(
           `[BATCH_MONITORING] Batch ${batchId} has been validating for ${Math.round(timeSinceCreation / 60000)} minutes`,
         );
         console.warn(
-          `[BATCH_MONITORING] This may indicate a file format issue. Check input file: ${batch.input_file_id}`,
+          `[BATCH_MONITORING] This may indicate a file format issue. Check input file: ${batch.inputFileId}`,
         );
 
         // Try to get file info for debugging
         try {
-          const fileInfo = await openai.files.retrieve(batch.input_file_id);
+          const fileInfo = await ai().filesRetrieve(batch.inputFileId);
           console.warn(
             `[BATCH_MONITORING] Input file status: ${fileInfo.status}, size: ${fileInfo.bytes} bytes`,
           );

--- a/packages/backend-base/src/shared/ai/ai-provider.factory.ts
+++ b/packages/backend-base/src/shared/ai/ai-provider.factory.ts
@@ -1,0 +1,43 @@
+import type { AiProvider } from "./ai-provider.interface";
+import { OpenAiProvider } from "./openai.provider";
+import { StubAiProvider } from "./stub.provider";
+
+/**
+ * Factory that resolves an AiProvider based on the `AI_PROVIDER` env var.
+ *
+ *   AI_PROVIDER=openai   (default)
+ *   AI_PROVIDER=stub     (tests / dev without OpenAI key)
+ *
+ * Returns a singleton per process for the resolved provider.
+ *
+ * Per spec feat-integrations br-int-001 (D-001).
+ */
+let cached: AiProvider | null = null;
+
+export function getAiProvider(name?: string): AiProvider {
+  if (cached && !name) return cached;
+
+  const resolved = (name ?? process.env.AI_PROVIDER ?? "openai").toLowerCase();
+  let provider: AiProvider;
+
+  switch (resolved) {
+    case "openai":
+      provider = new OpenAiProvider();
+      break;
+    case "stub":
+      provider = new StubAiProvider();
+      break;
+    default:
+      throw new Error(
+        `Unknown AI_PROVIDER "${resolved}" — supported: openai, stub`,
+      );
+  }
+
+  if (!name) cached = provider;
+  return provider;
+}
+
+/** For tests: reset the singleton. */
+export function resetAiProviderCache(): void {
+  cached = null;
+}

--- a/packages/backend-base/src/shared/ai/ai-provider.interface.ts
+++ b/packages/backend-base/src/shared/ai/ai-provider.interface.ts
@@ -47,10 +47,42 @@ export interface AiChatResponse {
   };
 }
 
+/**
+ * Options for the Responses API (newer Assistants-style API).
+ * Used by admin prompt playground + explanation regeneration + topic
+ * translation where instruction-style input is preferred over messages.
+ */
+export interface AiResponseOptions {
+  /** Model identifier (e.g. "gpt-5", "gpt-5-nano"). */
+  model: string;
+  /** Free-form instruction string (system role equivalent). */
+  instructions?: string;
+  /** Free-form input (user role equivalent). */
+  input: string;
+  /** Reasoning effort hint: "low" | "medium" | "high". */
+  reasoningEffort?: "low" | "medium" | "high";
+  /** Max output tokens. */
+  maxOutputTokens?: number;
+}
+
+export interface AiResponseResult {
+  /** Generated text content. */
+  outputText: string;
+  /** Provider/model that generated this. */
+  model: string;
+}
+
 export interface AiProvider {
   /** Provider identifier (e.g. "openai", "stub"). */
   readonly name: string;
 
   /** Send a chat completion request. */
   chatComplete(opts: AiChatOptions): Promise<AiChatResponse>;
+
+  /**
+   * Send a Responses-API style request (instructions + input). Used by admin
+   * prompt iteration + regeneration + topic translation flows. On OpenAI maps
+   * to the Responses API; on stub returns a deterministic fixture.
+   */
+  responsesCreate(opts: AiResponseOptions): Promise<AiResponseResult>;
 }

--- a/packages/backend-base/src/shared/ai/ai-provider.interface.ts
+++ b/packages/backend-base/src/shared/ai/ai-provider.interface.ts
@@ -1,0 +1,56 @@
+/**
+ * AI Provider Interface
+ *
+ * Provider-agnostic contract for chat completions. Per spec feat-integrations
+ * br-int-001 (D-001): consumer code MUST go through this interface, never
+ * `new OpenAI(...)` directly.
+ *
+ * Initial implementations:
+ *  - openai (OpenAiProvider) — production, uses `openai` SDK
+ *  - stub (StubAiProvider) — tests / dev, returns deterministic fixture
+ *
+ * Future providers (Anthropic, Vertex, Bedrock, etc.) plug in here without
+ * touching consumer code. Selected via `AI_PROVIDER` env (default: openai).
+ */
+
+export interface AiChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export interface AiChatOptions {
+  /** Model identifier — provider-specific. e.g. "gpt-5", "gpt-5-nano", "stub". */
+  model: string;
+  /** Conversation messages in order. */
+  messages: AiChatMessage[];
+  /** 0..2 — sampling randomness. Provider may clamp. */
+  temperature?: number;
+  /** Optional max tokens for the response. */
+  maxTokens?: number;
+  /**
+   * Optional response_format for providers that support it (e.g. OpenAI JSON mode).
+   * Pass-through; not all providers honor this.
+   */
+  responseFormat?: { type: "text" | "json_object" };
+}
+
+export interface AiChatResponse {
+  /** Generated text content. */
+  content: string;
+  /** Provider/model that generated this (for audit). */
+  model: string;
+  /** Token usage if reported by provider. */
+  usage?: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+}
+
+export interface AiProvider {
+  /** Provider identifier (e.g. "openai", "stub"). */
+  readonly name: string;
+
+  /** Send a chat completion request. */
+  chatComplete(opts: AiChatOptions): Promise<AiChatResponse>;
+}

--- a/packages/backend-base/src/shared/ai/ai-provider.interface.ts
+++ b/packages/backend-base/src/shared/ai/ai-provider.interface.ts
@@ -72,6 +72,88 @@ export interface AiResponseResult {
   model: string;
 }
 
+/**
+ * Files API — used by admin batch operations to upload JSONL request files
+ * and download result files. Per OpenAI semantics: upload returns a file_id
+ * which is then referenced by Batch operations.
+ */
+export interface AiFileCreateOptions {
+  /** Web `File` object (or a Buffer the provider knows how to wrap). */
+  file: File;
+  /** Provider-specific purpose. For OpenAI batch, must be `"batch"`. */
+  purpose: "batch" | "assistants" | "fine-tune" | "vision";
+}
+
+export interface AiFileResult {
+  /** File ID assigned by the provider. */
+  id: string;
+  /** Original filename, if reported by provider. */
+  filename?: string;
+  /** Size in bytes. */
+  bytes?: number;
+  /** Status string (e.g. "uploaded", "processed", "error"). */
+  status?: string;
+  /** Purpose this file was created with. */
+  purpose?: string;
+  /** Creation timestamp (provider's epoch). */
+  createdAt?: number;
+}
+
+/**
+ * Batch API — used by admin to enqueue large JSONL request batches against
+ * OpenAI's batch endpoint. Per OpenAI semantics: batch references an uploaded
+ * input_file_id and produces an output_file_id (and possibly an error_file_id).
+ */
+export interface AiBatchCreateOptions {
+  /** File ID returned from a prior `filesCreate({purpose: "batch"})` call. */
+  inputFileId: string;
+  /** Endpoint the batched requests target. */
+  endpoint: "/v1/responses" | "/v1/chat/completions" | "/v1/embeddings";
+  /** Completion window — currently OpenAI only accepts "24h". */
+  completionWindow?: "24h";
+  /** Optional metadata (echoed back on retrieve). */
+  metadata?: Record<string, string>;
+}
+
+export type AiBatchStatus =
+  | "validating"
+  | "failed"
+  | "in_progress"
+  | "finalizing"
+  | "completed"
+  | "expired"
+  | "cancelling"
+  | "cancelled";
+
+export interface AiBatchResult {
+  /** Batch ID assigned by the provider. */
+  id: string;
+  /** Current batch status. */
+  status: AiBatchStatus;
+  /** Input file id referenced when the batch was created. */
+  inputFileId: string;
+  /** Output file id once the batch completes (results JSONL). */
+  outputFileId?: string;
+  /** Error file id if the batch produced per-row errors. */
+  errorFileId?: string;
+  /** Endpoint the batch targets. */
+  endpoint?: string;
+  /** Per-status request counts. */
+  requestCounts?: { total: number; completed: number; failed: number };
+  /** Creation timestamp (epoch seconds). */
+  createdAt?: number;
+  /** Completion timestamp (epoch seconds). */
+  completedAt?: number;
+  /** Cancellation timestamp (epoch seconds). */
+  cancelledAt?: number;
+  /** Failure timestamp (epoch seconds). */
+  failedAt?: number;
+  /** Optional metadata echoed back. */
+  metadata?: Record<string, string> | null;
+  /** Errors object (provider-specific shape). */
+  errors?: { object: string; data: unknown[] } | null;
+}
+
 export interface AiProvider {
   /** Provider identifier (e.g. "openai", "stub"). */
   readonly name: string;
@@ -85,4 +167,22 @@ export interface AiProvider {
    * to the Responses API; on stub returns a deterministic fixture.
    */
   responsesCreate(opts: AiResponseOptions): Promise<AiResponseResult>;
+
+  /** Upload a file (used to feed batched JSONL requests). */
+  filesCreate(opts: AiFileCreateOptions): Promise<AiFileResult>;
+
+  /** Retrieve metadata for a previously uploaded file. */
+  filesRetrieve(fileId: string): Promise<AiFileResult>;
+
+  /** Download the bytes of a previously uploaded/produced file. */
+  filesContent(fileId: string): Promise<Response>;
+
+  /** Submit a batch job referencing a previously uploaded input file. */
+  batchesCreate(opts: AiBatchCreateOptions): Promise<AiBatchResult>;
+
+  /** Retrieve current state of a batch job. */
+  batchesRetrieve(batchId: string): Promise<AiBatchResult>;
+
+  /** Cancel an in-progress batch job. */
+  batchesCancel(batchId: string): Promise<AiBatchResult>;
 }

--- a/packages/backend-base/src/shared/ai/ai-provider.test.ts
+++ b/packages/backend-base/src/shared/ai/ai-provider.test.ts
@@ -98,3 +98,47 @@ describe("StubAiProvider", () => {
     expect(a.model).toBe(b.model);
   });
 });
+
+describe("StubAiProvider responsesCreate", () => {
+  const provider = new StubAiProvider();
+
+  it("returns deterministic output for given input", async () => {
+    const response = await provider.responsesCreate({
+      model: "gpt-5",
+      input: "Tell me about Genesis 1.",
+    });
+
+    expect(response.outputText).toContain("[stub-responses:gpt-5]");
+    expect(response.outputText).toContain("Tell me about Genesis 1.");
+    expect(response.model).toBe("stub-gpt-5");
+  });
+
+  it("identical input produces identical output", async () => {
+    const opts = {
+      model: "gpt-5",
+      input: "test input",
+      instructions: "follow these instructions",
+      reasoningEffort: "medium" as const,
+      maxOutputTokens: 1000,
+    };
+    const a = await provider.responsesCreate(opts);
+    const b = await provider.responsesCreate(opts);
+    expect(a.outputText).toBe(b.outputText);
+    expect(a.model).toBe(b.model);
+  });
+
+  it("ignores instructions/reasoningEffort/maxOutputTokens for output (deterministic)", async () => {
+    const a = await provider.responsesCreate({
+      model: "gpt-5",
+      input: "same input",
+    });
+    const b = await provider.responsesCreate({
+      model: "gpt-5",
+      input: "same input",
+      instructions: "different",
+      reasoningEffort: "high",
+      maxOutputTokens: 5000,
+    });
+    expect(a.outputText).toBe(b.outputText);
+  });
+});

--- a/packages/backend-base/src/shared/ai/ai-provider.test.ts
+++ b/packages/backend-base/src/shared/ai/ai-provider.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { getAiProvider, resetAiProviderCache } from "./ai-provider.factory";
+import { StubAiProvider } from "./stub.provider";
+
+describe("AiProvider factory", () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.AI_PROVIDER;
+    resetAiProviderCache();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      process.env.AI_PROVIDER = undefined;
+    } else {
+      process.env.AI_PROVIDER = originalEnv;
+    }
+    resetAiProviderCache();
+  });
+
+  it("returns stub provider when AI_PROVIDER=stub", () => {
+    process.env.AI_PROVIDER = "stub";
+    const provider = getAiProvider();
+    expect(provider.name).toBe("stub");
+  });
+
+  it("throws on unknown provider name", () => {
+    expect(() => getAiProvider("not-a-real-provider")).toThrow(
+      /Unknown AI_PROVIDER/,
+    );
+  });
+
+  it("caches the singleton between calls", () => {
+    process.env.AI_PROVIDER = "stub";
+    const a = getAiProvider();
+    const b = getAiProvider();
+    expect(a).toBe(b);
+  });
+
+  it("explicit name bypasses cache", () => {
+    process.env.AI_PROVIDER = "stub";
+    const cached = getAiProvider();
+    const explicit = getAiProvider("stub");
+    expect(cached).toBeInstanceOf(StubAiProvider);
+    expect(explicit).toBeInstanceOf(StubAiProvider);
+    // Different instances because explicit name skips cache
+    expect(cached).not.toBe(explicit);
+  });
+});
+
+describe("StubAiProvider", () => {
+  const provider = new StubAiProvider();
+
+  it("returns deterministic response keyed on user message", async () => {
+    const response = await provider.chatComplete({
+      model: "gpt-5",
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "What is the meaning of life?" },
+      ],
+    });
+
+    expect(response.content).toContain("[stub:gpt-5]");
+    expect(response.content).toContain("What is the meaning of life?");
+    expect(response.model).toBe("stub-gpt-5");
+  });
+
+  it("reports token usage estimate", async () => {
+    const response = await provider.chatComplete({
+      model: "gpt-5",
+      messages: [{ role: "user", content: "hello world" }],
+    });
+
+    expect(response.usage).toBeDefined();
+    expect(response.usage?.promptTokens).toBeGreaterThan(0);
+    expect(response.usage?.completionTokens).toBe(16);
+  });
+
+  it("handles empty messages array", async () => {
+    const response = await provider.chatComplete({
+      model: "gpt-5",
+      messages: [],
+    });
+
+    expect(response.content).toContain("[stub:gpt-5]");
+    expect(response.usage?.promptTokens).toBe(0);
+  });
+
+  it("identical input produces identical output (deterministic)", async () => {
+    const opts = {
+      model: "gpt-5",
+      messages: [{ role: "user" as const, content: "test prompt" }],
+    };
+    const a = await provider.chatComplete(opts);
+    const b = await provider.chatComplete(opts);
+    expect(a.content).toBe(b.content);
+    expect(a.model).toBe(b.model);
+  });
+});

--- a/packages/backend-base/src/shared/ai/index.ts
+++ b/packages/backend-base/src/shared/ai/index.ts
@@ -1,0 +1,12 @@
+export type {
+  AiChatMessage,
+  AiChatOptions,
+  AiChatResponse,
+  AiProvider,
+} from "./ai-provider.interface";
+export {
+  getAiProvider,
+  resetAiProviderCache,
+} from "./ai-provider.factory";
+export { OpenAiProvider } from "./openai.provider";
+export { StubAiProvider } from "./stub.provider";

--- a/packages/backend-base/src/shared/ai/openai.provider.ts
+++ b/packages/backend-base/src/shared/ai/openai.provider.ts
@@ -3,6 +3,8 @@ import type {
   AiChatOptions,
   AiChatResponse,
   AiProvider,
+  AiResponseOptions,
+  AiResponseResult,
 } from "./ai-provider.interface";
 
 /**
@@ -48,6 +50,28 @@ export class OpenAiProvider implements AiProvider {
           totalTokens: completion.usage.total_tokens,
         },
       }),
+    };
+  }
+
+  async responsesCreate(opts: AiResponseOptions): Promise<AiResponseResult> {
+    // biome-ignore lint/suspicious/noExplicitAny: OpenAI Responses API types lag SDK
+    const response = await (this.client as any).responses.create({
+      model: opts.model,
+      ...(opts.instructions !== undefined && {
+        instructions: opts.instructions,
+      }),
+      input: opts.input,
+      ...(opts.reasoningEffort && {
+        reasoning: { effort: opts.reasoningEffort },
+      }),
+      ...(opts.maxOutputTokens !== undefined && {
+        max_output_tokens: opts.maxOutputTokens,
+      }),
+    });
+
+    return {
+      outputText: response.output_text || "",
+      model: response.model || opts.model,
     };
   }
 }

--- a/packages/backend-base/src/shared/ai/openai.provider.ts
+++ b/packages/backend-base/src/shared/ai/openai.provider.ts
@@ -1,7 +1,12 @@
 import OpenAI from "openai";
 import type {
+  AiBatchCreateOptions,
+  AiBatchResult,
+  AiBatchStatus,
   AiChatOptions,
   AiChatResponse,
+  AiFileCreateOptions,
+  AiFileResult,
   AiProvider,
   AiResponseOptions,
   AiResponseResult,
@@ -74,4 +79,78 @@ export class OpenAiProvider implements AiProvider {
       model: response.model || opts.model,
     };
   }
+
+  async filesCreate(opts: AiFileCreateOptions): Promise<AiFileResult> {
+    const file = await this.client.files.create({
+      file: opts.file,
+      purpose: opts.purpose,
+    });
+    return mapOpenAiFile(file);
+  }
+
+  async filesRetrieve(fileId: string): Promise<AiFileResult> {
+    const file = await this.client.files.retrieve(fileId);
+    return mapOpenAiFile(file);
+  }
+
+  async filesContent(fileId: string): Promise<Response> {
+    return this.client.files.content(fileId);
+  }
+
+  async batchesCreate(opts: AiBatchCreateOptions): Promise<AiBatchResult> {
+    const batch = await this.client.batches.create({
+      input_file_id: opts.inputFileId,
+      endpoint: opts.endpoint,
+      completion_window: opts.completionWindow ?? "24h",
+      ...(opts.metadata && { metadata: opts.metadata }),
+    });
+    return mapOpenAiBatch(batch);
+  }
+
+  async batchesRetrieve(batchId: string): Promise<AiBatchResult> {
+    const batch = await this.client.batches.retrieve(batchId);
+    return mapOpenAiBatch(batch);
+  }
+
+  async batchesCancel(batchId: string): Promise<AiBatchResult> {
+    const batch = await this.client.batches.cancel(batchId);
+    return mapOpenAiBatch(batch);
+  }
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: openai SDK types vary by version
+function mapOpenAiFile(file: any): AiFileResult {
+  return {
+    id: file.id,
+    filename: file.filename,
+    bytes: file.bytes,
+    status: file.status,
+    purpose: file.purpose,
+    createdAt: file.created_at,
+  };
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: openai SDK types vary by version
+function mapOpenAiBatch(batch: any): AiBatchResult {
+  return {
+    id: batch.id,
+    status: batch.status as AiBatchStatus,
+    inputFileId: batch.input_file_id,
+    outputFileId: batch.output_file_id ?? undefined,
+    errorFileId: batch.error_file_id ?? undefined,
+    endpoint: batch.endpoint,
+    requestCounts: batch.request_counts
+      ? {
+          total: batch.request_counts.total,
+          completed: batch.request_counts.completed,
+          failed: batch.request_counts.failed,
+        }
+      : undefined,
+    createdAt: batch.created_at,
+    completedAt: batch.completed_at ?? undefined,
+    cancelledAt: batch.cancelled_at ?? undefined,
+    failedAt: batch.failed_at ?? undefined,
+    metadata: batch.metadata ?? null,
+    errors: batch.errors ?? null,
+  };
 }

--- a/packages/backend-base/src/shared/ai/openai.provider.ts
+++ b/packages/backend-base/src/shared/ai/openai.provider.ts
@@ -1,0 +1,53 @@
+import OpenAI from "openai";
+import type {
+  AiChatOptions,
+  AiChatResponse,
+  AiProvider,
+} from "./ai-provider.interface";
+
+/**
+ * OpenAI implementation of AiProvider. Uses the `openai` SDK + chat completions API.
+ *
+ * Apikey from `OPEN_AI_KEY` env. Models passed through as-is.
+ */
+export class OpenAiProvider implements AiProvider {
+  readonly name = "openai";
+  private readonly client: OpenAI;
+
+  constructor(apiKey?: string) {
+    const key = apiKey ?? process.env.OPEN_AI_KEY;
+    if (!key) {
+      throw new Error(
+        "OPEN_AI_KEY env not set; cannot construct OpenAiProvider",
+      );
+    }
+    this.client = new OpenAI({ apiKey: key });
+  }
+
+  async chatComplete(opts: AiChatOptions): Promise<AiChatResponse> {
+    const completion = await this.client.chat.completions.create({
+      model: opts.model,
+      messages: opts.messages,
+      ...(opts.temperature !== undefined && { temperature: opts.temperature }),
+      ...(opts.maxTokens !== undefined && { max_tokens: opts.maxTokens }),
+      ...(opts.responseFormat && { response_format: opts.responseFormat }),
+    });
+
+    const choice = completion.choices[0];
+    if (!choice?.message?.content) {
+      throw new Error(`OpenAI returned no content for model=${opts.model}`);
+    }
+
+    return {
+      content: choice.message.content,
+      model: completion.model,
+      ...(completion.usage && {
+        usage: {
+          promptTokens: completion.usage.prompt_tokens,
+          completionTokens: completion.usage.completion_tokens,
+          totalTokens: completion.usage.total_tokens,
+        },
+      }),
+    };
+  }
+}

--- a/packages/backend-base/src/shared/ai/openai.provider.ts
+++ b/packages/backend-base/src/shared/ai/openai.provider.ts
@@ -59,7 +59,6 @@ export class OpenAiProvider implements AiProvider {
   }
 
   async responsesCreate(opts: AiResponseOptions): Promise<AiResponseResult> {
-    // biome-ignore lint/suspicious/noExplicitAny: OpenAI Responses API types lag SDK
     const response = await (this.client as any).responses.create({
       model: opts.model,
       ...(opts.instructions !== undefined && {
@@ -118,7 +117,6 @@ export class OpenAiProvider implements AiProvider {
   }
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: openai SDK types vary by version
 function mapOpenAiFile(file: any): AiFileResult {
   return {
     id: file.id,
@@ -130,7 +128,6 @@ function mapOpenAiFile(file: any): AiFileResult {
   };
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: openai SDK types vary by version
 function mapOpenAiBatch(batch: any): AiBatchResult {
   return {
     id: batch.id,

--- a/packages/backend-base/src/shared/ai/stub.provider.ts
+++ b/packages/backend-base/src/shared/ai/stub.provider.ts
@@ -53,7 +53,10 @@ export class StubAiProvider implements AiProvider {
   // should mock this provider directly rather than rely on these stubs.
   private fileCounter = 0;
   private batchCounter = 0;
-  private files = new Map<string, { name: string; bytes: number; content: string }>();
+  private files = new Map<
+    string,
+    { name: string; bytes: number; content: string }
+  >();
   private batches = new Map<string, AiBatchResult>();
 
   async filesCreate(opts: AiFileCreateOptions): Promise<AiFileResult> {

--- a/packages/backend-base/src/shared/ai/stub.provider.ts
+++ b/packages/backend-base/src/shared/ai/stub.provider.ts
@@ -2,6 +2,8 @@ import type {
   AiChatOptions,
   AiChatResponse,
   AiProvider,
+  AiResponseOptions,
+  AiResponseResult,
 } from "./ai-provider.interface";
 
 /**
@@ -30,8 +32,15 @@ export class StubAiProvider implements AiProvider {
           0,
         ),
         completionTokens: 16,
-        totalTokens: 0, // recomputed below
+        totalTokens: 0,
       },
+    };
+  }
+
+  async responsesCreate(opts: AiResponseOptions): Promise<AiResponseResult> {
+    return {
+      outputText: `[stub-responses:${opts.model}] ${opts.input.slice(0, 80)}`,
+      model: `stub-${opts.model}`,
     };
   }
 }

--- a/packages/backend-base/src/shared/ai/stub.provider.ts
+++ b/packages/backend-base/src/shared/ai/stub.provider.ts
@@ -1,0 +1,37 @@
+import type {
+  AiChatOptions,
+  AiChatResponse,
+  AiProvider,
+} from "./ai-provider.interface";
+
+/**
+ * Stub AI provider for tests and dev environments.
+ *
+ * Returns a deterministic, low-cost response so tests don't burn OpenAI billing
+ * and don't depend on network. The output is keyed on the last user message so
+ * snapshot tests are stable.
+ */
+export class StubAiProvider implements AiProvider {
+  readonly name = "stub";
+
+  async chatComplete(opts: AiChatOptions): Promise<AiChatResponse> {
+    const lastUserMessage = opts.messages
+      .slice()
+      .reverse()
+      .find((m) => m.role === "user");
+    const echo = lastUserMessage?.content ?? "";
+
+    return {
+      content: `[stub:${opts.model}] ${echo.slice(0, 80)}`,
+      model: `stub-${opts.model}`,
+      usage: {
+        promptTokens: opts.messages.reduce(
+          (acc, m) => acc + Math.ceil(m.content.length / 4),
+          0,
+        ),
+        completionTokens: 16,
+        totalTokens: 0, // recomputed below
+      },
+    };
+  }
+}

--- a/packages/backend-base/src/shared/ai/stub.provider.ts
+++ b/packages/backend-base/src/shared/ai/stub.provider.ts
@@ -1,6 +1,10 @@
 import type {
+  AiBatchCreateOptions,
+  AiBatchResult,
   AiChatOptions,
   AiChatResponse,
+  AiFileCreateOptions,
+  AiFileResult,
   AiProvider,
   AiResponseOptions,
   AiResponseResult,
@@ -42,5 +46,90 @@ export class StubAiProvider implements AiProvider {
       outputText: `[stub-responses:${opts.model}] ${opts.input.slice(0, 80)}`,
       model: `stub-${opts.model}`,
     };
+  }
+
+  // Files / Batch — deterministic in-memory fakes. Keyed on input id so the
+  // same id consistently round-trips. Tests that need real OpenAI semantics
+  // should mock this provider directly rather than rely on these stubs.
+  private fileCounter = 0;
+  private batchCounter = 0;
+  private files = new Map<string, { name: string; bytes: number; content: string }>();
+  private batches = new Map<string, AiBatchResult>();
+
+  async filesCreate(opts: AiFileCreateOptions): Promise<AiFileResult> {
+    const id = `stub-file-${++this.fileCounter}`;
+    const bytes = await opts.file
+      .arrayBuffer()
+      .then((b) => b.byteLength)
+      .catch(() => 0);
+    const content = await opts.file.text().catch(() => "");
+    this.files.set(id, { name: opts.file.name, bytes, content });
+    return {
+      id,
+      filename: opts.file.name,
+      bytes,
+      status: "processed",
+      purpose: opts.purpose,
+      createdAt: Math.floor(Date.now() / 1000),
+    };
+  }
+
+  async filesRetrieve(fileId: string): Promise<AiFileResult> {
+    const file = this.files.get(fileId);
+    if (!file) {
+      throw new Error(`stub: file ${fileId} not found`);
+    }
+    return {
+      id: fileId,
+      filename: file.name,
+      bytes: file.bytes,
+      status: "processed",
+      createdAt: Math.floor(Date.now() / 1000),
+    };
+  }
+
+  async filesContent(fileId: string): Promise<Response> {
+    const file = this.files.get(fileId);
+    if (!file) {
+      throw new Error(`stub: file ${fileId} not found`);
+    }
+    return new Response(file.content);
+  }
+
+  async batchesCreate(opts: AiBatchCreateOptions): Promise<AiBatchResult> {
+    const id = `stub-batch-${++this.batchCounter}`;
+    const result: AiBatchResult = {
+      id,
+      status: "validating",
+      inputFileId: opts.inputFileId,
+      endpoint: opts.endpoint,
+      requestCounts: { total: 0, completed: 0, failed: 0 },
+      createdAt: Math.floor(Date.now() / 1000),
+      metadata: opts.metadata ?? null,
+    };
+    this.batches.set(id, result);
+    return result;
+  }
+
+  async batchesRetrieve(batchId: string): Promise<AiBatchResult> {
+    const batch = this.batches.get(batchId);
+    if (!batch) {
+      throw new Error(`stub: batch ${batchId} not found`);
+    }
+    return batch;
+  }
+
+  async batchesCancel(batchId: string): Promise<AiBatchResult> {
+    const batch = this.batches.get(batchId);
+    if (!batch) {
+      throw new Error(`stub: batch ${batchId} not found`);
+    }
+    const cancelled: AiBatchResult = {
+      ...batch,
+      status: "cancelled",
+      cancelledAt: Math.floor(Date.now() / 1000),
+    };
+    this.batches.set(batchId, cancelled);
+    return cancelled;
   }
 }

--- a/packages/backend-base/src/topics/services/topic.service.ts
+++ b/packages/backend-base/src/topics/services/topic.service.ts
@@ -1,4 +1,8 @@
 import type { Static } from "elysia";
+// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
+// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
+// as follow-up to feat-integrations br-int-001.
+
 import OpenAI from "openai";
 import { BibleRepository } from "../../bible/repository/bible.repository";
 import { PromptRepository } from "../../bible/repository/prompt.repository";

--- a/packages/backend-base/src/topics/services/topic.service.ts
+++ b/packages/backend-base/src/topics/services/topic.service.ts
@@ -1,12 +1,8 @@
 import type { Static } from "elysia";
-// TODO(D-001): direct OpenAI usage. Migrate to AiProvider abstraction in `../shared/ai`
-// once the abstraction supports OpenAI Responses API + Batch API + Files API. Tracked
-// as follow-up to feat-integrations br-int-001.
-
-import OpenAI from "openai";
 import { BibleRepository } from "../../bible/repository/bible.repository";
 import { PromptRepository } from "../../bible/repository/prompt.repository";
 import { SubtitleService } from "../../bible/services/subtitle.service";
+import { type AiProvider, getAiProvider } from "../../shared/ai";
 import type { db } from "../../shared/shared.plugin";
 import { parseAndInjectVerses } from "../../shared/verse-parser";
 import type { TopicDto, UpdateTopicDto } from "../dto/topic.dto";
@@ -18,6 +14,13 @@ export class TopicService {
   private bibleRepository: BibleRepository;
   private subtitleService: SubtitleService;
   private promptRepository: PromptRepository;
+  // Lazy: TopicService is instantiated eagerly at plugin load time, but
+  // OpenAiProvider's constructor requires OPEN_AI_KEY. Resolve on first use.
+  private _ai: AiProvider | null = null;
+  private get ai(): AiProvider {
+    if (!this._ai) this._ai = getAiProvider();
+    return this._ai;
+  }
 
   constructor(private readonly db: db) {
     this.topicRepository = new TopicRepository(this.db);
@@ -365,23 +368,19 @@ export class TopicService {
         )
         .join("\n");
 
-      // Call GPT-5 synchronously using the same pattern as bible.plugin.ts
-      const openaiClient = new OpenAI({
-        apiKey: process.env.OPEN_AI_KEY,
-      });
-
-      const response = await openaiClient.responses.create({
+      // Call GPT-5 via the AiProvider abstraction (D-001)
+      const response = await this.ai.responsesCreate({
         model: "gpt-5",
-        reasoning: { effort: "medium" },
+        reasoningEffort: "medium",
         instructions: "", // We leave instructions empty as requested
         input: prompt.prompt
           .replace("{category_name}", category.toLowerCase())
           .replace("{topics_list}", topicsData),
-        max_output_tokens: 50000,
+        maxOutputTokens: 50000,
       });
 
       // Parse the response - expect format: "1. Topic Name\n2. Topic Name\n..."
-      const sortedLines = (response.output_text || "")
+      const sortedLines = response.outputText
         .split("\n")
         .filter((line: string) => line.trim() !== "");
       const sortedTopicNames = sortedLines.map((line: string) => {


### PR DESCRIPTION
## Summary

Split from epic #208. Introduces an `AiProvider` abstraction and migrates all consumers off direct OpenAI client usage.

- New `AiProvider` interface + `OpenAiProvider` + `StubProvider`.
- Expanded with `responsesCreate`, Files API, Batch API.
- Migrates `topic.service` and 3 admin services through the abstraction.

## Commits

- `33e677c` refactor(ai): introduce AiProvider abstraction (D-001)
- `994f9e1` feat(ai): expand AiProvider with responsesCreate; refactor 2 admin services
- `adfbf48` refactor(ai): route topic.service through AiProvider abstraction
- `db5d0d7` refactor(ai): expand AiProvider with Files+Batch APIs and migrate all consumers
- `8c9d2fd` fix(ai): biome lint cleanup on AiProvider impls

## Risk

Medium — wide consumer migration but contained under `packages/backend-base/src/shared/ai/*` + 3 admin services + `topic.service`. Stub provider eases test mocking.

## Test plan

- [ ] CI green (lint, type, tests).
- [ ] Smoke test: trigger an explanation generation, batch operation, and topic service end-to-end.