### PR TITLE
feat(lemma): GET /lemma/:strongs?lang= endpoint

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -6,6 +6,7 @@ import {
   authPlugin,
   biblePlugin,
   healthCheckPlugin,
+  lemmaPlugin,
   offlinePlugin,
   supportPlugin,
   topicPlugin,
@@ -27,6 +28,7 @@ const app = new Elysia()
   .use(biblePlugin)
   .use(audioPlugin)
   .use(topicPlugin)
+  .use(lemmaPlugin)
   .use(supportPlugin)
   .use(adminPlugin)
   .use(offlinePlugin)

--- a/packages/backend-base/index.ts
+++ b/packages/backend-base/index.ts
@@ -14,6 +14,9 @@ import type { UserPlugin } from "./src/user/user.plugin";
 import topicPlugin from "./src/topics/topic.plugin";
 import type { TopicPlugin } from "./src/topics/topic.plugin";
 
+import lemmaPlugin from "./src/lemmas/lemma.plugin";
+import type { LemmaPlugin } from "./src/lemmas/lemma.plugin";
+
 import supportPlugin from "./src/support/support.plugin";
 import type { SupportPlugin } from "./src/support/support.plugin";
 
@@ -46,6 +49,8 @@ export {
   adminPlugin,
   type TopicPlugin,
   topicPlugin,
+  type LemmaPlugin,
+  lemmaPlugin,
   type HealthCheckPlugin,
   healthCheckPlugin,
   type SupportPlugin,

--- a/packages/backend-base/src/lemmas/lemma.plugin.ts
+++ b/packages/backend-base/src/lemmas/lemma.plugin.ts
@@ -1,0 +1,106 @@
+import { Elysia, t } from "elysia";
+import { NotFoundError } from "../common/errors";
+import { StandardErrorResponses } from "../common/response-schemas";
+import shared from "../shared/shared.plugin";
+import { LemmaService } from "./services/lemma.service";
+
+// Shared shape for a `related` cross-reference (mirrors RelatedWord on
+// the Kysely model — re-declared inline so the schema stays self-contained
+// for OpenAPI generation).
+const RelatedWordSchema = t.Object({
+  translit: t.String(),
+  note: t.String(),
+});
+
+// Response shape for `GET /lemma/:strongs`. Frontend renders these
+// directly — no further mapping. Translated fields fall back to the
+// English baseline field-by-field, so the response is always
+// renderable regardless of whether the requested language has a
+// translation row.
+const LemmaCardSchema = t.Object({
+  strongs: t.String(),
+  lemma: t.String(),
+  translit: t.Union([t.String(), t.Null()]),
+  pronunciation: t.Union([t.String(), t.Null()]),
+  nt_frequency: t.Union([t.Number(), t.Null()]),
+  ot_frequency: t.Union([t.Number(), t.Null()]),
+  loaded: t.Boolean(),
+  pos: t.Union([t.String(), t.Null()]),
+  basic_gloss: t.Union([t.String(), t.Null()]),
+  semantic_range: t.Union([t.Array(t.String()), t.Null()]),
+  notes: t.Union([t.String(), t.Null()]),
+  related: t.Union([t.Array(RelatedWordSchema), t.Null()]),
+  /**
+   * Language actually represented by the payload. Equals the requested
+   * `lang` query param when a translation row exists, else "en"
+   * (English baseline fallback). Frontend can use this to render a
+   * subtle "translated by AI" badge or skip it for English.
+   */
+  language_code: t.String(),
+  /**
+   * Origin of the translation — "llm:claude-haiku-4-5", "uw"
+   * (unfoldingWord), "hand", or null when no translation row exists
+   * (`is_translated: false`).
+   */
+  source: t.Union([t.String(), t.Null()]),
+  is_translated: t.Boolean(),
+});
+
+const plugin = new Elysia()
+  .use(shared)
+  .state((state) => ({
+    ...state,
+    lemmaService: new LemmaService(state.db),
+  }))
+  .group("/lemma", (app) =>
+    app.get(
+      "/:strongs",
+      async ({ params, query, store: { lemmaService } }) => {
+        // Canonicalize to the same `G####`/`H####` 4-digit-padded shape
+        // the loader writes — case-insensitive incoming, output is the
+        // exact PK we'd match in the DB.
+        const raw = params.strongs.trim().toUpperCase();
+        const m = raw.match(/^([GH])(\d+)$/);
+        if (!m) {
+          throw new NotFoundError(`Invalid Strong's number: ${params.strongs}`);
+        }
+        const strongs = `${m[1]}${Number.parseInt(m[2], 10).toString().padStart(4, "0")}`;
+
+        const lang = (query.lang ?? "en").trim();
+        const card = await lemmaService.getLemma(strongs, lang);
+        if (!card) throw new NotFoundError(`Lemma not found: ${strongs}`);
+        return card;
+      },
+      {
+        params: t.Object({
+          strongs: t.String({
+            description:
+              "Strong's number, e.g. G2385 or H0001. Case-insensitive; gets canonicalized to 4-digit zero-padded form server-side.",
+          }),
+        }),
+        query: t.Object({
+          lang: t.Optional(
+            t.String({
+              description:
+                "ISO 639-1 language code (es, de, fr, ru, it, pt, ro, hi, tl, uk). Defaults to 'en'. Falls back to English baseline if no translation exists for the requested language.",
+            }),
+          ),
+        }),
+        response: {
+          200: LemmaCardSchema,
+          404: StandardErrorResponses[400],
+          ...StandardErrorResponses,
+        },
+        detail: {
+          tags: ["Lemma"],
+          summary:
+            "Get a lemma card (Strong's-keyed) in any supported language",
+          description:
+            "Returns the lemma metadata (Greek/Hebrew lemma, transliteration, frequency) plus the translatable cards (pos, basic_gloss, semantic_range, notes, related) in the requested language. English baseline on the `lemmas` row, non-English from `lemma_translations` with field-by-field fallback. 404 if Strong's number isn't in the loaded set.",
+        },
+      },
+    ),
+  );
+
+export default plugin;
+export type LemmaPlugin = typeof plugin;

--- a/packages/backend-base/src/lemmas/lemma.plugin.ts
+++ b/packages/backend-base/src/lemmas/lemma.plugin.ts
@@ -1,4 +1,5 @@
 import { Elysia, t } from "elysia";
+import { createErrorHandler } from "../common/error-handler";
 import { NotFoundError } from "../common/errors";
 import { StandardErrorResponses } from "../common/response-schemas";
 import shared from "../shared/shared.plugin";
@@ -48,6 +49,7 @@ const LemmaCardSchema = t.Object({
 
 const plugin = new Elysia()
   .use(shared)
+  .onError(createErrorHandler("lemma plugin"))
   .state((state) => ({
     ...state,
     lemmaService: new LemmaService(state.db),

--- a/packages/backend-base/src/lemmas/repository/lemma.repository.ts
+++ b/packages/backend-base/src/lemmas/repository/lemma.repository.ts
@@ -1,0 +1,109 @@
+import type { RelatedWord } from "database/src/models/public/Lemmas";
+import { sql } from "kysely";
+import type { db } from "../../shared/shared.plugin";
+
+/**
+ * Merged lemma row returned from the DB after LEFT JOIN on
+ * lemma_translations. Translated fields fall back to the English baseline
+ * stored on `lemmas` when no translation exists for the requested
+ * language (mirrors topic_translations: `translated_name || original_name`).
+ */
+export interface LemmaCard {
+  strongs: string;
+  lemma: string;
+  translit: string | null;
+  pronunciation: string | null;
+  nt_frequency: number | null;
+  ot_frequency: number | null;
+  loaded: boolean;
+  pos: string | null;
+  basic_gloss: string | null;
+  semantic_range: string[] | null;
+  notes: string | null;
+  related: RelatedWord[] | null;
+  language_code: string;
+  source: string | null;
+  is_translated: boolean;
+}
+
+export class LemmaRepository {
+  constructor(private readonly db: db) {}
+
+  /**
+   * Fetch one lemma card with optional per-language overrides.
+   *
+   * For `language_code === 'en'` (or omitted), returns the English baseline
+   * on the `lemmas` row directly with `is_translated: false`. Web reads
+   * English from the bundled `@versemate/lexicon` JSON so this path is
+   * mostly for parity / mobile, but it stays consistent.
+   *
+   * For any other language, LEFT JOINs `lemma_translations` filtered on
+   * the requested `language_code` and prefers the `translated_*` fields
+   * when present, falling back to the English baseline field-by-field.
+   *
+   * Returns `null` if the strongs key isn't in `lemmas` at all.
+   */
+  async getLemma(
+    strongs: string,
+    languageCode = "en",
+  ): Promise<LemmaCard | null> {
+    const connection = this.db.getOrCreateConnection();
+
+    const row = await connection
+      .selectFrom("lemmas")
+      .leftJoin("lemma_translations", (join) =>
+        join
+          .onRef("lemmas.strongs", "=", "lemma_translations.strongs")
+          .on("lemma_translations.language_code", "=", sql.lit(languageCode))
+          .on("lemma_translations.is_active", "=", true),
+      )
+      .where("lemmas.strongs", "=", strongs)
+      .select([
+        "lemmas.strongs",
+        "lemmas.lemma",
+        "lemmas.translit",
+        "lemmas.pronunciation",
+        "lemmas.nt_frequency",
+        "lemmas.ot_frequency",
+        "lemmas.loaded",
+        "lemmas.pos as base_pos",
+        "lemmas.basic_gloss as base_basic_gloss",
+        "lemmas.semantic_range as base_semantic_range",
+        "lemmas.notes as base_notes",
+        "lemmas.related as base_related",
+        "lemma_translations.translated_pos",
+        "lemma_translations.translated_basic_gloss",
+        "lemma_translations.translated_semantic_range",
+        "lemma_translations.translated_notes",
+        "lemma_translations.translated_related",
+        "lemma_translations.source",
+      ])
+      .executeTakeFirst();
+
+    if (!row) return null;
+
+    const isTranslated = row.translated_basic_gloss != null;
+
+    return {
+      strongs: row.strongs,
+      lemma: row.lemma,
+      translit: row.translit,
+      pronunciation: row.pronunciation,
+      nt_frequency: row.nt_frequency,
+      ot_frequency: row.ot_frequency,
+      loaded: row.loaded,
+      // Field-by-field fallback. A translation row might have some
+      // fields populated and others null (e.g. notes translated but
+      // semantic_range still empty) — preserve the English value where
+      // the translation is missing, same as topic_translations.
+      pos: row.translated_pos ?? row.base_pos,
+      basic_gloss: row.translated_basic_gloss ?? row.base_basic_gloss,
+      semantic_range: row.translated_semantic_range ?? row.base_semantic_range,
+      notes: row.translated_notes ?? row.base_notes,
+      related: row.translated_related ?? row.base_related,
+      language_code: isTranslated ? languageCode : "en",
+      source: row.source,
+      is_translated: isTranslated,
+    };
+  }
+}

--- a/packages/backend-base/src/lemmas/services/lemma.service.ts
+++ b/packages/backend-base/src/lemmas/services/lemma.service.ts
@@ -1,0 +1,24 @@
+import type { db } from "../../shared/shared.plugin";
+import { LemmaRepository } from "../repository/lemma.repository";
+
+export class LemmaService {
+  private lemmaRepository: LemmaRepository;
+
+  constructor(private readonly db: db) {
+    this.lemmaRepository = new LemmaRepository(this.db);
+  }
+
+  async getLemma(strongs: string, languageCode = "en") {
+    try {
+      return await this.lemmaRepository.getLemma(strongs, languageCode);
+    } catch (error: unknown) {
+      console.error(
+        `Error fetching lemma ${strongs} (${languageCode}):`,
+        error,
+      );
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to fetch lemma: ${errorMessage}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds the read path that mobile + non-English web users hit to render tap-to-meaning lemma cards in their language. Stacks on top of #247 (depends on the lemmas + lemma_translations tables).

- New endpoint: `GET /lemma/:strongs?lang=<iso-code>` → 200 with merged card or 404
- LEFT JOIN `lemma_translations` on `(strongs, language_code)`, prefer `translated_*` fields, fall back to English baseline field-by-field — same convention as `topic_translations`
- Server-side canonicalization of Strong's input (case-insensitive, zero-pads to 4 digits) so `g80` and `G0080` both resolve
- `is_translated` boolean + `source` field so the frontend can flag AI-translated content if desired
- Layout mirrors `src/topics/`: repository → service → plugin
- Registered in `packages/backend-base/index.ts` and `apps/backend/src/index.ts`

## Why stacked on #247
The Kysely typed models for `lemmas` + `lemma_translations` only exist on #247's branch. Branching this PR off `feat/lemma-translations` lets us merge same-day after #247 lands. Once #247 merges, this PR auto-updates base to main with no manual rebase needed.

## Endpoint examples

\`\`\`bash
# Spanish (translation exists)
curl 'https://api.versemate.org/lemma/G2385?lang=es'
# → { strongs: "G2385", lemma: "Ἰάκωβος", basic_gloss: "Santiago", ... language_code: "es", is_translated: true, source: "llm:claude-haiku-4-5" }

# Japanese (no translation row yet)
curl 'https://api.versemate.org/lemma/G2385?lang=ja'
# → { ...English baseline..., language_code: "en", is_translated: false, source: null }

# Unknown Strong's
curl 'https://api.versemate.org/lemma/G99999'
# → 404
\`\`\`

## Test plan
- [ ] CI green (tsc + biome + build)
- [ ] After #247 lands + lemma seed runs, smoke test in prod: `curl https://api.versemate.org/lemma/G2385?lang=es | jq` returns Spanish card
- [ ] Verify English fallback: `curl /lemma/G2385?lang=zh-Hant-TW` returns English baseline with `is_translated: false`
- [ ] Frontend (separate PR) wires user.preferred_language → endpoint call for non-English users

🤖 Generated with [Claude Code](https://claude.com/claude-code)