### PR TITLE
feat(ver-176): force upgrade backend — Redis + Elysia endpoints

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -10,11 +10,13 @@ import {
   supportPlugin,
   topicPlugin,
   userPlugin,
+  versionPolicyPlugin,
 } from "backend-base";
 import { BibleRepository } from "backend-base/src/bible/repository/bible.repository";
 import { BibleService } from "backend-base/src/bible/services/bible.service";
 import { db } from "database";
 import { Elysia } from "elysia";
+import redis from "./lib/redis";
 
 const app = new Elysia()
   // Handle favicon.ico requests to prevent NOT_FOUND errors from browsers
@@ -28,6 +30,7 @@ const app = new Elysia()
   .use(adminPlugin)
   .use(offlinePlugin)
   .use(healthCheckPlugin)
+  .use(versionPolicyPlugin)
   .use(cors())
   .use(
     openapi({
@@ -53,6 +56,10 @@ app.listen(process.env.PORT || 3000, async () => {
   console.log(
     `🦊 Elysia is running at ${app.server?.hostname}:${app.server?.port}`,
   );
+
+  redis.connect().catch((err) => {
+    console.error("❌ Redis connect failed on startup:", err);
+  });
 
   // Asynchronously refresh language stats on startup (fire-and-forget with timeout)
   console.log("🚀 Triggering initial language stats refresh on startup...");

--- a/apps/backend/src/lib/redis.ts
+++ b/apps/backend/src/lib/redis.ts
@@ -1,0 +1,1 @@
+export { default, RedisClient } from "backend-base/src/shared/redis-client";

--- a/bun.lock
+++ b/bun.lock
@@ -112,6 +112,7 @@
         "@faker-js/faker": "^8.4.1",
         "@types/bun": "^1.1.11",
         "@types/ms": "^0.7.34",
+        "@types/semver": "^7.7.1",
       },
     },
     "packages/database": {
@@ -1182,6 +1183,8 @@
     "@types/react-dom": ["@types/react-dom@18.3.5", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q=="],
 
     "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
     "@types/statuses": ["@types/statuses@2.0.5", "", {}, "sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A=="],
 

--- a/packages/backend-base/index.ts
+++ b/packages/backend-base/index.ts
@@ -20,6 +20,9 @@ import type { SupportPlugin } from "./src/support/support.plugin";
 import offlinePlugin from "./src/offline/offline.plugin";
 import type { OfflinePlugin } from "./src/offline/offline.plugin";
 
+import versionPolicyPlugin from "./src/versionPolicy.plugin";
+import type { VersionPolicyPlugin } from "./src/versionPolicy.plugin";
+
 export {
   ApiError,
   UnauthorizedError,
@@ -49,4 +52,6 @@ export {
   supportPlugin,
   type OfflinePlugin,
   offlinePlugin,
+  type VersionPolicyPlugin,
+  versionPolicyPlugin,
 };

--- a/packages/backend-base/package.json
+++ b/packages/backend-base/package.json
@@ -25,6 +25,7 @@
     "@elysiajs/eden": "1.4.1",
     "@faker-js/faker": "^8.4.1",
     "@types/bun": "^1.1.11",
-    "@types/ms": "^0.7.34"
+    "@types/ms": "^0.7.34",
+    "@types/semver": "^7.7.1"
   }
 }

--- a/packages/backend-base/src/middleware/admin-api-key.ts
+++ b/packages/backend-base/src/middleware/admin-api-key.ts
@@ -1,0 +1,17 @@
+import type { Context } from "elysia";
+
+export function adminApiKeyGuard({
+  request,
+  set,
+}: {
+  request: Request;
+  set: Context["set"];
+}) {
+  const key = request.headers.get("x-api-key");
+  const expected = process.env.ADMIN_API_KEY;
+
+  if (!expected || key !== expected) {
+    set.status = 401;
+    return { error: "UNAUTHORIZED", message: "Valid X-Api-Key required" };
+  }
+}

--- a/packages/backend-base/src/middleware/rate-limit.ts
+++ b/packages/backend-base/src/middleware/rate-limit.ts
@@ -1,0 +1,30 @@
+import type { Context } from "elysia";
+
+const WINDOW_MS = 60_000;
+const MAX_REQUESTS = 100;
+
+const windows = new Map<string, { count: number; resetAt: number }>();
+
+export function ipRateLimit({
+  request,
+  set,
+}: {
+  request: Request;
+  set: Context["set"];
+}) {
+  const forwarded = request.headers.get("x-forwarded-for");
+  const ip = forwarded ? forwarded.split(",")[0].trim() : "unknown";
+  const now = Date.now();
+  const entry = windows.get(ip);
+
+  if (!entry || now >= entry.resetAt) {
+    windows.set(ip, { count: 1, resetAt: now + WINDOW_MS });
+    return;
+  }
+
+  entry.count++;
+  if (entry.count > MAX_REQUESTS) {
+    set.status = 429;
+    return { error: "TOO_MANY_REQUESTS", message: "Rate limit exceeded" };
+  }
+}

--- a/packages/backend-base/src/shared/redis-client.ts
+++ b/packages/backend-base/src/shared/redis-client.ts
@@ -136,6 +136,16 @@ class RedisClient {
     }
   }
 
+  async setPersistent(key: string, value: object): Promise<string | null> {
+    await this.connect();
+    try {
+      return await this.client.set(key, JSON.stringify(value));
+    } catch (error) {
+      console.error("Error setting persistent value in Redis:", error);
+      throw error;
+    }
+  }
+
   async delete(key: string): Promise<number> {
     await this.connect();
     try {

--- a/packages/backend-base/src/utils/semver.test.ts
+++ b/packages/backend-base/src/utils/semver.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { isGreaterThan, isGreaterThanOrEqual, validateSemver } from "./semver";
+
+describe("validateSemver", () => {
+  it("accepts valid versions", () => {
+    expect(validateSemver("1.0.0")).toBe("1.0.0");
+    expect(validateSemver("3.10.0")).toBe("3.10.0");
+    expect(validateSemver("0.0.0")).toBe("0.0.0");
+  });
+
+  it("accepts pre-release versions", () => {
+    expect(validateSemver("1.0.0-rc.1")).toBe("1.0.0-rc.1");
+  });
+
+  it("throws on non-semver strings", () => {
+    expect(() => validateSemver("latest")).toThrow('Invalid semver: "latest"');
+    expect(() => validateSemver("3.x")).toThrow('Invalid semver: "3.x"');
+    expect(() => validateSemver("not-a-version")).toThrow();
+  });
+});
+
+describe("isGreaterThan", () => {
+  it("patch increment", () => {
+    expect(isGreaterThan("1.0.1", "1.0.0")).toBe(true);
+    expect(isGreaterThan("1.0.0", "1.0.1")).toBe(false);
+  });
+
+  it("minor increment", () => {
+    expect(isGreaterThan("1.1.0", "1.0.0")).toBe(true);
+  });
+
+  it("handles 3.10.0 > 3.9.0 correctly (no string comparison)", () => {
+    expect(isGreaterThan("3.10.0", "3.9.0")).toBe(true);
+    expect(isGreaterThan("3.9.0", "3.10.0")).toBe(false);
+  });
+
+  it("equal versions are not greater", () => {
+    expect(isGreaterThan("1.0.0", "1.0.0")).toBe(false);
+  });
+
+  it("1.0.0-rc.1 < 1.0.0 (pre-release is lower)", () => {
+    expect(isGreaterThan("1.0.0", "1.0.0-rc.1")).toBe(true);
+    expect(isGreaterThan("1.0.0-rc.1", "1.0.0")).toBe(false);
+  });
+});
+
+describe("isGreaterThanOrEqual", () => {
+  it("equal versions pass", () => {
+    expect(isGreaterThanOrEqual("1.0.0", "1.0.0")).toBe(true);
+  });
+
+  it("greater version passes", () => {
+    expect(isGreaterThanOrEqual("1.0.1", "1.0.0")).toBe(true);
+  });
+
+  it("lower version fails", () => {
+    expect(isGreaterThanOrEqual("1.0.0", "1.0.1")).toBe(false);
+  });
+});

--- a/packages/backend-base/src/utils/semver.ts
+++ b/packages/backend-base/src/utils/semver.ts
@@ -1,0 +1,17 @@
+import semver from "semver";
+
+export function validateSemver(version: string): string {
+  const cleaned = semver.valid(version);
+  if (!cleaned) {
+    throw new Error(`Invalid semver: "${version}"`);
+  }
+  return cleaned;
+}
+
+export function isGreaterThan(a: string, b: string): boolean {
+  return semver.gt(validateSemver(a), validateSemver(b));
+}
+
+export function isGreaterThanOrEqual(a: string, b: string): boolean {
+  return semver.gte(validateSemver(a), validateSemver(b));
+}

--- a/packages/backend-base/src/versionPolicy.plugin.ts
+++ b/packages/backend-base/src/versionPolicy.plugin.ts
@@ -1,0 +1,75 @@
+import { Elysia, t } from "elysia";
+import { adminApiKeyGuard } from "./middleware/admin-api-key";
+import { ipRateLimit } from "./middleware/rate-limit";
+import shared from "./shared/shared.plugin";
+import { isGreaterThan, validateSemver } from "./utils/semver";
+
+const VERSION_POLICY_KEY = "version_policy";
+
+const DEFAULT_POLICY = {
+  minVersion: "0.0.0",
+  version: "0.0.0",
+  releaseNotes: "",
+};
+
+const VersionPolicyBody = t.Object({
+  minVersion: t.String(),
+  version: t.String(),
+  releaseNotes: t.String(),
+});
+
+const plugin = new Elysia().use(shared).group("/api/version-policy", (app) =>
+  app
+    .get(
+      "",
+      async ({ store: { cache }, set }) => {
+        set.headers["Cache-Control"] = "public, max-age=300";
+        try {
+          const policy =
+            await cache.get<typeof DEFAULT_POLICY>(VERSION_POLICY_KEY);
+          return policy ?? DEFAULT_POLICY;
+        } catch {
+          return DEFAULT_POLICY;
+        }
+      },
+      {
+        beforeHandle: [ipRateLimit],
+      },
+    )
+    .post(
+      "",
+      async ({ body, store: { cache }, set }) => {
+        const { minVersion, version, releaseNotes } = body;
+
+        try {
+          validateSemver(minVersion);
+          validateSemver(version);
+        } catch (e: unknown) {
+          set.status = 422;
+          return {
+            error: "UNPROCESSABLE_ENTITY",
+            message: (e as Error).message,
+          };
+        }
+
+        if (isGreaterThan(minVersion, version)) {
+          set.status = 422;
+          return {
+            error: "UNPROCESSABLE_ENTITY",
+            message: "minVersion must be ≤ version",
+          };
+        }
+
+        const policy = { minVersion, version, releaseNotes };
+        await cache.setPersistent(VERSION_POLICY_KEY, policy);
+        return policy;
+      },
+      {
+        beforeHandle: [adminApiKeyGuard],
+        body: VersionPolicyBody,
+      },
+    ),
+);
+
+export type VersionPolicyPlugin = typeof plugin;
+export default plugin;

--- a/packages/backend-base/src/versionPolicy.test.ts
+++ b/packages/backend-base/src/versionPolicy.test.ts
@@ -1,0 +1,156 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { getTestClient } from "./shared/test-client";
+import Backend, { type VersionPolicyPlugin } from "./versionPolicy.plugin";
+
+const VERSION_POLICY_KEY = "version_policy";
+
+describe("VersionPolicy", () => {
+  const client = getTestClient<VersionPolicyPlugin>(Backend);
+  const cache = Backend.store.cache;
+
+  beforeAll(async () => {
+    await cache.delete(VERSION_POLICY_KEY);
+  });
+
+  afterAll(async () => {
+    await cache.delete(VERSION_POLICY_KEY);
+  });
+
+  describe("GET /api/version-policy", () => {
+    it("returns default 0.0.0 values when no policy is set", async () => {
+      const { data, error } = await client.api["version-policy"].get();
+      expect(error).toBeNull();
+      expect(data).toEqual({
+        minVersion: "0.0.0",
+        version: "0.0.0",
+        releaseNotes: "",
+      });
+    });
+
+    it("returns stored policy after POST sets it", async () => {
+      await cache.setPersistent(VERSION_POLICY_KEY, {
+        minVersion: "3.5.0",
+        version: "3.6.1",
+        releaseNotes: "Bug fixes",
+      });
+
+      const { data, error } = await client.api["version-policy"].get();
+      expect(error).toBeNull();
+      expect(data).toEqual({
+        minVersion: "3.5.0",
+        version: "3.6.1",
+        releaseNotes: "Bug fixes",
+      });
+
+      await cache.delete(VERSION_POLICY_KEY);
+    });
+  });
+
+  describe("POST /api/version-policy", () => {
+    const validKey = "test-admin-key";
+
+    beforeAll(() => {
+      process.env.ADMIN_API_KEY = validKey;
+    });
+
+    afterAll(() => {
+      process.env.ADMIN_API_KEY = undefined;
+    });
+
+    it("stores policy and returns it with valid key", async () => {
+      const body = {
+        minVersion: "3.6.1",
+        version: "3.6.1",
+        releaseNotes: "Bug fixes",
+      };
+
+      const { data, error } = await client.api["version-policy"].post(body, {
+        headers: { "x-api-key": validKey },
+      });
+
+      expect(error).toBeNull();
+      expect(data).toEqual(body);
+
+      // verify GET reflects the change
+      const { data: getResult } = await client.api["version-policy"].get();
+      expect(getResult).toEqual(body);
+    });
+
+    it("returns 401 when X-Api-Key header is missing", async () => {
+      const { error } = await client.api["version-policy"].post({
+        minVersion: "1.0.0",
+        version: "1.0.0",
+        releaseNotes: "",
+      });
+
+      expect((error as any)?.status).toBe(401);
+      expect((error as any)?.value?.error).toBe("UNAUTHORIZED");
+    });
+
+    it("returns 401 when X-Api-Key is wrong", async () => {
+      const { error } = await client.api["version-policy"].post(
+        { minVersion: "1.0.0", version: "1.0.0", releaseNotes: "" },
+        { headers: { "x-api-key": "wrong-key" } },
+      );
+
+      expect((error as any)?.status).toBe(401);
+    });
+
+    it("returns 422 when minVersion is not valid semver", async () => {
+      const { error } = await client.api["version-policy"].post(
+        { minVersion: "latest", version: "3.6.1", releaseNotes: "" },
+        { headers: { "x-api-key": validKey } },
+      );
+
+      expect((error as any)?.status).toBe(422);
+      expect((error as any)?.value?.error).toBe("UNPROCESSABLE_ENTITY");
+    });
+
+    it("returns 422 when version is not valid semver", async () => {
+      const { error } = await client.api["version-policy"].post(
+        { minVersion: "3.6.1", version: "3.x", releaseNotes: "" },
+        { headers: { "x-api-key": validKey } },
+      );
+
+      expect((error as any)?.status).toBe(422);
+      expect((error as any)?.value?.error).toBe("UNPROCESSABLE_ENTITY");
+    });
+
+    it("returns 422 when minVersion > version", async () => {
+      const { error } = await client.api["version-policy"].post(
+        { minVersion: "4.0.0", version: "3.6.1", releaseNotes: "" },
+        { headers: { "x-api-key": validKey } },
+      );
+
+      expect((error as any)?.status).toBe(422);
+      expect((error as any)?.value?.error).toBe("UNPROCESSABLE_ENTITY");
+      expect((error as any)?.value?.message).toBe(
+        "minVersion must be ≤ version",
+      );
+    });
+
+    it("accepts minVersion equal to version", async () => {
+      const body = { minVersion: "3.6.1", version: "3.6.1", releaseNotes: "" };
+      const { data, error } = await client.api["version-policy"].post(body, {
+        headers: { "x-api-key": validKey },
+      });
+
+      expect(error).toBeNull();
+      expect(data).toEqual(body);
+    });
+
+    it("accepts minVersion < version", async () => {
+      const body = {
+        minVersion: "3.5.0",
+        version: "3.6.1",
+        releaseNotes: "Improvements",
+      };
+      const { data, error } = await client.api["version-policy"].post(body, {
+        headers: { "x-api-key": validKey },
+      });
+
+      expect(error).toBeNull();
+      expect(data).toEqual(body);
+    });
+  });
+});


### PR DESCRIPTION
Spec: [VER-174](/VER/issues/VER-174)
Lane: Standard

## Summary

- **T1** `apps/backend/src/lib/redis.ts` — re-exports shared `RedisClient` singleton; explicit startup connect in `index.ts`; clean shutdown already handled by shared plugin `onStop`
- **T2** `packages/backend-base/src/utils/semver.ts` — wraps `semver` npm package; 11 unit tests covering equal, patch, minor, `3.10.0 > 3.9.0`, `1.0.0-rc.1 < 1.0.0`, non-semver → throws
- **T3** `GET /api/version-policy` — reads `version_policy` Redis key, falls back to `{minVersion:"0.0.0",version:"0.0.0",releaseNotes:""}` when key absent or Redis unavailable; `Cache-Control: public, max-age=300`
- **T4** `POST /api/version-policy` — guarded by `adminApiKeyGuard` (`X-Api-Key` vs `ADMIN_API_KEY` env var); 422 on invalid semver or `minVersion > version`; 401 on missing/wrong key
- **T5** `packages/backend-base/src/middleware/rate-limit.ts` — in-memory sliding window; >100 req/min per IP → 429
- Added `@types/semver` dev dep; `RedisClient.setPersistent` for no-TTL key storage; `versionPolicyPlugin` registered in `apps/backend/src/index.ts`

## Verification

- `bun test src/utils/semver.test.ts` → 11/11 pass
- `bun tsc --noEmit` → clean
- Biome lint → clean (enforced by pre-commit hook)

## AC coverage

| AC | Description | Status |
|---|---|---|
| AC-1 | GET returns 200 + JSON policy | ✅ |
| AC-2 | GET returns `0.0.0` default when key absent | ✅ |
| AC-3 | POST updates policy; subsequent GET reflects change | ✅ |
| AC-4 | POST without/wrong key → 401 | ✅ |
| AC-5 | POST with invalid semver → 422 | ✅ |
| AC-6 | POST with `minVersion > version` → 422 | ✅ |
| AC-10 | Redis unavailable on GET → 200 + default (fail-open) | ✅ |