### PR TITLE
chore(bible): bundle multi-version ingest CLI into deployed image

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -31,8 +31,32 @@ bun dev
 ```
 |-- backend/
 |   |-- src/                 # Main source code
-|       |-- index.ts         # Entry point of the application
+|       |-- index.ts             # Elysia API server entry
+|       |-- ingest-versions.ts   # Multi-version Bible ingest CLI (bundled to dist/)
 ```
+
+## Bible ingest in production
+
+After a deploy, the multi-version Bible ingest loader can be run from inside
+the backend container. It is bundled into the production image as
+`dist/ingest-versions.js`:
+
+```bash
+# Inside the running backend container, with $POSTGRES_URL already set:
+bun ./dist/ingest-versions.js --input /path/to/output [--version KEY]
+```
+
+The `--input` directory must follow the layout produced by `verse-mate-web`'s
+`scripts/bible-ingest/build.py --all` (per-version `manifest.json` + per-book
+`<bookId>/<chapter>.json` files). Place that directory inside the container
+first — for example with `docker cp`, a mounted volume, or by downloading a
+tarball — since the loader reads from the local filesystem and does not
+fetch the data itself.
+
+The loader is idempotent: re-running updates existing verse text in place
+rather than duplicating rows. Use `--version KEY` to ingest one version at a
+time. Implementation lives in
+`packages/backend-base/src/bible/ingest-versions.ts`.
 
 ## Available Scripts
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -37,25 +37,33 @@ bun dev
 
 ## Bible ingest in production
 
-After a deploy, the multi-version Bible ingest loader can be run from inside
-the backend container. It is bundled into the production image as
-`dist/ingest-versions.js`:
+The multi-version Bible ingest loader is bundled into the production image
+as `dist/ingest-versions.js`, alongside `dist/index.js` and `dist/migrator.js`.
+It reads the per-version JSON output of `verse-mate-web`'s
+`scripts/bible-ingest/build.py --all` and upserts ~340k verses + localized
+book names across all 11 open-licensed translations.
+
+From inside the deployed backend container (e.g. the DO web terminal — the
+container's `$POSTGRES_URL` env handles the DB connection automatically):
 
 ```bash
-# Inside the running backend container, with $POSTGRES_URL already set:
+# Replace <URL> with a link to a tarball of the build.py output/ tree.
+curl -L <URL> -o /tmp/o.tar.gz \
+  && mkdir -p /tmp/output \
+  && tar -xzf /tmp/o.tar.gz -C /tmp/output \
+  && bun ./dist/ingest-versions.js --input /tmp/output
+```
+
+Or, if the `output/` tree is already inside the container (via `docker cp`,
+a mounted volume, etc.):
+
+```bash
 bun ./dist/ingest-versions.js --input /path/to/output [--version KEY]
 ```
 
-The `--input` directory must follow the layout produced by `verse-mate-web`'s
-`scripts/bible-ingest/build.py --all` (per-version `manifest.json` + per-book
-`<bookId>/<chapter>.json` files). Place that directory inside the container
-first — for example with `docker cp`, a mounted volume, or by downloading a
-tarball — since the loader reads from the local filesystem and does not
-fetch the data itself.
-
-The loader is idempotent: re-running updates existing verse text in place
-rather than duplicating rows. Use `--version KEY` to ingest one version at a
-time. Implementation lives in
+The loader is idempotent — re-running updates existing verse text in place
+rather than duplicating rows — so it's safe to retry if interrupted. Pass
+`--version KEY` to ingest one version at a time. Implementation lives in
 `packages/backend-base/src/bible/ingest-versions.ts`.
 
 ## Available Scripts

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -4,7 +4,7 @@
   "main": "./src/index.ts",
   "module": "./src/index.ts",
   "scripts": {
-    "build": "bun build ./src/index.ts --target bun --outdir ./dist",
+    "build": "bun build ./src/index.ts ./src/ingest-versions.ts --target bun --outdir ./dist",
     "dev": "bun run --watch src/index.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/apps/backend/src/ingest-versions.ts
+++ b/apps/backend/src/ingest-versions.ts
@@ -1,0 +1,45 @@
+/**
+ * Production CLI entry for the multi-version Bible ingest loader.
+ *
+ * In the deployed backend image this is bundled to dist/ingest-versions.js
+ * alongside dist/index.js + dist/migrator.js, so it can be run from inside
+ * the running backend container after a deploy:
+ *
+ *   bun ./dist/ingest-versions.js --input <dir> [--version KEY]
+ *
+ * The <dir> must contain the output of verse-mate-web's
+ * scripts/bible-ingest/build.py (one subdirectory per version key, each with
+ * manifest.json + <bookId>/<chapter>.json files). Place that directory
+ * inside the container before running (e.g. via `docker cp` or by mounting a
+ * volume), since the underlying loader reads from the local filesystem and
+ * does not fetch the data itself.
+ *
+ * Idempotent: re-running updates existing verse text rather than duplicating
+ * rows. Pass --version KEY to ingest a single version at a time.
+ */
+import path from "node:path";
+import { parseArgs } from "node:util";
+import { main } from "backend-base/src/bible/ingest-versions";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    input: { type: "string" },
+    version: { type: "string" },
+  },
+  allowPositionals: true,
+});
+
+if (!values.input) {
+  console.error(
+    "usage: bun ./dist/ingest-versions.js --input <dir> [--version KEY]",
+  );
+  process.exit(2);
+}
+
+main(path.resolve(values.input), values.version)
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

Make the multi-version Bible ingest loader from #242 runnable from inside the deployed backend container. Before this PR, the loader source lived only under `packages/backend-base/src/bible/ingest-versions.ts` — which is not copied into the production image — so #242 shipped storage + a loader script but no way to actually invoke it in prod without rebuilding.

- New `apps/backend/src/ingest-versions.ts` — thin CLI wrapper that imports `main()` from the loader, parses `--input` and `--version` args, exits with the right code.
- `apps/backend/package.json` — extends the existing `bun build ./src/index.ts` to also bundle `./src/ingest-versions.ts`, producing `dist/index.js` + `dist/ingest-versions.js`. The Dockerfile already does `COPY apps/backend/dist ./dist`, so the new file lands in `/app/dist/ingest-versions.js` automatically — no Dockerfile change needed.
- `apps/backend/README.md` — operational note documenting the prod ingest workflow.

After deploy, the loader can be run from inside the backend container:

```bash
bun ./dist/ingest-versions.js --input <dir> [--version KEY]
```

The bundled file is ~0.5 MB. `kysely` / `pg` / etc. are inlined the same way they are in `index.js`; only `node:*` modules stay external.

## Out of scope

**The data delivery question** — how to get `verse-mate-web`'s `scripts/bible-ingest/build.py` output into the container — is intentionally not in this PR. It depends on DO topology (Droplet SSH+`docker cp`, App Platform shell, K8s `kubectl exec`+volume mount, etc.) and on whether ops wants to one-shot it or wire it into S3/MinIO. The README points at `docker cp` / volume mount as the simplest starting points.

## Test plan

Verified locally on the Pi against a fresh Postgres 15.4 (same env that validated #242):

- [x] `bun run build` produces both entrypoints clean (`index.js` 5.55 MB + `ingest-versions.js` 0.51 MB).
- [x] `bun ./dist/ingest-versions.js` with no args prints usage + exits 2.
- [x] `bun ./dist/ingest-versions.js --input /no/such/dir` bubbles up the loader's friendly \"directory not found\" error + exits 1.
- [x] `bun tsc` clean across the whole repo.
- [x] Externalized deps in the bundled `ingest-versions.js` are only `node:fs/promises`, `node:path`, `node:util` — same posture as `index.js`. No surprise runtime deps required by the image.
- [ ] End-to-end run against a real DB inside a built image — easy to do as part of the next deploy by `docker exec`-ing into the running container and `--input`-ing a fixture; left as a deploy-time smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)