### PR TITLE
fix(frontend-base): gate end-user CTAs in SignIn behind mode="admin" (VERA-28)

### DIFF
--- a/apps/frontend-next/src/app/(auth)/login/page.tsx
+++ b/apps/frontend-next/src/app/(auth)/login/page.tsx
@@ -30,7 +30,7 @@ export default function Login() {
       <Suspense fallback={null}>
         <AdminRequiredBanner />
       </Suspense>
-      <SignIn />
+      <SignIn mode="admin" />
     </AuthWrapperPage>
   );
 }

--- a/packages/frontend-base/src/auth/SignIn/index.tsx
+++ b/packages/frontend-base/src/auth/SignIn/index.tsx
@@ -18,9 +18,11 @@ import { useSignInForm } from "./useSignInForm";
 
 export interface SignInProps {
   onSwitch?: (mode: "signup") => void;
+  mode?: "admin" | "end_user";
 }
 
-export function SignIn({ onSwitch }: SignInProps) {
+export function SignIn({ onSwitch, mode = "end_user" }: SignInProps) {
+  const isAdmin = mode === "admin";
   const { ssoGoogleEnabled, ssoAppleEnabled, apiUrl } = useStore($env, {
     keys: ["ssoGoogleEnabled", "ssoAppleEnabled", "apiUrl"],
   });
@@ -207,23 +209,27 @@ export function SignIn({ onSwitch }: SignInProps) {
           Login
         </Button>
       </form>
-      <Text align="center" color="var(--gray)">
-        Don't have account?{" "}
-        {onSwitch ? (
-          <button
-            type="button"
-            onClick={() => onSwitch("signup")}
-            className={sharedStyles.switchButton}
-          >
-            Create New Account
-          </button>
-        ) : (
-          <Link href="/create-account">Create New Account</Link>
-        )}
-      </Text>
-      <Text align="center" color="var(--gray)">
-        <Link href="/">Continue without an account</Link>
-      </Text>
+      {!isAdmin && (
+        <Text align="center" color="var(--gray)">
+          Don't have account?{" "}
+          {onSwitch ? (
+            <button
+              type="button"
+              onClick={() => onSwitch("signup")}
+              className={sharedStyles.switchButton}
+            >
+              Create New Account
+            </button>
+          ) : (
+            <Link href="/create-account">Create New Account</Link>
+          )}
+        </Text>
+      )}
+      {!isAdmin && (
+        <Text align="center" color="var(--gray)">
+          <Link href="/">Continue without an account</Link>
+        </Text>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Non-blocking follow-up from QA on VERA-22. The shared `SignIn` component in `packages/frontend-base` rendered two dead anchors in admin `/login`:

```html
<a href="/create-account">Create New Account</a>
<a href="/">Continue without an account</a>
```

Both targets are middleware-redirected to `/login` in `apps/frontend-next` (redirect loop, UX-only — not a security issue).

## Changes

- `packages/frontend-base/src/auth/SignIn/index.tsx` — add optional `mode?: "admin" | "end_user"` prop (default `end_user`). When `mode === "admin"`, skip both end-user CTAs.
- `apps/frontend-next/src/app/(auth)/login/page.tsx` — pass `mode="admin"`.
- Mobile/end-user app rendering of `SignIn` is unchanged (default mode `end_user`).

## DoD

- [x] `apps/frontend-next` `/login` HTML no longer contains the two anchors above.
- [x] Mobile/end-user app rendering of `SignIn` unchanged (default-prop kept identical behavior).
- [x] Typecheck green (`bun tsc` clean; pre-commit hook re-ran tsc on staged files).

Base is the VERA-22 branch so this stacks on top of that PR.

Issue: VERA-28
