### PR TITLE
feat(bible): localize chapter commentary via lang query param

### DIFF
--- a/packages/backend-base/src/bible/bible.plugin.ts
+++ b/packages/backend-base/src/bible/bible.plugin.ts
@@ -267,7 +267,7 @@ const plugin = new Elysia()
           currentUserId,
         }) => {
           const { bookId, chapterNumber } = params;
-          const { explanationType } = query;
+          const { explanationType, lang } = query;
           const versionKey =
             query.bible_version ?? query.versionKey ?? "NASB1995";
 
@@ -288,6 +288,7 @@ const plugin = new Elysia()
             version_id: version.id,
             type: explanationType as ExplanationTypeEnum | undefined,
             user_id: currentUserId || undefined,
+            lang,
           });
 
           return { explanation };
@@ -301,6 +302,12 @@ const plugin = new Elysia()
             bible_version: t.Optional(t.String()),
             versionKey: t.Optional(t.String()),
             explanationType: t.Optional(t.String()),
+            lang: t.Optional(
+              t.String({
+                description:
+                  "BCP-47 language code (e.g. 'es', 'pt-BR') for the AI commentary. Selects the active explanation in that language, falling back to English when no translation exists. Takes precedence over the bible version's language and the signed-in user's preferred_language.",
+              }),
+            ),
           }),
           response: {
             200: ExplanationSchema,

--- a/packages/backend-base/src/bible/bible.test.ts
+++ b/packages/backend-base/src/bible/bible.test.ts
@@ -112,6 +112,32 @@ describe("Bible Plugin", () => {
       expect(ukrkl).toBeDefined();
       expect(ukrkl?.testament_coverage).toBe("nt");
     });
+
+    it("GET /bible/book/explanation/:bookId/:chapterNumber - returns the explanation shape", async () => {
+      const { data, error } =
+        // @ts-ignore - Dynamic path parameters
+        await testClient.bible.book.explanation[1][1].get({
+          query: { explanationType: "summary" },
+        });
+
+      expect(error).toBeFalsy();
+      expect(data).toBeTruthy();
+      expect(data).toHaveProperty("explanation");
+    });
+
+    it("GET /bible/book/explanation/:bookId/:chapterNumber - accepts optional lang query param", async () => {
+      const { data, error } =
+        // @ts-ignore - Dynamic path parameters
+        await testClient.bible.book.explanation[1][1].get({
+          query: { explanationType: "summary", lang: "es" },
+        });
+
+      // The endpoint accepts the language selector; when no Spanish translation
+      // exists it falls back to English rather than erroring.
+      expect(error).toBeFalsy();
+      expect(data).toBeTruthy();
+      expect(data).toHaveProperty("explanation");
+    });
   });
 
   describe("Bookmarks CRUD", () => {

--- a/packages/backend-base/src/bible/services/bible.service.ts
+++ b/packages/backend-base/src/bible/services/bible.service.ts
@@ -142,10 +142,12 @@ export class BibleService {
     version_id,
     user_id,
     type,
+    lang,
   }: Pick<ChapterDto, "book_id" | "chapter_number"> & {
     version_id: string;
     user_id?: string;
     type?: ExplanationTypeEnum;
+    lang?: string;
   }) {
     // Get language_code from version_id
     const version = await this.db
@@ -172,6 +174,12 @@ export class BibleService {
       if (user?.preferred_language) {
         language_code = user.preferred_language;
       }
+    }
+
+    // An explicit request param wins over both the version's language and the
+    // signed-in user's stored preference (mirrors GET /topics/:id/explanation).
+    if (lang) {
+      language_code = lang;
     }
 
     // Per spec feat-i18n br-i18n-002 (D-013) + br-i18n-004 (D-014):


### PR DESCRIPTION
## Summary

AI chapter commentary (Summary / By-Line / Detailed) always rendered in **English**, ignoring the user's language preference. Root cause: `GET /bible/book/explanation/:bookId/:chapterNumber` had **no language selector** — only `bible_version` / `versionKey` / `explanationType` — so a client had no way to request a language (the `/topics/:id/explanation` endpoint already supports `?lang=`).

This adds an optional `lang` query param to the chapter explanation endpoint, mirroring the topics endpoint.

- **`bible.plugin.ts`** — endpoint now accepts `lang` and threads it to the service. The Elysia query schema carries a description, so the param is discoverable in the auto-generated OpenAPI.
- **`bible.service.ts`** — `getExplanation` accepts `lang`; an explicit param takes precedence over the bible version's language **and** the signed-in user's `preferred_language`. Missing translations still fall back to English via the existing `withEnglishFallback` + BCP-47 alias resolution (`en` ↔ `en-US`, `pt` ↔ `pt-BR`), so the `translated` / `source_language` metadata is preserved.
- **`bible.test.ts`** — adds coverage for the explanation response shape and for accepting the optional `lang` param.

Key point: the service *already* did language resolution internally — the only thing missing was the endpoint surface to request a language. This is a small plumbing change, not new selection logic.

## Not in this PR

- **Data**: non-English chapter explanations must exist and be marked active for the languages in `/bible/languages` (via `/admin/batch-explanations` / `/admin/topics/translate-explanations`). Until that data exists, `lang=es` correctly falls back to English.
- **Frontend** (`verse-mate/verse-mate-web`): `fetchExplanation()` should pass the user's preferred language as `lang`, and `_explanationCache` must include language in its key (currently `bookId:chapter` only). Separate repo.

## Test plan

- [x] `bun tsc` clean
- [x] Biome clean; pre-commit hooks (Biome + tsc) pass
- [ ] Backend tests (`cd packages/backend-base && bun test src/bible/bible.test.ts`) — **not run here** (sandbox has no Postgres/Valkey; Docker image pulls are network-blocked)
- [ ] After non-English explanations are generated: `GET /bible/book/explanation/1/1?explanationType=summary&lang=es` returns Spanish; falls back to English when a translation is missing

https://claude.ai/code/session_01XAu5kjoGJCtUuB3zHTCLZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01XAu5kjoGJCtUuB3zHTCLZs)_