### PR TITLE
fix(frontend-next): pin Turbopack root to silence lockfile warning

### DIFF
--- a/apps/frontend-next/next.config.mjs
+++ b/apps/frontend-next/next.config.mjs
@@ -1,4 +1,8 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import withPWA from "@ducanh2912/next-pwa";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const cacheLoggingPlugin = {
   cacheKeyWillBeUsed: async ({ request, mode }) => {
@@ -52,6 +56,13 @@ const cacheLoggingPlugin = {
 const nextConfig = {
   // Using standalone output mode for OpenNext adapter
   output: "standalone",
+  // Pin Turbopack workspace root to the verse-mate monorepo root so it
+  // picks repos/verse-mate/bun.lock instead of an outer lockfile (e.g.
+  // specwise-verse-mate/bun.lock). Silences the "multiple lockfiles
+  // detected" warning emitted on first dev run.
+  turbopack: {
+    root: path.join(__dirname, "..", ".."),
+  },
   typescript: {
     ignoreBuildErrors: true,
   },


### PR DESCRIPTION
## Summary
- Set `turbopack.root` in `apps/frontend-next/next.config.mjs` to the verse-mate monorepo root
- Stops Next.js 15 Turbopack from picking the outer `specwise-verse-mate/bun.lock` over `repos/verse-mate/bun.lock`
- Cosmetic only; every dev sees the warning on first `next dev`

Discovered during VERA-2. Tracked as VERA-13.

## Test plan
- [x] `node --check apps/frontend-next/next.config.mjs` passes
- [x] `next dev --turbopack` boots without the `We detected multiple lockfiles` warning

Co-Authored-By: Paperclip <noreply@paperclip.ing>