### PR TITLE
feat(bible): serve Strong's-tagged verses via ?tagged=1 

### DIFF
--- a/packages/backend-base/src/bible/bible.plugin.ts
+++ b/packages/backend-base/src/bible/bible.plugin.ts
@@ -81,6 +81,18 @@ function validateBookId(bookId: number): void {
   }
 }
 
+/**
+ * Parse an opt-in boolean query flag. Permissive on the truthy side ("1",
+ * "true", "yes" — case-insensitive) and silent on everything else, so the
+ * back-compat contract holds: an unrecognized value is treated as omitted
+ * rather than 400'd.
+ */
+function isTruthyQueryFlag(raw: string | undefined): boolean {
+  if (!raw) return false;
+  const v = raw.toLowerCase();
+  return v === "1" || v === "true" || v === "yes";
+}
+
 const plugin = new Elysia()
   .use(shared)
   .onError(createErrorHandler("bible plugin"))
@@ -149,6 +161,13 @@ const plugin = new Elysia()
           const versionKey =
             query.bible_version ?? query.versionKey ?? "NASB1995";
 
+          // Strong's-tagged rendering is opt-in. Truthy values ("1" / "true" /
+          // "yes") flip per-verse output to {verseNumber, tokens} for rows
+          // that have been seeded via ingest-strongs-tokens. Untagged rows
+          // (and the entire NASB1995 / KJV path) still serve the legacy
+          // {verseNumber, text} shape — back-compat is silent.
+          const tagged = isTruthyQueryFlag(query.tagged);
+
           const version = await db
             .getOrCreateConnection()
             .selectFrom("bible_versions")
@@ -164,6 +183,7 @@ const plugin = new Elysia()
             book_id: bookId,
             chapter_number: chapterNumber,
             version_id: version.id,
+            tagged,
           });
 
           return result;
@@ -176,6 +196,12 @@ const plugin = new Elysia()
           query: t.Object({
             bible_version: t.Optional(t.String()),
             versionKey: t.Optional(t.String()),
+            /**
+             * Opt-in flag for Strong's-tagged verse rendering. Accepts
+             * "1", "true", or "yes" (case-insensitive). Anything else
+             * (or omitted) returns the legacy `{verseNumber, text}` shape.
+             */
+            tagged: t.Optional(t.String()),
           }),
           response: {
             200: ChapterSchema,

--- a/packages/backend-base/src/bible/dto/book/verses.dto.ts
+++ b/packages/backend-base/src/bible/dto/book/verses.dto.ts
@@ -1,9 +1,35 @@
 import { type Static, t } from "elysia";
 
+/**
+ * One token on a Strong's-tagged verse. Joining each token's `text` field
+ * reproduces the verse text byte-for-byte — the lossless-join invariant
+ * the seed loader and chapter endpoint both enforce.
+ */
+const VerseTokenDto = t.Object({
+  text: t.String(),
+  /** Strong's number in canonical G####/H#### form (4-digit padded). */
+  strongs: t.Optional(t.String()),
+  /** Secondary Strong's for compound surface words (e.g. "Jesucristo"). */
+  strongs_alt: t.Optional(t.Array(t.String())),
+  /** Optional LLM-alignment confidence 0..1 (omitted for published sources). */
+  confidence: t.Optional(t.Number()),
+});
+
+/**
+ * Per-verse element returned by `/bible/book/:bookId/:chapterNumber`.
+ *
+ * `text` is always present (back-compat with every existing caller).
+ * `tokens` is an optional additive field — populated only when the caller
+ * passes `?tagged=1` AND the row has Strong's data seeded. Clients that
+ * understand Strong's prefer `tokens` (one underlined surface per
+ * `strongs` entry); clients that don't keep rendering `text` exactly as
+ * before. Joining each `tokens[*].text` reproduces `text` byte-for-byte.
+ */
 export const VersesDto = t.Array(
   t.Object({
     verseNumber: t.Number(),
     text: t.String(),
+    tokens: t.Optional(t.Array(VerseTokenDto)),
   }),
 );
 

--- a/packages/backend-base/src/bible/repository/bible.repository.ts
+++ b/packages/backend-base/src/bible/repository/bible.repository.ts
@@ -102,15 +102,29 @@ export class BibleRepository {
   async getVerses({
     chapter_id,
     version_id,
+    withTokens = false,
   }: Pick<ChapterDto, "chapter_id"> & {
     version_id: string;
+    /**
+     * When true, also fetch `verses.tokens` JSONB. Rows where tokens IS
+     * NULL still flow through with text only — the service layer decides
+     * per-row whether to emit the tagged or legacy shape. Default false
+     * keeps the read narrow for the untagged path.
+     */
+    withTokens?: boolean;
   }) {
+    const baseSelect = [
+      "verses.verse_number as verseNumber",
+      "verses.text",
+    ] as const;
+    const taggedSelect = [...baseSelect, "verses.tokens"] as const;
+
     const verses = await this.db
       .getOrCreateConnection()
       .selectFrom("verses")
       .where("chapter_id", "=", chapter_id)
       .where("version_id", "=", version_id)
-      .select(["verses.verse_number as verseNumber", "verses.text"])
+      .select(withTokens ? taggedSelect : baseSelect)
       .orderBy("verseNumber", "asc")
       .execute();
 

--- a/packages/backend-base/src/bible/schemas/bible-response.schema.ts
+++ b/packages/backend-base/src/bible/schemas/bible-response.schema.ts
@@ -73,10 +73,24 @@ const ChapterBookType = t.Object({
           end_verse: t.Number(),
         }),
       ),
+      // Per-verse: `text` is always present (back-compat). `tokens` is
+      // additive — populated only when the caller passes `?tagged=1` AND
+      // the row has Strong's data seeded. Joining `tokens[*].text`
+      // reproduces `text` byte-for-byte.
       verses: t.Array(
         t.Object({
           verseNumber: t.Number(),
           text: t.String(),
+          tokens: t.Optional(
+            t.Array(
+              t.Object({
+                text: t.String(),
+                strongs: t.Optional(t.String()),
+                strongs_alt: t.Optional(t.Array(t.String())),
+                confidence: t.Optional(t.Number()),
+              }),
+            ),
+          ),
         }),
       ),
     }),

--- a/packages/backend-base/src/bible/services/bible.service.ts
+++ b/packages/backend-base/src/bible/services/bible.service.ts
@@ -1,6 +1,7 @@
 import type ExplanationTypeEnum from "database/src/models/public/ExplanationTypeEnum";
 import type HighlightColorEnum from "database/src/models/public/HighlightColorEnum";
 import type TestamentEnum from "database/src/models/public/TestamentEnum";
+import type { VerseToken } from "database/src/models/public/Verses";
 import { NotFoundError, ValidationError } from "../../common/errors";
 import { resolveLanguageCode, withEnglishFallback } from "../../shared/i18n";
 import type { db } from "../../shared/shared.plugin";
@@ -30,8 +31,17 @@ export class BibleService {
     book_id,
     chapter_number,
     version_id,
+    tagged = false,
   }: Pick<ChapterDto, "book_id" | "chapter_number"> & {
     version_id: string;
+    /**
+     * When true, fetch `verses.tokens` and emit the Strong's-tagged shape
+     * (`{verseNumber, tokens}`) for rows where tokens IS NOT NULL. Rows
+     * without tokens still emit the legacy shape (`{verseNumber, text}`),
+     * so mixed-coverage chapters stay safe on the wire. Default false
+     * preserves the legacy response byte-for-byte.
+     */
+    tagged?: boolean;
   }) {
     const { book } = await this.bibleRepository.getBook({ book_id });
     if (!book) return { message: "Book not found" };
@@ -56,9 +66,12 @@ export class BibleService {
     const { verses } = await this.bibleRepository.getVerses({
       chapter_id: chapter.chapter_id,
       version_id,
+      withTokens: tagged,
     });
 
-    return { book: this.formattedBook({ book, chapter, subtitles, verses }) };
+    return {
+      book: this.formattedBook({ book, chapter, subtitles, verses, tagged }),
+    };
   }
 
   async getBibleVersions() {
@@ -696,11 +709,21 @@ export class BibleService {
     chapter,
     subtitles,
     verses,
+    tagged = false,
   }: {
     book: BookDto;
     chapter: Pick<ChapterDto, "chapter_id" | "chapter_number">;
     subtitles: Omit<SubtitlesDto, "chapter_id">[];
-    verses: VersesDto;
+    /**
+     * Raw verse rows from `getVerses`. When tagged=true the rows may also
+     * carry a `tokens` field (null for verses we haven't seeded yet).
+     */
+    verses: Array<{
+      verseNumber: number;
+      text: string;
+      tokens?: unknown;
+    }>;
+    tagged?: boolean;
   }) {
     if (
       !book ||
@@ -717,6 +740,23 @@ export class BibleService {
       return null;
     }
 
+    // `text` is always emitted (back-compat — every existing client reads
+    // it). When `tagged=true` AND the row has a non-null tokens array we
+    // also include `tokens` so Strong's-aware clients can render the
+    // tagged shape. Clients that ignore the new field keep working
+    // exactly as before. Mixed-coverage chapters are valid: some verses
+    // get `tokens`, others don't.
+    const formattedVerses: VersesDto = verses.map((v) => {
+      if (tagged && Array.isArray(v.tokens) && v.tokens.length > 0) {
+        return {
+          verseNumber: v.verseNumber,
+          text: v.text,
+          tokens: v.tokens as VerseToken[],
+        };
+      }
+      return { verseNumber: v.verseNumber, text: v.text };
+    });
+
     return {
       bookId: book.book_id,
       name: book.name,
@@ -729,7 +769,7 @@ export class BibleService {
         {
           chapterNumber: chapter.chapter_number,
           subtitles: subtitles,
-          verses: verses,
+          verses: formattedVerses,
         },
       ], //the first array is always "truthy"
     };


### PR DESCRIPTION
## Summary

- Wires up the `verses.tokens` column from #245 to the chapter endpoint behind an opt-in `?tagged=1` flag.
- **Additive, back-compat shape**: `text` is always present, `tokens` is an optional new field that appears only when `?tagged=1` is requested AND the row has Strong's data seeded.
- Permissive flag parsing: `1` / `true` / `yes` (case-insensitive) all enable; anything else keeps the legacy shape silently.
- Mixed-coverage chapters are valid — a verse without seeded tokens simply omits `tokens`, the rest of the array still gets the tagged field.

This PR is **based on #245**, not `main` — merging this PR re-bases automatically when #245 lands first.

## Wire shape after this PR

```jsonc
// GET /bible/book/59/1?bible_version=RVR09  ← unchanged, exactly as today
{ "verseNumber": 1, "text": "JACOBO, siervo de Dios y del Señor Jesucristo, ..." }

// GET /bible/book/59/1?bible_version=RVR09&tagged=1  ← new shape
{
  "verseNumber": 1,
  "text": "JACOBO, siervo de Dios y del Señor Jesucristo, ...",
  "tokens": [
    { "text": "JACOBO", "strongs": "G2385" },
    { "text": ", " },
    { "text": "siervo", "strongs": "G1401" },
    { "text": " " },
    { "text": "de Dios", "strongs": "G2316" },
    ...
  ]
}

// GET /bible/book/40/1?bible_version=NASB1995&tagged=1
//   ← also unchanged, NASB1995 has no tokens seeded so tokens stays absent
{ "verseNumber": 1, "text": "The book of the genealogy of Jesus Christ ..." }
```

Existing frontend consumers read `verses[*].text` exactly as before. The new `tokens` field is invisible to them — `JSON.parse` keeps it, but if they don't access it, nothing changes. **Zero regression risk to current rendering.**

## Lossless-join invariant (the contract)

The seed loader from #245 enforces `tokens.map(t => t.text).join("") === text` for every row before writing. This PR depends on that invariant: when emitting `tokens`, the joined text is guaranteed to reproduce the `text` field byte-for-byte, so a Strong's-aware client can render *only* the tokens and the user sees identical characters to what an untagged client gets.

## Test plan

- [ ] CI typecheck + lint passes (locally green: `bunx tsc --noEmit` + `bunx biome check`)
- [ ] After #245 merges and the seed runs in non-prod:
  - [ ] `curl /bible/book/59/1?bible_version=RVR09` returns legacy shape unchanged (no `tokens` field)
  - [ ] `curl /bible/book/59/1?bible_version=RVR09&tagged=1` returns `tokens` on each verse
  - [ ] For each verse with `tokens`: `tokens.map(t => t.text).join("") === text` (byte-exact)
  - [ ] `curl /bible/book/40/1?bible_version=NASB1995&tagged=1` returns no `tokens` (silent fallback — NASB1995 is not seeded)
  - [ ] `tagged=true` and `tagged=yes` behave identically to `tagged=1`
  - [ ] `tagged=foo` (unrecognized value) returns legacy shape (silent back-compat — not a 400)
- [ ] Eden Treaty types regenerate cleanly for the frontend (the optional `tokens?` field is additive, shouldn't break existing call sites)
- [ ] Verify `verses.tokens IS NULL` rows in mixed-coverage chapters: those verses appear in the response without a `tokens` field, neighboring tagged verses do have it
- [ ] No regression on `/bible/book/:bookId/introduction`, `/bible/versions`, `/bible/languages` — only `/bible/book/:bookId/:chapterNumber` changed

## What's NOT in this PR

- Frontend `STRONGS_INDEX` export from `@versemate/lexicon`
- Frontend `TokenizedVerse.tsx` consumption of the new `tokens` field
- Tests (would want vitest coverage for the per-row decision logic; deferred to a follow-up once a test pattern is established for the bible plugin — `apps/backend/test` is empty)

Per the original handoff doc, frontend integration is Phase 3 — a separate session.

## Draft until #245 lands

Marking draft because:
1. #245 needs to merge first (this PR's base branch)
2. After #245 deploy, the seed needs to run (`bun ./dist/ingest-strongs-tokens.js`)
3. Only then is there any data to verify against here — un-draft after that

🤖 Generated with [Claude Code](https://claude.com/claude-code)