### PR TITLE
fix(bible): only Strong's-tag words that have a definition card

### DIFF
--- a/packages/backend-base/src/bible/repository/bible.repository.ts
+++ b/packages/backend-base/src/bible/repository/bible.repository.ts
@@ -143,6 +143,26 @@ export class BibleRepository {
   }
 
   /**
+   * Of the given Strong's numbers, return the subset that has an actual
+   * lemma card (a non-empty `basic_gloss`). Used to gate Strong's-tagged
+   * rendering so the reader only underlines words the user can actually
+   * tap into a definition for — ~12k of the ~14k tagged Strong's numbers
+   * have no card content, and underlining those produced empty popovers.
+   */
+  async getStrongsWithContent(strongs: string[]): Promise<Set<string>> {
+    if (strongs.length === 0) return new Set();
+    const rows = await this.db
+      .getOrCreateConnection()
+      .selectFrom("lemmas")
+      .where("strongs", "in", strongs)
+      .where("basic_gloss", "is not", null)
+      .where(sql<boolean>`trim(basic_gloss) <> ''`)
+      .select("strongs")
+      .execute();
+    return new Set(rows.map((r) => r.strongs));
+  }
+
+  /**
    * Localized book name for a given version (USFM \h). Falls back to null when
    * the version has no localized name (e.g. NASB1995, which uses books.name).
    */

--- a/packages/backend-base/src/bible/services/bible.service.ts
+++ b/packages/backend-base/src/bible/services/bible.service.ts
@@ -69,6 +69,43 @@ export class BibleService {
       withTokens: tagged,
     });
 
+    // Strong's-tagged rendering: only keep the tag on tokens whose lemma
+    // actually has a definition card. ~12k of the ~14k tagged Strong's
+    // numbers have no `basic_gloss`, and tagging those underlined words
+    // the user couldn't get a definition for (empty popover). Stripping
+    // `strongs`/`strongs_alt` here demotes them back to plain-text tokens,
+    // so the reader only underlines tap-worthy words. Untouched when not
+    // tagged (legacy path) or when a chapter has no token coverage.
+    if (tagged && verses) {
+      const allStrongs = new Set<string>();
+      for (const v of verses) {
+        const tokens = (v as { tokens?: VerseToken[] }).tokens;
+        if (!Array.isArray(tokens)) continue;
+        for (const tok of tokens) {
+          if (tok.strongs) allStrongs.add(tok.strongs);
+          for (const alt of tok.strongs_alt ?? []) allStrongs.add(alt);
+        }
+      }
+      if (allStrongs.size > 0) {
+        const withContent = await this.bibleRepository.getStrongsWithContent([
+          ...allStrongs,
+        ]);
+        for (const v of verses) {
+          const tokens = (v as { tokens?: VerseToken[] }).tokens;
+          if (!Array.isArray(tokens)) continue;
+          for (const tok of tokens) {
+            if (tok.strongs && !withContent.has(tok.strongs)) {
+              tok.strongs = undefined;
+            }
+            if (tok.strongs_alt) {
+              const keptAlt = tok.strongs_alt.filter((s) => withContent.has(s));
+              tok.strongs_alt = keptAlt.length > 0 ? keptAlt : undefined;
+            }
+          }
+        }
+      }
+    }
+
     return {
       book: this.formattedBook({ book, chapter, subtitles, verses, tagged }),
     };


### PR DESCRIPTION
## Problem
Andy: tapping underlined words on some Bible versions opened **empty** definition popovers.

The `?tagged=1` chapter endpoint emitted `strongs` for every aligned token straight from `verses.tokens`, with no check that the lemma had any card content. Distinct Strong's numbers tagged per version vs. how many have **no `basic_gloss`** (measured on prod):

| version | distinct tagged | empty card |
|---|---|---|
| TGLULB | 13,344 | 11,224 |
| RVR09 | 13,325 | 11,207 |
| LSG | 12,312 | 10,300 |
| SCH51 | 9,454 | 7,670 |
| SYN | 4,854 | 2,721 |
| VDC / RIV / HCV / BLIV / UKRKL | ~2,100 | ~2 (already curated) |

So on the first five versions **70–85% of underlined words led to an empty popover.** (English NASB1995/KJV are unaffected — they use the bundled `@versemate/lexicon`, which is the curated 12k-entry set with no empties.)

## Fix
Gate the tag on content. `getBook({tagged:true})` collects the chapter's Strong's numbers, asks the repository which have a non-empty `basic_gloss` (new `getStrongsWithContent`), and strips `strongs`/`strongs_alt` off any token whose lemma has no card. Those tokens fall back to the plain-text shape, so the reader simply doesn't underline them.

- One extra indexed `strongs IN (...)` lookup per tagged request, bounded by chapter size.
- No data deletion — purely a read-time filter, fully reversible.

## Verification (against prod, read-only)
- LSG / RVR09 / SCH51 Genesis 1: ~75% of taggings dropped (the empty-card words), the rest kept.
- VDC / RIV Genesis 1: 0 dropped (already curated).
- `bun tsc` clean.

## Follow-up (not needed for this symptom)
The ~16k empty lemma rows can stay — they're harmless once untagged. If Andy still wants the table pruned for housekeeping that's a separate, optional migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)