### PR TITLE
fix(ci): drop manual admin preview deploy job (VERA-29)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,51 +233,10 @@ jobs:
           workingDirectory: ./apps/frontend-next
           command: deploy --env ${{ env.CLOUDFLARE_ENV }}
 
-  # Optional: Deploy preview for PRs (admin app only)
-  admin-cloudflare-deploy-preview:
-    name: Admin CloudFlare PR Preview
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    needs: [build-backend, build-admin]
-    if: github.event_name == 'pull_request'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: 1.2.23
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Build frontend for deployment
-        working-directory: ./apps/frontend-next
-        run: bun run build:worker
-
-      - name: Deploy Preview to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: ./apps/frontend-next
-          command: versions upload --env ${{ env.CLOUDFLARE_ENV }} --preview-alias pr-${{ github.event.number }}
-
-      - name: Comment PR with preview URL
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const previewUrl = `https://pr-${{ github.event.number }}-v-m-preview-app.verse-mate.workers.dev`;
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `🚀 Admin preview deployment is ready! Check it out at: ${previewUrl}`
-            })
+  # Admin app PR previews are produced by Cloudflare Workers Builds Git
+  # integration (worker `v-m-preview`, URL `<branch>-v-m-preview.verse-mate.workers.dev`).
+  # The Cloudflare bot comments the live preview URL on each PR — no
+  # duplicate manual job here. See VERA-29.
 
   website-cloudflare-deploy:
     name: Website CloudFlare Deploy


### PR DESCRIPTION
## Summary

Drops the manual `admin-cloudflare-deploy-preview` job from `.github/workflows/build.yml`. That job uploaded a worker version to `v-m-preview-app` and commented `pr-<n>-v-m-preview-app.verse-mate.workers.dev`, a host that returns 404.

Cloudflare Workers Builds Git integration already auto-deploys PR branches to worker `v-m-preview` (URL `<branch>-v-m-preview.verse-mate.workers.dev`) and the Cloudflare bot posts the live preview URL on each PR. Keeping the manual job around was wasted CI minutes plus a dead-link comment.

Refs: VERA-29.

## Why option 2 (drop, don't rename)

Renaming `preview.name` in `wrangler.jsonc` to `v-m-preview` would collide with the Cloudflare-managed auto-deploy on the same worker. Eliminating the manual job removes the drift surface entirely.

## Test plan

- [ ] Open a fresh PR against `main` after this merges; confirm the Cloudflare bot comments a 200-returning preview URL.
- [ ] Confirm no duplicate preview deploy comments (only the Cloudflare bot one).
- [ ] Website preview job (`website-cloudflare-deploy-preview`) is untouched — out of scope for VERA-29 but likely has the same anti-pattern; tracked separately if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)