### PR TITLE
feat(audio): 0.5x speed option + localStorage persistence (VER-91)

### DIFF
--- a/packages/frontend-base/src/hooks/useAudioPlayerStore.test.ts
+++ b/packages/frontend-base/src/hooks/useAudioPlayerStore.test.ts
@@ -63,10 +63,35 @@ const sampleTrack: AudioTrack = {
   source_href: "/bible/1/1",
 };
 
+// Minimal localStorage + window shim so the SSR-guarded persistence path
+// in useAudioPlayerStore can be exercised under bun:test, which doesn't
+// ship a DOM. Real browser behavior is covered by the runtime store; this
+// shim only needs the getItem/setItem/removeItem surface.
+class FakeStorage {
+  private store = new Map<string, string>();
+  getItem(key: string) {
+    return this.store.get(key) ?? null;
+  }
+  setItem(key: string, value: string) {
+    this.store.set(key, value);
+  }
+  removeItem(key: string) {
+    this.store.delete(key);
+  }
+  clear() {
+    this.store.clear();
+  }
+}
+const fakeStorage = new FakeStorage();
+(globalThis as unknown as { window: { localStorage: FakeStorage } }).window = {
+  localStorage: fakeStorage,
+};
+
 describe("audioPlayerStore", () => {
   let el: FakeAudio;
 
   beforeEach(() => {
+    fakeStorage.clear();
     _resetAudioPlayerStore();
     el = new FakeAudio();
     audioPlayerActions._setAudioElement(el as unknown as HTMLAudioElement);
@@ -123,6 +148,13 @@ describe("audioPlayerStore", () => {
     audioPlayerActions.setSpeed(1.5);
     expect($speed.get()).toBe(1.5);
     expect(el.playbackRate).toBe(1.5);
+  });
+
+  it("setSpeed persists to localStorage (VER-91)", () => {
+    audioPlayerActions.setSpeed(0.5);
+    expect(fakeStorage.getItem("vm_audio_speed")).toBe("0.5");
+    audioPlayerActions.setSpeed(1.5);
+    expect(fakeStorage.getItem("vm_audio_speed")).toBe("1.5");
   });
 
   it("close: tears everything down", async () => {

--- a/packages/frontend-base/src/hooks/useAudioPlayerStore.ts
+++ b/packages/frontend-base/src/hooks/useAudioPlayerStore.ts
@@ -36,6 +36,21 @@ export const $playbackState = atom<AudioPlaybackState>("idle");
 export const $elapsedSeconds = atom<number>(0);
 export const $durationSeconds = atom<number>(0);
 export const $speed = atom<number>(1);
+
+// VER-91: hydrate $speed from localStorage. Guarded for SSR — Next.js
+// imports this store on the server during render, where localStorage
+// is undefined. Invalid/legacy values (e.g. 0.75) silently fall through
+// to the default of 1.
+const VALID_SPEEDS = [0.5, 1, 1.25, 1.5, 2];
+if (typeof window !== "undefined") {
+  const stored = Number.parseFloat(
+    window.localStorage.getItem("vm_audio_speed") ?? "",
+  );
+  if (VALID_SPEEDS.includes(stored)) {
+    $speed.set(stored);
+  }
+}
+
 export const $error = atom<string | null>(null);
 export const $dockVisible = atom<boolean>(false);
 export const $fullSheetOpen = atom<boolean>(false);
@@ -134,6 +149,9 @@ export const audioPlayerActions = {
   setSpeed(speed: number) {
     $speed.set(speed);
     if (audioElementRef) audioElementRef.playbackRate = speed;
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("vm_audio_speed", String(speed));
+    }
   },
 
   close() {

--- a/packages/frontend-base/src/ui/AudioPlayer/AudioFullSheet.tsx
+++ b/packages/frontend-base/src/ui/AudioPlayer/AudioFullSheet.tsx
@@ -30,7 +30,7 @@ import { AudioPlayerContext } from "./AudioPlayerContext";
 import { AudioResumeChip } from "./AudioResumeChip";
 import styles from "./audio-player.module.css";
 
-const SPEEDS = [0.75, 1, 1.25, 1.5, 2];
+const SPEEDS = [0.5, 1, 1.25, 1.5, 2];
 
 function formatTime(seconds: number): string {
   const mm = Math.floor(seconds / 60);


### PR DESCRIPTION
## Summary

Implements **Group A — Web** from the audio-playback-speed spec ([VER-80](/VER/issues/VER-80), [verse-mate-meta PR #9](https://github.com/verse-mate/verse-mate-meta/pull/9), spec folder `specs/2026-05-16-0129-audio-playback-speed/`).

- **A1** `AudioFullSheet.tsx` — `SPEEDS` constant: `0.75` → `0.5`. The speed row now reads `0.5×ㅤ1×ㅤ1.25×ㅤ1.5×ㅤ2×`.
- **A2** `useAudioPlayerStore.ts setSpeed` — writes the selected rate to `localStorage` under key `vm_audio_speed`.
- **A3** `useAudioPlayerStore.ts` module init — hydrates `$speed` from that key on first import; legacy `0.75` (not in `VALID_SPEEDS`) silently falls back to the default of `1`.

## Spec deviation (minor): SSR guard

The spec snippet used raw `localStorage` at module top level. This package is consumed by `apps/frontend-next` (Next.js), which imports the store during server render where `localStorage` is undefined. I wrapped both the read and write in `typeof window !== "undefined"` guards. This preserves the spec's intent (persist on the client, no-op elsewhere) without breaking SSR. Happy to revisit if the spec wants a different guard.

## Verification

- `bun test packages/frontend-base/src/hooks/useAudioPlayerStore.test.ts` — 10/10 pass, including a new case for `setSpeed → localStorage` (uses an in-test `FakeStorage` shim because `bun:test` has no DOM).
- `bun tsc` — clean.
- `bun lint` — clean for changed files (16 pre-existing warnings elsewhere are unrelated).

## Test plan (manual, browser)

- [ ] Open the audio full sheet → speed row shows `0.5×  1×  1.25×  1.5×  2×` (no `0.75×`).
- [ ] Select `1.5×` → reload → `1.5×` still active on first render (DevTools → Application → Local Storage shows `vm_audio_speed = "1.5"`).
- [ ] Manually set `vm_audio_speed = "0.75"` in DevTools → reload → player defaults to `1×`.
- [ ] Selecting `0.5×` fires `AUDIO_SPEED_CHANGED` with `toSpeed: 0.5` (event wiring unchanged).

## Parent

- [VER-91](/VER/issues/VER-91) — this ticket
- [VER-80](/VER/issues/VER-80) — feature spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)