### PR TITLE
fix(frontend-next): drop year-long s-maxage on admin HTML (VERA-22 follow-up)

### DIFF
--- a/apps/frontend-next/src/middleware.ts
+++ b/apps/frontend-next/src/middleware.ts
@@ -4,6 +4,14 @@ import { ACCESS_TOKEN_COOKIE } from "./lib/utils";
 const LOGIN_PATH = "/login";
 const ADMIN_HOME = "/admin";
 const ADMIN_REQUIRED_REDIRECT = `${LOGIN_PATH}?error=admin_required`;
+// Admin app — never cache HTML at the CDN. Overrides the default
+// s-maxage=31536000 that OpenNext applies to statically prerendered routes.
+const NO_STORE = "private, no-store";
+
+function withNoStore(response: NextResponse): NextResponse {
+  response.headers.set("Cache-Control", NO_STORE);
+  return response;
+}
 
 function isPublicPath(pathname: string): boolean {
   if (pathname === LOGIN_PATH) return true;
@@ -17,7 +25,7 @@ function redirectToLogin(request: NextRequest): NextResponse {
   const url = request.nextUrl.clone();
   url.pathname = LOGIN_PATH;
   url.search = "";
-  return NextResponse.redirect(url);
+  return withNoStore(NextResponse.redirect(url));
 }
 
 function redirectAdminRequired(request: NextRequest): NextResponse {
@@ -26,7 +34,7 @@ function redirectAdminRequired(request: NextRequest): NextResponse {
   url.search = "?error=admin_required";
   const response = NextResponse.redirect(url);
   response.cookies.delete(ACCESS_TOKEN_COOKIE);
-  return response;
+  return withNoStore(response);
 }
 
 async function fetchIsAdmin(accessToken: string): Promise<boolean | null> {
@@ -59,13 +67,13 @@ export async function middleware(request: NextRequest) {
         const url = request.nextUrl.clone();
         url.pathname = ADMIN_HOME;
         url.search = "";
-        return NextResponse.redirect(url);
+        return withNoStore(NextResponse.redirect(url));
       }
       if (isAdmin === false) {
         return redirectAdminRequired(request);
       }
     }
-    return NextResponse.next();
+    return withNoStore(NextResponse.next());
   }
 
   if (!accessToken) {
@@ -86,10 +94,10 @@ export async function middleware(request: NextRequest) {
     const url = request.nextUrl.clone();
     url.pathname = ADMIN_HOME;
     url.search = "";
-    return NextResponse.redirect(url);
+    return withNoStore(NextResponse.redirect(url));
   }
 
-  return NextResponse.next();
+  return withNoStore(NextResponse.next());
 }
 
 export const config = {


### PR DESCRIPTION
## Summary

Follow-up to [VERA-22](https://app.paperclip.ing/VERA/issues/VERA-22) (PR #231): kills the year-long CDN cache on admin HTML so staging actually serves new builds without manual Cloudflare purges. Rolls [VERA-23](https://app.paperclip.ing/VERA/issues/VERA-23)'s cache-header line item into this change.

- `apps/frontend-next/src/middleware.ts` now sets `Cache-Control: private, no-store` on every middleware response: pass-through `next()`, login redirects, admin-required redirects, and the `/ → /admin` redirect.
- Overrides the default `s-maxage=31536000` that OpenNext applies to statically prerendered routes — wrong for an admin app and the root cause of the stale-HTML smoke failures.

## Why this over a CF purge

- No new secret (CF API token) to manage.
- Removes the underlying bug instead of adding a manual purge ritual.
- Year-long s-maxage on an authenticated admin surface is a security smell (cached HTML can leak between sessions at the edge).

## Test plan

- [x] `bun tsc` clean.
- [x] Lint clean (pre-commit hook ran biome + tsc).
- [ ] After merge + deploy, smoke `https://staging.app.verse-mate.xyz/` — expect `cache-control: private, no-store` and a fresh response. Bust CF once with `?v=<short-sha>` if the prior cached entry is still served during revalidation.

🤖 Co-authored by Paperclip