### PR TITLE
fix(db): restore migration deleted by VER-120 revert (unblocks all deploys)

### DIFF
--- a/packages/database/migrations/20260521120000-update-byline-template-min-sentences.ts
+++ b/packages/database/migrations/20260521120000-update-byline-template-min-sentences.ts
@@ -1,0 +1,44 @@
+import { type Kysely, sql } from "kysely";
+import type Database from "../src/models/Database";
+
+/**
+ * Update the active Byline Template in user_prompt_templates to require
+ * "at least 3 complete sentences" per verse Summary — aligns the DB record
+ * with the VER-120 quality gate enforced in the generation pipeline.
+ *
+ * Prior wording said "at least 2-3 sentences", which allowed 2-sentence
+ * outputs that fail the quality bar.
+ */
+export async function up(db: Kysely<Database>): Promise<void> {
+  console.log(
+    "VER-120: updating byline template to require ≥3-sentence summaries...",
+  );
+
+  await sql`
+    UPDATE user_prompt_templates
+    SET prompt_template = REPLACE(
+          REPLACE(
+            prompt_template,
+            'in at least 2-3 sentences',
+            'in at least 3 complete sentences'
+          ),
+          'at least 2-3 sentences',
+          'at least 3 complete sentences'
+        )
+    WHERE explanation_type = 'byline'
+  `.execute(db);
+
+  console.log("VER-120: byline template updated.");
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await sql`
+    UPDATE user_prompt_templates
+    SET prompt_template = REPLACE(
+          prompt_template,
+          'in at least 3 complete sentences',
+          'in at least 2-3 sentences'
+        )
+    WHERE explanation_type = 'byline'
+  `.execute(db);
+}


### PR DESCRIPTION
## Critical — every deploy since the VER-120 revert has been failing

DO App Platform runs the migrator before the app boots. Since #253 (the VER-120 revert) deleted the migration file `20260521120000-update-byline-template-min-sentences.ts`, the migrator dies:

```
error: corrupted migrations: previously executed migration
20260521120000-update-byline-template-min-sentences is missing
ERROR component terminated with non-zero exit code: 1
```

Kysely refuses to run when a migration recorded as executed in the DB is missing from disk. That's why #254 (the Strong's content-gate) built green in CI but never went live — the container couldn't boot.

## Fix
Restore the migration file verbatim from its original commit (`01f12b1`). It's already applied in prod, so the migrator finds it in the executed set and **skips it** — pure no-op at runtime; it just satisfies the on-disk integrity check.

The revert correctly removed the actually-bad part (the per-deploy startup remediation hook + audit script). Only the migration *file* needed to come back — deleting an already-applied migration file is never safe.

## After merge
- Deploy should boot cleanly.
- #254's content-gate goes live with it — verify: `curl 'https://api.versemate.org/bible/book/1/1?bible_version=LSG&tagged=1'` should drop from ~290 tagged tokens to ~70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)