### PR TITLE
fix(batch): bump DEFAULT_MAX_OUTPUT_TOKENS 50k→90k (avoid truncation)

### DIFF
--- a/packages/backend-base/src/admin/services/batch-operations.service.ts
+++ b/packages/backend-base/src/admin/services/batch-operations.service.ts
@@ -41,7 +41,11 @@ interface BatchJobRequest {
   };
 }
 
-export const DEFAULT_MAX_OUTPUT_TOKENS = 50000;
+// Ceiling, not a target — only allows longer output when the model needs it.
+// Bumped 50k→90k after long study chapters (e.g. ru Matthew 25, uk Jeremiah 41)
+// truncated: high-effort reasoning tokens count toward this limit, so big
+// documents hit 50k and returned incomplete JSON. 90k lands them.
+export const DEFAULT_MAX_OUTPUT_TOKENS = 90000;
 
 async function calculateActualCost(
   promptTokens: number,


### PR DESCRIPTION
Long study chapters (ru Matthew 25, uk Jeremiah 41) deterministically truncated — high-effort reasoning tokens count toward `max_output_tokens`, so big docs hit the 50k ceiling and returned incomplete JSON. Re-running at 90k landed both. It's a ceiling, not a target, so this only allows longer output when the model needs it (no effect on short batches, no forced cost increase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)