### PR TITLE
fix(docs): correct backend port references (3001 → 4000)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ make install  # Sets up Docker, env files, installs dependencies, runs migration
 
 ### Development
 ```bash
-bun dev       # Runs both backend (port 3001) and frontend (port 3000) concurrently
+bun dev       # Runs both backend (port 4000) and frontend (port 3000) concurrently
 ```
 
 ### Code Quality
@@ -49,7 +49,7 @@ cd apps/frontend-next && bun build  # Build frontend
 ### Monorepo Structure
 ```
 /apps
-  /backend - Elysia API server (port 3001)
+  /backend - Elysia API server (port 4000)
   /frontend-next - Next.js app (port 3000) — the logged-in PWA at app.versemate.org
   /website - Marketing website (port 3002) — the public site at versemate.org
 /packages

--- a/agent-os/product/tech-stack.md
+++ b/agent-os/product/tech-stack.md
@@ -86,7 +86,7 @@
 ### Monorepo Organization
 ```
 /apps
-  /backend - Elysia API server (port 3001)
+  /backend - Elysia API server (port 4000)
   /frontend-next - Next.js application (port 3000)
   /website - Marketing website
 

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -37,7 +37,7 @@ TTS_MODEL_OPENAI=tts-1-hd
 EXPLANATION_AUDIO_STUB_PATH=./fixtures/explanation-audio-stub.mp3
 
 # SSO Authentication
-BACKEND_URL=http://localhost:3001
+BACKEND_URL=http://localhost:4000
 FRONTEND_URL=http://localhost:3000
 
 # Google OAuth 2.0

--- a/apps/frontend-next/.dev.vars
+++ b/apps/frontend-next/.dev.vars
@@ -1,3 +1,3 @@
-API_URL=http://localhost:3001
+API_URL=http://localhost:4000
 APP_URL=http://localhost:3000
 NEXT_PUBLIC_ASK_VERSE_MATE=false

--- a/packages/backend-base/.env.example
+++ b/packages/backend-base/.env.example
@@ -34,7 +34,7 @@ TTS_MODEL_OPENAI=tts-1-hd
 EXPLANATION_AUDIO_STUB_PATH=./fixtures/explanation-audio-stub.mp3
 
 # SSO Authentication
-BACKEND_URL=http://localhost:3001
+BACKEND_URL=http://localhost:4000
 FRONTEND_URL=http://localhost:3000
 
 # Google OAuth 2.0


### PR DESCRIPTION
## Summary

Backend listens on `PORT=4000` (see `apps/backend/.env.example` and the OpenAPI `servers[]` entry in `apps/backend/src/index.ts`), but several docs and env templates still pointed at `3001`. This sent contributors to the wrong port and broke local SSO callbacks during VERA-2 bring-up.

Updated:
- `CLAUDE.md` — dev section + monorepo diagram
- `agent-os/product/tech-stack.md` — monorepo diagram
- `apps/backend/.env.example` — `BACKEND_URL`
- `packages/backend-base/.env.example` — `BACKEND_URL`
- `apps/frontend-next/.dev.vars` — `API_URL`

Refs VERA-10. No code logic changes — doc/env defaults only.

## Test plan
- [ ] `bun dev` still starts backend on 4000 (no behavior change; PORT default unchanged)
- [ ] `grep -rn 3001` shows no remaining stale backend-port references (only legitimate non-port matches in lexicon data files)
