### PR TITLE
fix(lemma): normalize lang code + tighten is_translated; add coverage report

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -4,7 +4,7 @@
   "main": "./src/index.ts",
   "module": "./src/index.ts",
   "scripts": {
-    "build": "bun build ./src/index.ts ./src/ingest-versions.ts ./src/ingest-strongs-tokens.ts ./src/ingest-lemmas.ts --target bun --outdir ./dist",
+    "build": "bun build ./src/index.ts ./src/ingest-versions.ts ./src/ingest-strongs-tokens.ts ./src/ingest-lemmas.ts ./src/lemma-coverage.ts --target bun --outdir ./dist",
     "dev": "bun run --watch src/index.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/apps/backend/src/lemma-coverage.ts
+++ b/apps/backend/src/lemma-coverage.ts
@@ -1,0 +1,39 @@
+/**
+ * Production CLI entry for the lemma translation-coverage report.
+ *
+ * Bundled to dist/lemma-coverage.js alongside dist/index.js so it can be
+ * run inside the deployed backend container to see how much of each
+ * language's lemma set is translated:
+ *
+ *   bun ./dist/lemma-coverage.js                 # all known languages
+ *   bun ./dist/lemma-coverage.js --lang es,de    # a subset
+ *   bun ./dist/lemma-coverage.js --json          # machine-readable
+ *
+ * Read-only. See scripts/lemma-translate/README.md for how to backfill the
+ * gaps this report surfaces.
+ */
+import { parseArgs } from "node:util";
+import { reportCoverage } from "backend-base/src/lemmas/coverage";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    lang: { type: "string" },
+    json: { type: "boolean" },
+  },
+  allowPositionals: true,
+});
+
+const langs = values.lang
+  ? values.lang
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+  : undefined;
+
+reportCoverage({ langs, json: values.json ?? false })
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/backend-base/src/lemmas/coverage.ts
+++ b/packages/backend-base/src/lemmas/coverage.ts
@@ -1,0 +1,199 @@
+/**
+ * Lemma translation-coverage report.
+ *
+ * For each language, counts how many of the `loaded` lemmas (the curated
+ * tap-worthy set the `/lemma` endpoint serves a translated card for) are:
+ *
+ *   - complete : a translation row exists and covers every English prose
+ *                field — this is exactly what makes `is_translated: true`.
+ *   - partial  : a translation row exists but at least one prose field
+ *                still falls back to English.
+ *   - missing  : no translation row for that lemma + language.
+ *
+ * Surfaces the coverage gap described in the lexicon handoff so a backfill
+ * can be prioritized. Read-only — runs against whatever DB the `database`
+ * package is pointed at.
+ *
+ * Usage (bundled into the deployed image, same as ingest-lemmas):
+ *   bun ./dist/lemma-coverage.js                 # all known languages
+ *   bun ./dist/lemma-coverage.js --lang es,de    # a subset
+ *   bun ./dist/lemma-coverage.js --json          # machine-readable
+ */
+import { db } from "database";
+import { isLemmaFullyTranslated } from "./lemma-language";
+
+/** The languages the LLM pipeline targets (scripts/lemma-translate). */
+export const SUPPORTED_LEMMA_LANGUAGES = [
+  "es",
+  "de",
+  "fr",
+  "ru",
+  "it",
+  "pt",
+  "ro",
+  "hi",
+  "tl",
+  "uk",
+] as const;
+
+export interface LanguageCoverage {
+  language_code: string;
+  /** loaded lemmas (the denominator — same for every language). */
+  total_loaded: number;
+  complete: number;
+  partial: number;
+  missing: number;
+  /** translation rows whose strongs is not in the loaded set. */
+  extra_unloaded: number;
+  /** complete / total_loaded, rounded to 1 decimal. */
+  complete_pct: number;
+}
+
+export async function computeCoverage(
+  langsFilter?: string[],
+): Promise<{ totalLoaded: number; rows: LanguageCoverage[] }> {
+  const conn = db.getOrCreateConnection();
+
+  const loaded = await conn
+    .selectFrom("lemmas")
+    .where("loaded", "=", true)
+    .select([
+      "strongs",
+      "pos",
+      "basic_gloss",
+      "semantic_range",
+      "notes",
+      "related",
+    ])
+    .execute();
+  const loadedStrongs = new Set(loaded.map((l) => l.strongs));
+  const totalLoaded = loaded.length;
+
+  // Languages to report: the explicit filter, else the supported set plus
+  // any other codes actually present (e.g. a stray region-suffixed "pt-BR"
+  // that wouldn't match a normalized "pt" request — worth surfacing).
+  const present = (
+    await conn
+      .selectFrom("lemma_translations")
+      .where("is_active", "=", true)
+      .select("language_code")
+      .distinct()
+      .execute()
+  ).map((r) => r.language_code);
+  const langs = (
+    langsFilter?.length
+      ? langsFilter
+      : [...new Set([...SUPPORTED_LEMMA_LANGUAGES, ...present])]
+  ).sort();
+
+  const translations = await conn
+    .selectFrom("lemma_translations")
+    .where("is_active", "=", true)
+    .where("language_code", "in", langs)
+    .select([
+      "strongs",
+      "language_code",
+      "translated_pos",
+      "translated_basic_gloss",
+      "translated_semantic_range",
+      "translated_notes",
+      "translated_related",
+    ])
+    .execute();
+
+  const baseByStrongs = new Map(loaded.map((l) => [l.strongs, l]));
+  const rows: LanguageCoverage[] = langs.map((language_code) => ({
+    language_code,
+    total_loaded: totalLoaded,
+    complete: 0,
+    partial: 0,
+    missing: 0,
+    extra_unloaded: 0,
+    complete_pct: 0,
+  }));
+  const byLang = new Map(rows.map((r) => [r.language_code, r]));
+  const seen = new Map<string, Set<string>>();
+
+  for (const t of translations) {
+    const row = byLang.get(t.language_code);
+    if (!row) continue;
+    if (!loadedStrongs.has(t.strongs)) {
+      row.extra_unloaded += 1;
+      continue;
+    }
+    let seenForLang = seen.get(t.language_code);
+    if (!seenForLang) {
+      seenForLang = new Set();
+      seen.set(t.language_code, seenForLang);
+    }
+    seenForLang.add(t.strongs);
+
+    const baseRow = baseByStrongs.get(t.strongs);
+    if (!baseRow) continue;
+    const complete = isLemmaFullyTranslated(
+      {
+        pos: baseRow.pos,
+        basic_gloss: baseRow.basic_gloss,
+        semantic_range: baseRow.semantic_range,
+        notes: baseRow.notes,
+        related: baseRow.related,
+      },
+      {
+        pos: t.translated_pos,
+        basic_gloss: t.translated_basic_gloss,
+        semantic_range: t.translated_semantic_range,
+        notes: t.translated_notes,
+        related: t.translated_related,
+      },
+    );
+    if (complete) row.complete += 1;
+    else row.partial += 1;
+  }
+
+  for (const row of rows) {
+    const covered = (seen.get(row.language_code) ?? new Set()).size;
+    row.missing = totalLoaded - covered;
+    row.complete_pct =
+      totalLoaded === 0
+        ? 0
+        : Math.round((row.complete / totalLoaded) * 1000) / 10;
+  }
+
+  return { totalLoaded, rows };
+}
+
+export async function reportCoverage(opts: {
+  langs?: string[];
+  json?: boolean;
+}): Promise<void> {
+  const { totalLoaded, rows } = await computeCoverage(opts.langs);
+
+  if (opts.json) {
+    console.log(JSON.stringify({ total_loaded: totalLoaded, rows }, null, 2));
+    return;
+  }
+
+  console.log(`Loaded lemmas (translatable universe): ${totalLoaded}\n`);
+  const header = [
+    "lang".padEnd(6),
+    "complete".padStart(9),
+    "partial".padStart(8),
+    "missing".padStart(8),
+    "extra".padStart(6),
+    "complete%".padStart(10),
+  ].join("  ");
+  console.log(header);
+  console.log("-".repeat(header.length));
+  for (const r of rows) {
+    console.log(
+      [
+        r.language_code.padEnd(6),
+        String(r.complete).padStart(9),
+        String(r.partial).padStart(8),
+        String(r.missing).padStart(8),
+        String(r.extra_unloaded).padStart(6),
+        `${r.complete_pct}%`.padStart(10),
+      ].join("  "),
+    );
+  }
+}

--- a/packages/backend-base/src/lemmas/lemma-language.test.ts
+++ b/packages/backend-base/src/lemmas/lemma-language.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "bun:test";
+import {
+  type LemmaProseValues,
+  isLemmaFullyTranslated,
+  normalizeLanguageCode,
+} from "./lemma-language";
+
+describe("normalizeLanguageCode", () => {
+  it("passes through a bare base code", () => {
+    expect(normalizeLanguageCode("es")).toBe("es");
+    expect(normalizeLanguageCode("de")).toBe("de");
+  });
+
+  it("lowercases", () => {
+    expect(normalizeLanguageCode("ES")).toBe("es");
+    expect(normalizeLanguageCode("Pt")).toBe("pt");
+  });
+
+  it("strips a region suffix", () => {
+    expect(normalizeLanguageCode("es-MX")).toBe("es");
+    expect(normalizeLanguageCode("pt-BR")).toBe("pt");
+    expect(normalizeLanguageCode("pt_BR")).toBe("pt");
+    expect(normalizeLanguageCode("zh-Hans")).toBe("zh");
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeLanguageCode("  fr  ")).toBe("fr");
+  });
+
+  it("keeps 3-letter codes (e.g. Filipino)", () => {
+    expect(normalizeLanguageCode("fil")).toBe("fil");
+  });
+
+  it("collapses empty / null / garbage to en", () => {
+    expect(normalizeLanguageCode("")).toBe("en");
+    expect(normalizeLanguageCode(null)).toBe("en");
+    expect(normalizeLanguageCode(undefined)).toBe("en");
+    expect(normalizeLanguageCode("english")).toBe("en");
+    expect(normalizeLanguageCode("123")).toBe("en");
+  });
+
+  it("neutralizes a SQL-injection attempt to en", () => {
+    expect(normalizeLanguageCode("es'; DROP TABLE lemmas;--")).toBe("en");
+  });
+
+  it("normalizes en variants to en", () => {
+    expect(normalizeLanguageCode("en")).toBe("en");
+    expect(normalizeLanguageCode("en-US")).toBe("en");
+  });
+});
+
+const base = (over: Partial<LemmaProseValues> = {}): LemmaProseValues => ({
+  pos: "Noun",
+  basic_gloss: "house",
+  semantic_range: ["dwelling", "household"],
+  notes: "A note.",
+  related: [{ translit: "bayit", note: "related" }],
+  ...over,
+});
+
+describe("isLemmaFullyTranslated", () => {
+  it("true when every baseline prose field has a translation", () => {
+    expect(
+      isLemmaFullyTranslated(
+        base(),
+        base({
+          pos: "Sustantivo",
+          basic_gloss: "casa",
+          semantic_range: ["morada"],
+          notes: "Una nota.",
+          related: [{ translit: "bayit", note: "relacionado" }],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("false when a baseline field is left untranslated (English leakage)", () => {
+    expect(
+      isLemmaFullyTranslated(
+        base(),
+        base({
+          pos: "Sustantivo",
+          basic_gloss: "casa",
+          semantic_range: null, // leaks English
+          notes: "Una nota.",
+          related: [{ translit: "bayit", note: "relacionado" }],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("false when only basic_gloss is translated (old lenient policy)", () => {
+    expect(
+      isLemmaFullyTranslated(
+        base(),
+        base({
+          pos: null,
+          basic_gloss: "casa",
+          semantic_range: null,
+          notes: null,
+          related: null,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not require fields the baseline itself lacks", () => {
+    expect(
+      isLemmaFullyTranslated(
+        base({ notes: null, related: null }),
+        base({
+          pos: "Sustantivo",
+          basic_gloss: "casa",
+          semantic_range: ["morada"],
+          notes: null,
+          related: null,
+        }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/backend-base/src/lemmas/lemma-language.ts
+++ b/packages/backend-base/src/lemmas/lemma-language.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure helpers shared by the `/lemma` endpoint and the coverage report.
+ * No DB / service imports — kept side-effect free so they unit-test
+ * without a database or env.
+ */
+
+/**
+ * Normalize an incoming language code to the bare lowercase ISO 639 base
+ * code that `lemma_translations.language_code` is keyed on for the LLM
+ * pipeline (es, de, fr, ...).
+ *
+ * Strips a region/script suffix and lowercases, so `es-MX`, `ES`, `pt_BR`
+ * and `zh-Hans` collapse to `es` / `pt` / `zh`. The web/mobile client
+ * already strips the suffix before calling, but normalizing here as well
+ * means a stray region code — or an authenticated user's stored
+ * `preferred_language` that still carries one — matches the same row
+ * instead of silently falling back to English.
+ *
+ * Anything that isn't a plausible 2-3 letter code collapses to `"en"`,
+ * which keeps the value safe to inline as a SQL literal and routes the
+ * lookup to the English baseline (there are no `en` rows in
+ * `lemma_translations`).
+ */
+export function normalizeLanguageCode(raw: string | null | undefined): string {
+  const base = (raw ?? "").trim().toLowerCase().split(/[-_]/)[0];
+  return /^[a-z]{2,3}$/.test(base) ? base : "en";
+}
+
+/** Translatable prose fields on a lemma card (everything else is universal). */
+export const LEMMA_PROSE_FIELDS = [
+  "pos",
+  "basic_gloss",
+  "semantic_range",
+  "notes",
+  "related",
+] as const;
+
+export type LemmaProseField = (typeof LEMMA_PROSE_FIELDS)[number];
+
+export type LemmaProseValues = Record<LemmaProseField, unknown>;
+
+/**
+ * A lemma card "reads as fully translated" only when every English prose
+ * field present on the baseline has a non-null translation — i.e. no field
+ * leaks back to English via the field-by-field fallback. Fields the
+ * baseline itself lacks (null) impose no requirement.
+ *
+ * Callers MUST first confirm a translation row exists: with an all-null
+ * baseline (a non-loaded lemma) every check passes vacuously, so this
+ * returning `true` is only meaningful when paired with a row-presence
+ * check.
+ */
+export function isLemmaFullyTranslated(
+  base: LemmaProseValues,
+  translated: LemmaProseValues,
+): boolean {
+  return LEMMA_PROSE_FIELDS.every(
+    (field) => base[field] == null || translated[field] != null,
+  );
+}

--- a/packages/backend-base/src/lemmas/lemma.plugin.ts
+++ b/packages/backend-base/src/lemmas/lemma.plugin.ts
@@ -33,17 +33,23 @@ const LemmaCardSchema = t.Object({
   related: t.Union([t.Array(RelatedWordSchema), t.Null()]),
   /**
    * Language actually represented by the payload. Equals the requested
-   * `lang` query param when a translation row exists, else "en"
-   * (English baseline fallback). Frontend can use this to render a
-   * subtle "translated by AI" badge or skip it for English.
+   * `lang` query param (normalized to its base ISO code) whenever a
+   * translation row exists — even a partial one — else "en" (English
+   * baseline fallback).
    */
   language_code: t.String(),
   /**
-   * Origin of the translation — "llm:claude-haiku-4-5", "uw"
-   * (unfoldingWord), "hand", or null when no translation row exists
-   * (`is_translated: false`).
+   * Origin of the translation row — "llm:claude-haiku-4-5", "uw"
+   * (unfoldingWord), "hand", or null when no translation row exists.
    */
   source: t.Union([t.String(), t.Null()]),
+  /**
+   * True only when the card reads as fully translated — every English
+   * prose field present on the baseline has a translation, so nothing
+   * leaks back to English via the field-by-field fallback. A row that
+   * translates only some fields stays `false` (the "Translated" badge
+   * shouldn't claim a half-English card).
+   */
   is_translated: t.Boolean(),
 });
 
@@ -68,8 +74,9 @@ const plugin = new Elysia()
         }
         const strongs = `${m[1]}${Number.parseInt(m[2], 10).toString().padStart(4, "0")}`;
 
-        const lang = (query.lang ?? "en").trim();
-        const card = await lemmaService.getLemma(strongs, lang);
+        // Pass the raw query value through — the repository normalizes it
+        // to the bare ISO base code (es-MX/ES → es) before matching.
+        const card = await lemmaService.getLemma(strongs, query.lang ?? "en");
         if (!card) throw new NotFoundError(`Lemma not found: ${strongs}`);
         return card;
       },
@@ -84,7 +91,7 @@ const plugin = new Elysia()
           lang: t.Optional(
             t.String({
               description:
-                "ISO 639-1 language code (es, de, fr, ru, it, pt, ro, hi, tl, uk). Defaults to 'en'. Falls back to English baseline if no translation exists for the requested language.",
+                "ISO 639-1 language code (es, de, fr, ru, it, pt, ro, hi, tl, uk). Defaults to 'en'. Case-insensitive; a region suffix (es-MX) is stripped to its base code server-side. Falls back to English baseline if no translation exists for the requested language.",
             }),
           ),
         }),

--- a/packages/backend-base/src/lemmas/repository/lemma.repository.ts
+++ b/packages/backend-base/src/lemmas/repository/lemma.repository.ts
@@ -1,6 +1,10 @@
 import type { RelatedWord } from "database/src/models/public/Lemmas";
 import { sql } from "kysely";
 import type { db } from "../../shared/shared.plugin";
+import {
+  isLemmaFullyTranslated,
+  normalizeLanguageCode,
+} from "../lemma-language";
 
 /**
  * Merged lemma row returned from the DB after LEFT JOIN on
@@ -49,12 +53,19 @@ export class LemmaRepository {
   ): Promise<LemmaCard | null> {
     const connection = this.db.getOrCreateConnection();
 
+    // Match on the bare lowercase ISO base code the translation rows are
+    // keyed on (es, de, ...). Without this an `es-MX` / `ES` request misses
+    // every `es` row and silently falls back to English. The normalized
+    // value is also guaranteed `^[a-z]{2,3}$` (or "en"), so it stays safe
+    // to inline as the `sql.lit` literal below.
+    const lang = normalizeLanguageCode(languageCode);
+
     const row = await connection
       .selectFrom("lemmas")
       .leftJoin("lemma_translations", (join) =>
         join
           .onRef("lemmas.strongs", "=", "lemma_translations.strongs")
-          .on("lemma_translations.language_code", "=", sql.lit(languageCode))
+          .on("lemma_translations.language_code", "=", sql.lit(lang))
           .on("lemma_translations.is_active", "=", true),
       )
       .where("lemmas.strongs", "=", strongs)
@@ -71,6 +82,7 @@ export class LemmaRepository {
         "lemmas.semantic_range as base_semantic_range",
         "lemmas.notes as base_notes",
         "lemmas.related as base_related",
+        "lemma_translations.translation_id",
         "lemma_translations.translated_pos",
         "lemma_translations.translated_basic_gloss",
         "lemma_translations.translated_semantic_range",
@@ -82,7 +94,33 @@ export class LemmaRepository {
 
     if (!row) return null;
 
-    const isTranslated = row.translated_basic_gloss != null;
+    // A translation row exists for this language. `translation_id` is
+    // non-nullable on the row, so it reliably distinguishes "row present
+    // but some fields null" from "no row at all".
+    const hasTranslationRow = row.translation_id != null;
+
+    // `is_translated` means "this card reads as translated" — true only
+    // when the row covers every English prose field present on the
+    // baseline, so the "Translated" badge never shows over English prose
+    // leaked in via the field-by-field fallback below.
+    const isTranslated =
+      hasTranslationRow &&
+      isLemmaFullyTranslated(
+        {
+          pos: row.base_pos,
+          basic_gloss: row.base_basic_gloss,
+          semantic_range: row.base_semantic_range,
+          notes: row.base_notes,
+          related: row.base_related,
+        },
+        {
+          pos: row.translated_pos,
+          basic_gloss: row.translated_basic_gloss,
+          semantic_range: row.translated_semantic_range,
+          notes: row.translated_notes,
+          related: row.translated_related,
+        },
+      );
 
     return {
       strongs: row.strongs,
@@ -101,7 +139,11 @@ export class LemmaRepository {
       semantic_range: row.translated_semantic_range ?? row.base_semantic_range,
       notes: row.translated_notes ?? row.base_notes,
       related: row.translated_related ?? row.base_related,
-      language_code: isTranslated ? languageCode : "en",
+      // Which language's data the payload represents. Equals the requested
+      // (normalized) code whenever a translation row exists — even a
+      // partial one — else "en". `is_translated` separately signals whether
+      // that row is complete.
+      language_code: hasTranslationRow ? lang : "en",
       source: row.source,
       is_translated: isTranslated,
     };

--- a/scripts/lemma-translate/README.md
+++ b/scripts/lemma-translate/README.md
@@ -59,6 +59,23 @@ python3 translate_batch.py \
 
 After steps 1 + 2, `out/` is ready to feed the loader.
 
+## Measure coverage
+
+To see how much of each language is translated (and prioritize a
+backfill), run the read-only coverage report inside the deployed
+container — it queries the live DB, no inputs needed:
+
+```sh
+bun ./dist/lemma-coverage.js            # all known languages
+bun ./dist/lemma-coverage.js --lang es  # one language
+bun ./dist/lemma-coverage.js --json     # machine-readable
+```
+
+`complete` counts lemmas whose translation covers every English prose
+field (this is exactly what flips `is_translated: true` on `/lemma`);
+`partial` rows exist but still leak some English; `missing` rows have no
+translation at all. Source: `apps/backend/src/lemma-coverage.ts`.
+
 ## Deploy
 
 Hand the `out/` directory to the operator who can run inside the prod


### PR DESCRIPTION
## Context

Follows the lexicon-coverage handoff: non-English users see some lemma popovers fully translated and others in English, with "no obvious pattern." The handoff localizes the fix to the backend (`/lemma` endpoint + translation data) and lists actionable items. This PR implements the **code-side** items (#3 partial-field policy, #4 language matching) plus a coverage-measurement tool (#1).

> The actual translation **data backfill** (running the Anthropic batch + ingesting rows) can't run in the web/CI container — it needs an API key, the external `_lemmas.json` source, network to Anthropic, and a live DB. That step is left for an operator; this PR makes closing the gap correct and measurable.

## Changes

- **Language-code normalization (handoff #4).** The repository matched `lemma_translations.language_code` exactly, so an `es-MX` / `ES` request missed every `es` row and silently fell back to English — a real contributor to the "random/broken" symptom (mobile sends the iOS BCP-47 locale `es-MX`, not bare `es`). `normalizeLanguageCode` now strips the region/script suffix and lowercases (`es-MX`, `ES`, `pt_BR`, `zh-Hans` → `es`/`pt`/`zh`) before matching. The normalized value is constrained to `^[a-z]{2,3}$` (else `"en"`) — note Kysely's `sql.lit()` already escapes string literals so the prior code wasn't exploitable; this just tightens the value at the boundary so a future regression to raw concatenation can't reopen the door, and routes locale-suffixed misses to their base code.
- **Tighten `is_translated` (handoff #3).** Previously `true` whenever `translated_basic_gloss` was non-null — so a half-English card could still show the "Translated" badge. Now `true` only when the row covers **every** English prose field present on the baseline (no leakage via the field-by-field fallback). `language_code` now reflects whether any (possibly partial) row exists, matching the documented contract.
- **Coverage report (handoff #1).** New read-only `lemma-coverage` CLI, bundled into the deployed image like `ingest-lemmas`. Reports complete / partial / missing translation counts per language so the gap can be measured and prioritized:
  ```sh
  bun ./dist/lemma-coverage.js            # all known languages
  bun ./dist/lemma-coverage.js --lang es  # one language
  bun ./dist/lemma-coverage.js --json     # machine-readable
  ```
  Its "complete" definition reuses the same `isLemmaFullyTranslated` helper the endpoint uses, so the report and the badge agree.

## Test plan

- [x] `bun test src/lemmas/lemma-language.test.ts` — 12 pure-helper tests (normalization + completeness), no DB needed
- [x] `bunx tsc` clean
- [x] `biome check` clean
- [x] `bun run build` bundles `lemma-coverage.js`
- [ ] Operator: run `bun ./dist/lemma-coverage.js` against prod DB to quantify the gap, then backfill via `scripts/lemma-translate/` and re-run to confirm
- [ ] Operator: `curl "/lemma/H4161?lang=es-MX"` now matches the same row as `?lang=es`

https://claude.ai/code/session_011ucG45U2RwP5uKPshyBEgV