### PR TITLE
fix(database): repair corrupted migrations after VER-120 revert

### DIFF
--- a/packages/database/migrations/20260529120000-revert-byline-template-min-sentences.ts
+++ b/packages/database/migrations/20260529120000-revert-byline-template-min-sentences.ts
@@ -1,0 +1,52 @@
+import { type Kysely, sql } from "kysely";
+import type Database from "../src/models/Database";
+
+/**
+ * Compensating migration for the reverted VER-120 change (PR #240, reverted in
+ * PR #253). The original migration 20260521120000-update-byline-template-min-sentences
+ * rewrote the active Byline Template wording from "at least 2-3 sentences" to
+ * "at least 3 complete sentences" via a data UPDATE.
+ *
+ * Reverting PR #240 only removed the migration *file* — the prod DB data change
+ * stayed applied. This migration rolls that data change back so the DB matches
+ * the reverted code.
+ *
+ * Note: the orphan kysely_migration row for 20260521120000 must be deleted
+ * separately (bun migrate:fix 20260521120000-update-byline-template-min-sentences)
+ * before this runs — Kysely's corruption check aborts migrateToLatest before any
+ * migration executes while that row exists.
+ *
+ * Uses the broad pattern "at least 3 complete sentences" so it undoes BOTH
+ * forms the original up() produced ("in at least 3 complete sentences" and the
+ * bare "at least 3 complete sentences"); the original down() only handled the
+ * "in ..." form. Idempotent: REPLACE is a no-op if already in the 2-3 form.
+ */
+export async function up(db: Kysely<Database>): Promise<void> {
+  console.log(
+    "VER-120 revert: reverting byline template back to '2-3 sentences'...",
+  );
+
+  await sql`
+    UPDATE user_prompt_templates
+    SET prompt_template = REPLACE(
+          prompt_template,
+          'at least 3 complete sentences',
+          'at least 2-3 sentences'
+        )
+    WHERE explanation_type = 'byline'
+  `.execute(db);
+
+  console.log("VER-120 revert: byline template reverted.");
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await sql`
+    UPDATE user_prompt_templates
+    SET prompt_template = REPLACE(
+          prompt_template,
+          'at least 2-3 sentences',
+          'at least 3 complete sentences'
+        )
+    WHERE explanation_type = 'byline'
+  `.execute(db);
+}

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -2,10 +2,11 @@
   "name": "database",
   "module": "index.ts",
   "scripts": {
-    "build": "bun build ./src/migrator.ts ./src/seeder.ts --target bun --minify --outdir ./dist",
+    "build": "bun build ./src/migrator.ts ./src/seeder.ts ./src/actions/fix-migration.ts --target bun --minify --outdir ./dist",
     "migrate:deploy": "bun ./src/migrator.ts migrate-deploy",
     "migrate:dev": "bun ./src/migrator.ts migrate-dev",
     "migrate:down": "bun ./src/migrator.ts migrate-down",
+    "migrate:fix": "bun ./src/actions/fix-migration.ts",
     "model:generate": "kanel && biome check --write ./src/models",
     "dbml:generate": "prisma db pull && prisma generate",
     "db:seed": "bun ./src/seeder.ts",


### PR DESCRIPTION
## Problem

Reverting #240 (VER-120, in #253) deleted the migration file `20260521120000-update-byline-template-min-sentences` but left two effects on prod DB:

1. **Orphan `kysely_migration` row** → Kysely runs its corruption check *before* executing any migration, so it throws `previously executed migration ... is missing` and aborts every `migrate-deploy` — including the container-boot CMD. **All deploys blocked.**
2. **Data change stayed applied** — byline template text still reads `at least 3 complete sentences` instead of `at least 2-3 sentences`. The revert only removed the file, not the DB UPDATE.

```
error: corrupted migrations: previously executed migration 20260521120000-update-byline-template-min-sentences is missing
```

## Fix

- **Compensating migration** `20260529120000-revert-byline-template-min-sentences.ts` — reverts the template text back to `2-3 sentences`. Uses the broad `at least 3 complete sentences` → `at least 2-3 sentences` pattern so it undoes **both** forms the original `up()` produced (the original `down()` only handled the `in ...` variant). Idempotent.
- **`migrate:fix` npm script** + bundle `fix-migration.ts` into `build` (`dist/actions/fix-migration.js`) so the orphan-row deletion is runnable in the prod container.

## ⚠️ Required prod op — ordered

**Step 1 (run BEFORE deploying this)** — delete the orphan row on prod DB:
```bash
cd packages/database && bun migrate:fix 20260521120000-update-byline-template-min-sentences
```
or
```sql
DELETE FROM kysely_migration WHERE name = '20260521120000-update-byline-template-min-sentences';
```

**Step 2** — merge + deploy. Container boot runs `migrate-deploy` → applies the compensating migration → template data reverted, DB consistent with reverted code.

Order matters: Step 2's migration cannot run while the orphan row exists.

> Any other environment that ran the reverted migration (staging?) needs Step 1 too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
