### PR TITLE
fix(makefile): use cp -n for .env files in install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 install:
 	docker compose up -d
 	sleep 10s
-	cp apps/backend/.env.example apps/backend/.env
-	cp apps/frontend-next/.env.example apps/frontend-next/.env
-	cp packages/backend-base/.env.example packages/backend-base/.env
-	cp packages/database/.env.example packages/database/.env
+	cp -n apps/backend/.env.example apps/backend/.env
+	cp -n apps/frontend-next/.env.example apps/frontend-next/.env
+	cp -n packages/backend-base/.env.example packages/backend-base/.env
+	cp -n packages/database/.env.example packages/database/.env
 	bun install --frozen-lockfile
 	cd packages/database && bun migrate:deploy
 	cd packages/database && bun db:seed


### PR DESCRIPTION
## Summary

- Switch the four `cp` lines in `install` to `cp -n` (no-clobber) so re-running `make install` no longer silently overwrites local `.env` edits.

## Why

Discovered during VERA-2: a returning developer re-runs `make install` and loses any local edits in their `.env` files because the target uses plain `cp`. `cp -n` skips when the destination exists, preserving local state.

## Test plan

- [x] `make install` on a clean clone still seeds all four `.env` files
- [x] `make install` on a repo with pre-existing `.env` files leaves them untouched

Refs: VERA-11