### PR TITLE
feat(frontend-base): gate end-user CTAs in SignIn behind mode="admin" (VERA-28)

### DIFF
--- a/apps/frontend-next/src/app/(auth)/login/page.tsx
+++ b/apps/frontend-next/src/app/(auth)/login/page.tsx
@@ -30,7 +30,7 @@ export default function Login() {
       <Suspense fallback={null}>
         <AdminRequiredBanner />
       </Suspense>
-      <SignIn />
+      <SignIn mode="admin" />
     </AuthWrapperPage>
   );
 }

--- a/packages/frontend-base/src/auth/SignIn/index.tsx
+++ b/packages/frontend-base/src/auth/SignIn/index.tsx
@@ -18,9 +18,11 @@ import { useSignInForm } from "./useSignInForm";
 
 export interface SignInProps {
   onSwitch?: (mode: "signup") => void;
+  mode?: "admin" | "end_user";
 }
 
-export function SignIn({ onSwitch }: SignInProps) {
+export function SignIn({ onSwitch, mode = "end_user" }: SignInProps) {
+  const isAdmin = mode === "admin";
   const { ssoGoogleEnabled, ssoAppleEnabled, apiUrl } = useStore($env, {
     keys: ["ssoGoogleEnabled", "ssoAppleEnabled", "apiUrl"],
   });
@@ -207,23 +209,27 @@ export function SignIn({ onSwitch }: SignInProps) {
           Login
         </Button>
       </form>
-      <Text align="center" color="var(--gray)">
-        Don't have account?{" "}
-        {onSwitch ? (
-          <button
-            type="button"
-            onClick={() => onSwitch("signup")}
-            className={sharedStyles.switchButton}
-          >
-            Create New Account
-          </button>
-        ) : (
-          <Link href="/create-account">Create New Account</Link>
-        )}
-      </Text>
-      <Text align="center" color="var(--gray)">
-        <Link href="/">Continue without an account</Link>
-      </Text>
+      {!isAdmin && (
+        <Text align="center" color="var(--gray)">
+          Don't have account?{" "}
+          {onSwitch ? (
+            <button
+              type="button"
+              onClick={() => onSwitch("signup")}
+              className={sharedStyles.switchButton}
+            >
+              Create New Account
+            </button>
+          ) : (
+            <Link href="/create-account">Create New Account</Link>
+          )}
+        </Text>
+      )}
+      {!isAdmin && (
+        <Text align="center" color="var(--gray)">
+          <Link href="/">Continue without an account</Link>
+        </Text>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Re-opens [VERA-28](/VERA/issues/VERA-28) after PR #232 was auto-closed when its base `feat-admin-only-frontend/vera-22` was deleted post-VERA-22 squash-merge.

## Summary
- Adds optional `mode?: "admin" | "end_user"` prop on shared `SignIn` in `packages/frontend-base`. Defaults to `end_user` — mobile/end-user surface unchanged.
- When `mode === "admin"`, skips the two CTAs that loop back to `/login` in the admin app: `Create New Account` and `Continue without an account`.
- `apps/frontend-next/src/app/(auth)/login/page.tsx` passes `mode="admin"`.

## Verification
- `bun run tsc` clean on the rebased branch.
- Diff identical to the original VERA-28 commit (`fc71136`); only commit re-parented on `main`.

## QA
Once preview URL fires, hand off to QA for staging verify of `/login` HTML on `apps/frontend-next`.
