### PR TITLE
feat(translate): local claude -p translation path + resumable queue

### DIFF
--- a/packages/backend-base/src/admin/services/batch-operations.service.ts
+++ b/packages/backend-base/src/admin/services/batch-operations.service.ts
@@ -1282,23 +1282,28 @@ export class BatchOperationService {
     }));
   }
 
-  private async createBookTranslateBatch(
+  /**
+   * Build the translate `BatchJobRequest[]` for a book + target language +
+   * explanation types, WITHOUT submitting anything to OpenAI. This is the pure
+   * request-building half of `createBookTranslateBatch`, extracted so the local
+   * `claude -p` path can obtain the exact same requests and run them itself.
+   *
+   * Returns the requests plus the resolved `bookId` (the caller's OpenAI path
+   * needs it for the file name + batch_jobs row). `skipExisting` filtering is
+   * applied internally so there is a single source of truth for the query +
+   * prompt/title loading + per-explanation `buildTranslateRequests` mapping.
+   */
+  private async buildBookTranslateRequestsInternal(
     model: string,
-    adminUserId: string,
-    effort: "low" | "medium" | "high",
-    bookName: string,
-    source_language_code: string,
-    target_language_code: string,
+    sourceLanguageCode: string,
+    targetLanguageCode: string,
     explanationTypes: string[],
+    bookName: string,
+    effort: "low" | "medium" | "high",
+    maxOutputTokens: number,
     skipExisting: boolean,
-    parentBatchId?: number,
     chapterNumbers?: number[],
-    maxOutputTokens = DEFAULT_MAX_OUTPUT_TOKENS,
-    batchType = "translate",
-  ) {
-    console.log(
-      `[BATCH] Creating translate batch for book: ${bookName}, source: ${source_language_code}, target: ${target_language_code}${chapterNumbers ? `, chapters: ${chapterNumbers.join(", ")}` : ""}`,
-    );
+  ): Promise<{ batchRequests: BatchJobRequest[]; bookId: number }> {
     const connection = this.db.getOrCreateConnection();
 
     const book = await connection
@@ -1317,12 +1322,12 @@ export class BatchOperationService {
 
     const sourceVersion = await connection
       .selectFrom("bible_versions")
-      .where("language_code", "=", source_language_code)
+      .where("language_code", "=", sourceLanguageCode)
       .select("language_code")
       .executeTakeFirst();
 
     if (!sourceVersion) {
-      const error = `Source Bible version with language "${source_language_code}" not found.`;
+      const error = `Source Bible version with language "${sourceLanguageCode}" not found.`;
       console.error(`[BATCH] ${error}`);
       throw new Error(error);
     }
@@ -1333,7 +1338,7 @@ export class BatchOperationService {
 
     const targetVersion = await connection
       .selectFrom("bible_versions")
-      .where("language_code", "=", target_language_code)
+      .where("language_code", "=", targetLanguageCode)
       .select(["id", "language_code"])
       .executeTakeFirst();
 
@@ -1341,7 +1346,7 @@ export class BatchOperationService {
     // We can create explanations for any valid language code
     if (!targetVersion) {
       console.log(
-        `[BATCH] Target Bible version with language "${target_language_code}" not found in database, but continuing with translation to custom language.`,
+        `[BATCH] Target Bible version with language "${targetLanguageCode}" not found in database, but continuing with translation to custom language.`,
       );
     } else {
       console.log(
@@ -1364,7 +1369,7 @@ export class BatchOperationService {
 
     console.log("[BATCH] Found active translate prompt");
 
-    const language = getLanguageName(target_language_code);
+    const language = getLanguageName(targetLanguageCode);
     const finalPrompt = translatePrompt.prompt.replace("{language}", language);
 
     console.log(`[BATCH] Target language name: ${language}`);
@@ -1372,7 +1377,7 @@ export class BatchOperationService {
     // Fetch localized title templates for the target language
     const titleTemplates = await connection
       .selectFrom("translation_templates")
-      .where("language_code", "=", target_language_code)
+      .where("language_code", "=", targetLanguageCode)
       .select(["type", "title_template"])
       .execute();
 
@@ -1403,7 +1408,7 @@ export class BatchOperationService {
       .selectFrom("explanations")
       .innerJoin("chapters", "explanations.chapter_id", "chapters.chapter_id")
       .where("chapters.book_id", "=", book.book_id)
-      .where("explanations.language_code", "=", source_language_code)
+      .where("explanations.language_code", "=", sourceLanguageCode)
       .where("is_active", "=", true);
 
     if (chapterNumbers && chapterNumbers.length > 0) {
@@ -1427,7 +1432,7 @@ export class BatchOperationService {
       .execute();
 
     console.log(
-      `[BATCH] Found ${activeExplanations.length} active explanations for ${bookName} in ${source_language_code}`,
+      `[BATCH] Found ${activeExplanations.length} active explanations for ${bookName} in ${sourceLanguageCode}`,
     );
 
     let batchRequests: BatchJobRequest[] = [];
@@ -1438,7 +1443,7 @@ export class BatchOperationService {
         .selectFrom("explanations")
         .innerJoin("chapters", "explanations.chapter_id", "chapters.chapter_id")
         .where("chapters.book_id", "=", book.book_id)
-        .where("explanations.language_code", "=", target_language_code)
+        .where("explanations.language_code", "=", targetLanguageCode)
         .where("explanations.type", "in", explanationTypes as any)
         .where("explanations.is_active", "=", true);
 
@@ -1473,7 +1478,7 @@ export class BatchOperationService {
           for (const req of this.buildTranslateRequests({
             explanation,
             bookName,
-            targetLanguageCode: target_language_code,
+            targetLanguageCode,
             itemPrompt,
             model,
             effort,
@@ -1497,7 +1502,7 @@ export class BatchOperationService {
         return this.buildTranslateRequests({
           explanation,
           bookName,
-          targetLanguageCode: target_language_code,
+          targetLanguageCode,
           itemPrompt,
           model,
           effort,
@@ -1505,6 +1510,75 @@ export class BatchOperationService {
         });
       });
     }
+
+    return { batchRequests, bookId: book.book_id };
+  }
+
+  /**
+   * Public pure request-builder for the explanation translate path: returns the
+   * `BatchJobRequest[]` for a book + target language + explanation types without
+   * any OpenAI submission. Used by the local `claude -p` executor (Part B).
+   *
+   * `skipExisting` (default false) forwards to the internal helper so the queue
+   * worker can build only the still-undone requests; existing callers that omit
+   * it keep the prior full-set behavior.
+   */
+  async buildBookTranslateRequests(
+    model: string,
+    sourceLanguageCode: string,
+    targetLanguageCode: string,
+    explanationTypes: string[],
+    bookName: string,
+    effort: "low" | "medium" | "high",
+    maxOutputTokens: number,
+    chapterNumbers?: number[],
+    skipExisting = false,
+  ): Promise<BatchJobRequest[]> {
+    const { batchRequests } = await this.buildBookTranslateRequestsInternal(
+      model,
+      sourceLanguageCode,
+      targetLanguageCode,
+      explanationTypes,
+      bookName,
+      effort,
+      maxOutputTokens,
+      skipExisting,
+      chapterNumbers,
+    );
+    return batchRequests;
+  }
+
+  private async createBookTranslateBatch(
+    model: string,
+    adminUserId: string,
+    effort: "low" | "medium" | "high",
+    bookName: string,
+    source_language_code: string,
+    target_language_code: string,
+    explanationTypes: string[],
+    skipExisting: boolean,
+    parentBatchId?: number,
+    chapterNumbers?: number[],
+    maxOutputTokens = DEFAULT_MAX_OUTPUT_TOKENS,
+    batchType = "translate",
+  ) {
+    console.log(
+      `[BATCH] Creating translate batch for book: ${bookName}, source: ${source_language_code}, target: ${target_language_code}${chapterNumbers ? `, chapters: ${chapterNumbers.join(", ")}` : ""}`,
+    );
+    const connection = this.db.getOrCreateConnection();
+
+    const { batchRequests, bookId } =
+      await this.buildBookTranslateRequestsInternal(
+        model,
+        source_language_code,
+        target_language_code,
+        explanationTypes,
+        bookName,
+        effort,
+        maxOutputTokens,
+        skipExisting,
+        chapterNumbers,
+      );
 
     if (batchRequests.length === 0) {
       console.log(
@@ -1546,7 +1620,7 @@ export class BatchOperationService {
     const file = await this.ai.filesCreate({
       file: new File(
         [new Uint8Array(buffer)],
-        `translate_batch_${book.book_id}_${Date.now()}.jsonl`,
+        `translate_batch_${bookId}_${Date.now()}.jsonl`,
       ),
       purpose: "batch",
     });
@@ -1570,7 +1644,7 @@ export class BatchOperationService {
         model,
         total_requests: batchRequests.length,
         created_by: adminUserId,
-        book_id: book.book_id,
+        book_id: bookId,
         parent_batch_id: parentBatchId,
         bible_version: target_language_code,
         source_language_code,
@@ -3179,7 +3253,7 @@ export class BatchOperationService {
     );
   }
 
-  private async processTranslateOutputFile(
+  async processTranslateOutputFile(
     batchId: string,
     outputFileId: string,
     batchJob: {
@@ -3187,14 +3261,23 @@ export class BatchOperationService {
       bible_version?: string;
       book_id?: number | null;
     },
+    localContent?: string,
   ) {
-    const fileContent = await this.ai.filesContent(outputFileId);
-    const jsonData =
-      typeof (fileContent as any).text === "function"
-        ? await (fileContent as any).text()
-        : typeof (fileContent as any).arrayBuffer === "function"
-          ? new TextDecoder().decode(await (fileContent as any).arrayBuffer())
-          : String(fileContent);
+    // When `localContent` is provided (local `claude -p` path), use it directly
+    // as the output file content and skip the OpenAI download entirely.
+    // Otherwise behave exactly as before.
+    let jsonData: string;
+    if (localContent != null) {
+      jsonData = localContent;
+    } else {
+      const fileContent = await this.ai.filesContent(outputFileId);
+      jsonData =
+        typeof (fileContent as any).text === "function"
+          ? await (fileContent as any).text()
+          : typeof (fileContent as any).arrayBuffer === "function"
+            ? new TextDecoder().decode(await (fileContent as any).arrayBuffer())
+            : String(fileContent);
+    }
     const lines = jsonData
       .split("\n")
       .filter((line: string) => line.trim() !== "");
@@ -5815,16 +5898,24 @@ export class BatchOperationService {
     };
   }
 
-  private async createStudyTranslateBatch(
+  /**
+   * Pure request-builder for the study translate path: returns the
+   * `BatchJobRequest[]` for a book + target language without any OpenAI
+   * submission. Extracted from `createStudyTranslateBatch` (the studies query +
+   * `skipExisting` filter + prompt load + per-study request mapping) so the
+   * local `claude -p` executor (Part B) can obtain the exact same requests.
+   * Returns `[]` when there is nothing to translate (no studies, or all already
+   * translated under `skipExisting`).
+   */
+  async buildStudyTranslateRequests(
     model: string,
-    adminUserId: string,
+    targetLanguageCode: string,
     effort: "low" | "medium" | "high",
     bookName: string,
-    target_language_code: string,
     skipExisting: boolean,
     chapterNumbers?: number[],
     maxOutputTokens = DEFAULT_MAX_OUTPUT_TOKENS,
-  ) {
+  ): Promise<BatchJobRequest[]> {
     const connection = this.db.getOrCreateConnection();
 
     // Select studies by the book name stored in their own content, NOT via the
@@ -5845,7 +5936,7 @@ export class BatchOperationService {
           chapterNumbers ? ` chapters=${chapterNumbers.join(",")}` : ""
         }`,
       );
-      return null;
+      return [];
     }
 
     let toTranslate = studies;
@@ -5853,7 +5944,7 @@ export class BatchOperationService {
       const existing = await connection
         .selectFrom("study_translations")
         .select(["study_id"])
-        .where("language_code", "=", target_language_code)
+        .where("language_code", "=", targetLanguageCode)
         .where("is_active", "=", true)
         .where(
           "study_id",
@@ -5867,9 +5958,9 @@ export class BatchOperationService {
 
     if (toTranslate.length === 0) {
       console.log(
-        `[BATCH][study-translate] all ${studies.length} studies already translated to ${target_language_code} for ${bookName}`,
+        `[BATCH][study-translate] all ${studies.length} studies already translated to ${targetLanguageCode} for ${bookName}`,
       );
-      return null;
+      return [];
     }
 
     // Load the active study-translate prompt from the `prompts` table — same
@@ -5877,7 +5968,7 @@ export class BatchOperationService {
     // `translate` batch loads `prompt_type='translate'` the same way). The
     // prompt text lives in the DB (managed via the admin prompts UI), NOT in
     // code; `{language}` is substituted with the target language name.
-    const languageName = getLanguageName(target_language_code);
+    const languageName = getLanguageName(targetLanguageCode);
     const studyPrompt = await connection
       .selectFrom("prompts")
       .where("prompt_type", "=", "translate-study")
@@ -5891,8 +5982,8 @@ export class BatchOperationService {
     }
     const instruction = studyPrompt.prompt.replace("{language}", languageName);
 
-    const batchRequests: BatchJobRequest[] = toTranslate.map((study) => ({
-      custom_id: `study|${bookName}|${study.chapter}|${target_language_code}|${study.study_id}`,
+    return toTranslate.map((study) => ({
+      custom_id: `study|${bookName}|${study.chapter}|${targetLanguageCode}|${study.study_id}`,
       method: "POST",
       url: "/v1/responses",
       body: {
@@ -5908,6 +5999,35 @@ export class BatchOperationService {
         text: { format: { type: "json_object" } },
       },
     }));
+  }
+
+  private async createStudyTranslateBatch(
+    model: string,
+    adminUserId: string,
+    effort: "low" | "medium" | "high",
+    bookName: string,
+    target_language_code: string,
+    skipExisting: boolean,
+    chapterNumbers?: number[],
+    maxOutputTokens = DEFAULT_MAX_OUTPUT_TOKENS,
+  ) {
+    const connection = this.db.getOrCreateConnection();
+
+    const batchRequests = await this.buildStudyTranslateRequests(
+      model,
+      target_language_code,
+      effort,
+      bookName,
+      skipExisting,
+      chapterNumbers,
+      maxOutputTokens,
+    );
+
+    // Nothing to translate (no studies, or all already translated under
+    // skipExisting) — the builder already logged the reason. Skip submission.
+    if (batchRequests.length === 0) {
+      return null;
+    }
 
     const validation = this.validateCustomIdUniqueness(batchRequests);
     if (!validation.isValid) {
@@ -6019,30 +6139,13 @@ export class BatchOperationService {
   }
 
   /**
-   * Writeback for "translate-study" batches: parse each result line, validate
-   * the translated study JSON, and upsert into study_translations
-   * (unique on study_id + language_code).
+   * Load the deterministic term dictionary once (all languages) and return a
+   * lazy per-language resolver. Best-effort: a dictionary failure must never
+   * break a writeback (translations still land, just un-normalized). Shared by
+   * the OpenAI batch writeback and the local `claude -p` path.
    */
-  async processStudyTranslateOutputFile(
-    batchId: string,
-    outputFileId: string,
-    batchJob: { model: string },
-  ) {
-    const fileResponse = await this.ai.filesContent(outputFileId);
-    let content: string;
-    try {
-      content = await fileResponse.text();
-    } catch {
-      const buf = await fileResponse.arrayBuffer();
-      content = new TextDecoder().decode(buf);
-    }
-
-    const lines = content.split("\n").filter((l) => l.trim());
+  async loadStudyTermDictResolver(): Promise<(lang: string) => StudyTermDict> {
     const connection = this.db.getOrCreateConnection();
-
-    // Load the deterministic term dictionary once (all languages), then build a
-    // per-language lookup lazily. Best-effort: a dictionary failure must never
-    // break the writeback (translations still land, just un-normalized).
     let termRows: StudyTermRow[] = [];
     try {
       termRows = await connection
@@ -6054,7 +6157,7 @@ export class BatchOperationService {
       console.error("[BATCH][study-translate] term dictionary load failed:", e);
     }
     const dictCache = new Map<string, StudyTermDict>();
-    const dictFor = (lang: string): StudyTermDict => {
+    return (lang: string): StudyTermDict => {
       let d = dictCache.get(lang);
       if (!d) {
         d = buildStudyTermDictMap(termRows, lang);
@@ -6062,6 +6165,95 @@ export class BatchOperationService {
       }
       return d;
     };
+  }
+
+  /**
+   * Parse + validate one model response and upsert it into study_translations
+   * (unique on study_id + language_code). Shared by the OpenAI batch writeback
+   * and the local `claude -p` path so the saving logic can never drift.
+   * Returns true on success, false if the text failed to parse or had an
+   * invalid study shape.
+   */
+  async writeStudyTranslation(
+    studyId: number,
+    languageCode: string,
+    rawText: string,
+    model: string,
+    dictFor: (lang: string) => StudyTermDict,
+  ): Promise<boolean> {
+    const translated = this.parseStudyJson(rawText);
+    if (!translated || !this.isValidStudyShape(translated)) {
+      console.error(
+        `[BATCH][study-translate] invalid translated JSON/shape for study_id=${studyId} (${languageCode})`,
+      );
+      return false;
+    }
+
+    // Deterministically fix any label-like field the model left in English
+    // (pills/contrast-type/columns/title book name) from the DB dictionary.
+    const { content: normalized, replaced } = applyStudyTermDictionary(
+      translated,
+      dictFor(languageCode),
+    );
+    if (replaced > 0) {
+      console.log(
+        `[BATCH][study-translate] normalized ${replaced} term(s) for study_id=${studyId} (${languageCode})`,
+      );
+    }
+
+    const connection = this.db.getOrCreateConnection();
+    await connection
+      .insertInto("study_translations")
+      .values({
+        study_id: studyId,
+        language_code: languageCode,
+        translated_content: normalized as object,
+        source: model,
+        is_active: true,
+      })
+      .onConflict((oc) =>
+        oc.columns(["study_id", "language_code"]).doUpdateSet({
+          translated_content: normalized as object,
+          source: model,
+          is_active: true,
+          updated_at: new Date(),
+        }),
+      )
+      .execute();
+    return true;
+  }
+
+  /**
+   * Writeback for "translate-study" batches: parse each result line, validate
+   * the translated study JSON, and upsert into study_translations
+   * (unique on study_id + language_code).
+   */
+  async processStudyTranslateOutputFile(
+    batchId: string,
+    outputFileId: string,
+    batchJob: { model: string },
+    localContent?: string,
+  ) {
+    // When `localContent` is provided (local `claude -p` path), use it directly
+    // as the output file content and skip the OpenAI download entirely.
+    // Otherwise behave exactly as before.
+    let content: string;
+    if (localContent != null) {
+      content = localContent;
+    } else {
+      const fileResponse = await this.ai.filesContent(outputFileId);
+      try {
+        content = await fileResponse.text();
+      } catch {
+        const buf = await fileResponse.arrayBuffer();
+        content = new TextDecoder().decode(buf);
+      }
+    }
+
+    const lines = content.split("\n").filter((l) => l.trim());
+    const connection = this.db.getOrCreateConnection();
+
+    const dictFor = await this.loadStudyTermDictResolver();
 
     let successCount = 0;
     let errorCount = 0;
@@ -6138,46 +6330,18 @@ export class BatchOperationService {
         continue;
       }
 
-      const translated = this.parseStudyJson(extractedText);
-      if (!translated || !this.isValidStudyShape(translated)) {
-        console.error(
-          `[BATCH][study-translate] invalid translated JSON/shape for study_id=${studyId} (${languageCode})`,
-        );
-        errorCount++;
-        continue;
-      }
-
-      // Deterministically fix any label-like field the model left in English
-      // (pills/contrast-type/columns/title book name) from the DB dictionary.
-      const { content: normalized, replaced } = applyStudyTermDictionary(
-        translated,
-        dictFor(languageCode),
+      const ok = await this.writeStudyTranslation(
+        studyId,
+        languageCode,
+        extractedText,
+        batchJob.model,
+        dictFor,
       );
-      if (replaced > 0) {
-        console.log(
-          `[BATCH][study-translate] normalized ${replaced} term(s) for study_id=${studyId} (${languageCode})`,
-        );
+      if (ok) {
+        successCount++;
+      } else {
+        errorCount++;
       }
-
-      await connection
-        .insertInto("study_translations")
-        .values({
-          study_id: studyId,
-          language_code: languageCode,
-          translated_content: normalized as object,
-          source: batchJob.model,
-          is_active: true,
-        })
-        .onConflict((oc) =>
-          oc.columns(["study_id", "language_code"]).doUpdateSet({
-            translated_content: normalized as object,
-            source: batchJob.model,
-            is_active: true,
-            updated_at: new Date(),
-          }),
-        )
-        .execute();
-      successCount++;
     }
 
     const actualCost = await calculateActualCost(

--- a/packages/backend-base/src/bible/claude-batch-executor.ts
+++ b/packages/backend-base/src/bible/claude-batch-executor.ts
@@ -1,0 +1,169 @@
+/**
+ * Run an array of OpenAI-Batch-shaped requests through a LOCAL `claude -p`
+ * subprocess instead of submitting them to the OpenAI Batch API, and produce
+ * output in the SAME JSONL line shape that the existing `process*OutputFile`
+ * writebacks parse. This lets the local Claude path reuse the unchanged
+ * request-building (`buildBookTranslateRequests` / `buildStudyTranslateRequests`)
+ * and the unchanged writeback (`processTranslateOutputFile` /
+ * `processStudyTranslateOutputFile`) — only the OpenAI "middle step" is swapped.
+ *
+ * Per-request transport is delegated to `runClaudeTranslate` (see
+ * `study-claude-translator.ts`); this module is the batch driver around it:
+ * sequential execution (single subscription), usage-limit short-circuit, and
+ * OpenAI-output-line synthesis.
+ */
+import { runClaudeTranslate } from "./study-claude-translator";
+
+/**
+ * Minimal compatible shape of the request objects the batch services build.
+ * The full `BatchJobRequest` interface in `batch-operations.service.ts` is not
+ * exported; we only read these fields here, so a structurally-compatible local
+ * definition keeps this module decoupled while remaining assignable from the
+ * service's array.
+ */
+export interface BatchJobRequestLike {
+  custom_id: string;
+  body: {
+    model: string;
+    instructions?: string;
+    input: string;
+  };
+}
+
+export interface ClaudeBatchResult {
+  /** Newline-joined OpenAI-output-shaped lines, ready for a `process*OutputFile`. */
+  jsonl: string;
+  total: number;
+  succeeded: number;
+  failed: number;
+  /** True if we hit a usage/session limit and stopped early. */
+  stoppedByUsageLimit: boolean;
+}
+
+export interface ExecuteBatchViaClaudeOptions {
+  /** Claude model alias passed through to `runClaudeTranslate` ("haiku" | "sonnet" | "opus"). */
+  model: string;
+  /** Dedicated-subscription config dir (CLAUDE_CONFIG_DIR). Omit = ambient login. */
+  configDir?: string;
+  /** Hard per-request subprocess timeout, ms. */
+  timeoutMs?: number;
+  /** Called after each processed request (whether success or failure). */
+  onProgress?: (done: number, total: number, customId: string) => void;
+}
+
+/**
+ * Run each request sequentially through `claude -p` and synthesize an
+ * OpenAI-output JSONL line per processed request, matching exactly what the
+ * writebacks parse: `custom_id`, `response.status_code`,
+ * `response.body.usage.{input_tokens,output_tokens}`, and the text at
+ * `response.body.output[0].content[0].text`.
+ *
+ * Usage limit → stop early (no line emitted for the limited request; the
+ * remaining requests are simply not processed this run). Transient/error
+ * responses and thrown spawn/timeout failures emit a non-200 line so the
+ * writeback counts them as errors and skips them, without aborting the batch.
+ */
+export async function executeBatchRequestsViaClaude(
+  requests: BatchJobRequestLike[],
+  opts: ExecuteBatchViaClaudeOptions,
+): Promise<ClaudeBatchResult> {
+  const { model, configDir, timeoutMs, onProgress } = opts;
+  const total = requests.length;
+  const lines: string[] = [];
+  let succeeded = 0;
+  let failed = 0;
+  let done = 0;
+  let stoppedByUsageLimit = false;
+
+  for (const req of requests) {
+    if (stoppedByUsageLimit) break;
+
+    const customId = req.custom_id;
+
+    try {
+      const result = await runClaudeTranslate({
+        instruction: req.body.instructions ?? "",
+        input: req.body.input,
+        model,
+        configDir,
+        timeoutMs,
+      });
+
+      if (result.isUsageLimit) {
+        // Hit a usage/session wall — stop and leave the rest unprocessed.
+        // Do NOT emit a line for this request.
+        stoppedByUsageLimit = true;
+        break;
+      }
+
+      const inputTokens = result.usage?.input_tokens ?? 0;
+      const outputTokens = result.usage?.output_tokens ?? 0;
+
+      if (result.isError) {
+        // Transient (e.g. 529) or other CLI error → non-200 line so the
+        // writeback counts it as an error and skips it.
+        failed++;
+        lines.push(
+          JSON.stringify({
+            custom_id: customId,
+            response: {
+              status_code: result.apiErrorStatus ?? 500,
+              body: {
+                usage: {
+                  input_tokens: inputTokens,
+                  output_tokens: outputTokens,
+                },
+              },
+            },
+          }),
+        );
+      } else {
+        succeeded++;
+        lines.push(
+          JSON.stringify({
+            custom_id: customId,
+            response: {
+              status_code: 200,
+              body: {
+                usage: {
+                  input_tokens: inputTokens,
+                  output_tokens: outputTokens,
+                },
+                output: [{ content: [{ text: result.raw }] }],
+              },
+            },
+          }),
+        );
+      }
+    } catch (error) {
+      // Spawn failure / timeout — emit a non-200 line and keep going.
+      console.error(
+        `[CLAUDE-BATCH] request ${customId} threw:`,
+        error instanceof Error ? error.message : error,
+      );
+      failed++;
+      lines.push(
+        JSON.stringify({
+          custom_id: customId,
+          response: {
+            status_code: 500,
+            body: {
+              usage: { input_tokens: 0, output_tokens: 0 },
+            },
+          },
+        }),
+      );
+    }
+
+    done++;
+    onProgress?.(done, total, customId);
+  }
+
+  return {
+    jsonl: lines.join("\n"),
+    total,
+    succeeded,
+    failed,
+    stoppedByUsageLimit,
+  };
+}

--- a/packages/backend-base/src/bible/run-translation-job.ts
+++ b/packages/backend-base/src/bible/run-translation-job.ts
@@ -1,0 +1,110 @@
+/**
+ * CLI runner for the resumable local-`claude -p` translation QUEUE.
+ *
+ * Creates a translation_jobs row for the given contract and runs it to
+ * completion (or until paused by a usage-limit window / run budget), reusing
+ * Part A's build → execute → writeback pipeline via TranslationJobService.
+ *
+ * Usage (from packages/backend-base, with POSTGRES_URL; runs where the `claude`
+ * CLI + the chosen subscription login live — i.e. the Pi):
+ *   TARGET_LANG=fr KINDS="summary,byline,study" SCOPE=book BOOK_NAME=James \
+ *   bun run src/bible/run-translation-job.ts
+ *
+ * Env:
+ *   TARGET_LANG                 (required, e.g. fr)
+ *   KINDS                       (comma list of summary|byline|detailed|study)
+ *   SCOPE                       (bible|book, default book)
+ *   BOOK_NAME                   (required when SCOPE=book)
+ *   CHAPTERS                    (optional comma ints, e.g. "1,2")
+ *   CLAUDE_MODEL                (default haiku)
+ *   CLAUDE_CONFIG_DIR_TRANSLATE (optional → job.config_dir)
+ *   SOURCE_LANG                 (default en)
+ *   PAUSE_RETRY_MS              (optional sleep before retrying after a limit)
+ *   MAX_RUN_MS                  (optional run budget; returns paused when hit)
+ *
+ * Exit codes: 0 completed, 2 still paused (resume later), 1 error.
+ */
+import { db } from "database";
+import { TranslationJobService } from "./translation-job.service";
+
+const TARGET_LANG = process.env.TARGET_LANG;
+const KINDS = (process.env.KINDS || "")
+  .split(",")
+  .map((k) => k.trim())
+  .filter((k) => k.length > 0);
+const SCOPE = (process.env.SCOPE as "bible" | "book") || "book";
+const BOOK_NAME = process.env.BOOK_NAME || undefined;
+const CHAPTERS = process.env.CHAPTERS
+  ? process.env.CHAPTERS.split(",").map((c) => Number.parseInt(c.trim(), 10))
+  : undefined;
+const CLAUDE_MODEL = process.env.CLAUDE_MODEL || "haiku";
+const CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR_TRANSLATE || undefined;
+const SOURCE_LANG = process.env.SOURCE_LANG || "en";
+const PAUSE_RETRY_MS = process.env.PAUSE_RETRY_MS
+  ? Number(process.env.PAUSE_RETRY_MS)
+  : undefined;
+const MAX_RUN_MS = process.env.MAX_RUN_MS
+  ? Number(process.env.MAX_RUN_MS)
+  : undefined;
+
+async function main() {
+  if (!TARGET_LANG) throw new Error("TARGET_LANG env required");
+  if (KINDS.length === 0) throw new Error("KINDS env required (comma list)");
+  if (SCOPE === "book" && !BOOK_NAME) {
+    throw new Error("BOOK_NAME env required when SCOPE=book");
+  }
+
+  db.getOrCreateConnection();
+
+  console.log(
+    `=== Translation job: ${TARGET_LANG} | kinds=[${KINDS.join(
+      ",",
+    )}] | scope=${SCOPE}${BOOK_NAME ? ` (${BOOK_NAME})` : ""}${
+      CHAPTERS ? ` chapters=${CHAPTERS.join(",")}` : ""
+    } | ${CLAUDE_MODEL} ===\n`,
+  );
+
+  const service = new TranslationJobService();
+
+  const job = await service.createJob({
+    targetLanguageCode: TARGET_LANG,
+    kinds: KINDS,
+    scopeType: SCOPE,
+    bookName: BOOK_NAME,
+    chapterNumbers: CHAPTERS,
+    model: CLAUDE_MODEL,
+    configDir: CONFIG_DIR,
+    sourceLanguageCode: SOURCE_LANG,
+  });
+
+  console.log(
+    `Created job ${job.job_id} — ${job.total_units} unit(s) to translate.\n`,
+  );
+
+  if (job.total_units === 0) {
+    console.log("Nothing to translate. Done.");
+    await db.closeConnection();
+    process.exit(0);
+  }
+
+  await service.processJob(job.job_id, {
+    pauseRetryMs: PAUSE_RETRY_MS,
+    maxRunMs: MAX_RUN_MS,
+  });
+
+  const final = await service.getJob(job.job_id);
+  console.log(
+    `\n=== status=${final.status} done=${final.done_units}/${final.total_units} failed=${final.failed_units} ===`,
+  );
+
+  await db.closeConnection();
+  if (final.status === "completed") process.exit(0);
+  // Paused (usage-limit window not cleared within the run budget) — resume later.
+  process.exit(2);
+}
+
+main().catch(async (e) => {
+  console.error("FAILED:", e);
+  await db.closeConnection();
+  process.exit(1);
+});

--- a/packages/backend-base/src/bible/study-claude-translator.ts
+++ b/packages/backend-base/src/bible/study-claude-translator.ts
@@ -1,0 +1,185 @@
+/**
+ * Translate one study via a local `claude -p` subprocess (Claude subscription),
+ * instead of the OpenAI Batch API. Pure transport: given the same `instruction`
+ * (the DB `translate-study` prompt with `{language}` substituted) and `input`
+ * (the same string the OpenAI path builds), it returns the model's raw text plus
+ * usage / rate-limit metadata. Parsing + validation + writeback are handled by
+ * the shared `BatchOperationService.writeStudyTranslation` so this path and the
+ * OpenAI path can never drift.
+ *
+ * Proven recipe (claude 2.1.168, verified 2026-06-07):
+ *   - MAX_THINKING_TOKENS=0 is MANDATORY — otherwise the model spends the whole
+ *     window on extended thinking and emits no translation for minutes.
+ *     `--effort low` does NOT disable thinking.
+ *   - `--system-prompt` REPLACES the default (coding) system prompt.
+ *   - `--setting-sources user` + cwd OUTSIDE the user's home keeps the giant
+ *     project CLAUDE.md from leaking into context.
+ *   - NEVER `--bare`: it drops the credential source ("Not logged in").
+ *   - `--output-format json` envelope: { result, is_error, api_error_status,
+ *     usage, session_id }.
+ */
+import { tmpdir } from "node:os";
+
+/** A transient (server-side) API error worth resuming + retrying, NOT a quota wall. */
+const TRANSIENT_API_STATUSES = new Set([429, 500, 502, 503, 504, 529]);
+
+export interface ClaudeTranslateResult {
+  /** The model's response text (expected to be the translated study JSON). */
+  raw: string;
+  /** True when the CLI reported an error (auth, quota, transient API, etc.). */
+  isError: boolean;
+  /** HTTP-ish status from the CLI failure envelope, when present (e.g. 529). */
+  apiErrorStatus: number | null;
+  /** True when the error is server-side/transient (resume + retry), not a quota limit. */
+  isTransient: boolean;
+  /** True when the failure text looks like a usage/session limit (sleep until reset). */
+  isUsageLimit: boolean;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+  /** Session id from the envelope — pass to a resume on transient failure. */
+  sessionId?: string;
+  /** Wall-clock of the CLI call, ms. */
+  durationMs?: number;
+  /** Raw envelope, for callers that want the rest (modelUsage, cost, etc.). */
+  envelope?: Record<string, unknown>;
+}
+
+export interface ClaudeTranslateOptions {
+  /** System prompt (the translate-study prompt with {language} filled). */
+  instruction: string;
+  /** User input — the same string the OpenAI path sends. */
+  input: string;
+  /** Claude model alias: "haiku" (throughput default) | "sonnet" | "opus". */
+  model?: string;
+  /** Dedicated-subscription config dir (CLAUDE_CONFIG_DIR). Omit = ambient login. */
+  configDir?: string;
+  /** Hard timeout for the subprocess, ms. Default 6 min. */
+  timeoutMs?: number;
+  /** Path to the `claude` binary. Default "claude" (on PATH). */
+  claudeBin?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 6 * 60_000;
+
+function looksLikeUsageLimit(text: string): boolean {
+  const t = text.toLowerCase();
+  return (
+    t.includes("out of") &&
+    (t.includes("usage") || t.includes("limit") || t.includes("resets"))
+  );
+}
+
+/**
+ * Run one translation through `claude -p`. Never throws on a model/CLI error —
+ * inspect `isError` / `isTransient` / `isUsageLimit` and decide (retry vs
+ * sleep-until-reset) at the caller. Throws only on spawn failure / timeout.
+ */
+export async function runClaudeTranslate(
+  opts: ClaudeTranslateOptions,
+): Promise<ClaudeTranslateResult> {
+  const {
+    instruction,
+    input,
+    model = "haiku",
+    configDir,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    claudeBin = "claude",
+  } = opts;
+
+  const env: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+    // The single most important flag — see file header.
+    MAX_THINKING_TOKENS: "0",
+  };
+  if (configDir) env.CLAUDE_CONFIG_DIR = configDir;
+
+  const proc = Bun.spawn(
+    [
+      claudeBin,
+      "-p",
+      "-",
+      "--system-prompt",
+      instruction,
+      "--setting-sources",
+      "user",
+      "--model",
+      model,
+      "--output-format",
+      "json",
+    ],
+    {
+      // cwd outside the user's home so ~/CLAUDE.md is never auto-discovered.
+      cwd: tmpdir(),
+      env,
+      stdin: new TextEncoder().encode(input),
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+
+  const timer = setTimeout(() => {
+    try {
+      proc.kill("SIGKILL");
+    } catch {
+      // already gone
+    }
+  }, timeoutMs);
+
+  let stdout: string;
+  let exitCode: number;
+  try {
+    [stdout, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      proc.exited,
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!stdout.trim()) {
+    const errText = await new Response(proc.stderr).text().catch(() => "");
+    throw new Error(
+      `claude -p produced no output (exit ${exitCode})${
+        errText ? `: ${errText.slice(0, 300)}` : " — likely killed by timeout"
+      }`,
+    );
+  }
+
+  let envelope: Record<string, unknown>;
+  try {
+    envelope = JSON.parse(stdout) as Record<string, unknown>;
+  } catch {
+    throw new Error(
+      `claude -p output was not JSON (exit ${exitCode}): ${stdout.slice(0, 300)}`,
+    );
+  }
+
+  const isError = envelope.is_error === true;
+  const apiErrorStatus =
+    typeof envelope.api_error_status === "number"
+      ? (envelope.api_error_status as number)
+      : null;
+  const raw = typeof envelope.result === "string" ? envelope.result : "";
+
+  return {
+    raw,
+    isError,
+    apiErrorStatus,
+    isTransient:
+      apiErrorStatus != null && TRANSIENT_API_STATUSES.has(apiErrorStatus),
+    isUsageLimit: isError && apiErrorStatus == null && looksLikeUsageLimit(raw),
+    usage: envelope.usage as ClaudeTranslateResult["usage"],
+    sessionId:
+      typeof envelope.session_id === "string"
+        ? (envelope.session_id as string)
+        : undefined,
+    durationMs:
+      typeof envelope.duration_ms === "number"
+        ? (envelope.duration_ms as number)
+        : undefined,
+    envelope,
+  };
+}

--- a/packages/backend-base/src/bible/translation-job.service.test.ts
+++ b/packages/backend-base/src/bible/translation-job.service.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import { aggregateRemaining, splitKinds } from "./translation-job.service";
+
+/**
+ * Pure-logic unit tests for the translation-job delta computation. No DB:
+ * `splitKinds` and `aggregateRemaining` are the side-effect-free core that
+ * `computeRemainingUnits` builds on (the DB part only feeds per-book request
+ * counts into `aggregateRemaining`).
+ */
+
+describe("splitKinds", () => {
+  it("splits commentary types from the literal 'study'", () => {
+    expect(splitKinds(["summary", "byline", "study"])).toEqual({
+      commentaryTypes: ["summary", "byline"],
+      includeStudy: true,
+    });
+  });
+
+  it("keeps commentary types in canonical order regardless of input order", () => {
+    expect(splitKinds(["detailed", "summary"]).commentaryTypes).toEqual([
+      "summary",
+      "detailed",
+    ]);
+  });
+
+  it("study-only", () => {
+    expect(splitKinds(["study"])).toEqual({
+      commentaryTypes: [],
+      includeStudy: true,
+    });
+  });
+
+  it("ignores unknown kinds", () => {
+    expect(splitKinds(["bogus", "summary"])).toEqual({
+      commentaryTypes: ["summary"],
+      includeStudy: false,
+    });
+  });
+
+  it("empty kinds → nothing", () => {
+    expect(splitKinds([])).toEqual({
+      commentaryTypes: [],
+      includeStudy: false,
+    });
+  });
+});
+
+describe("aggregateRemaining", () => {
+  it("sums units and drops zero-work books", () => {
+    const result = aggregateRemaining([
+      { bookName: "James", commentaryUnits: 3, studyUnits: 5 },
+      { bookName: "Jude", commentaryUnits: 0, studyUnits: 0 },
+      { bookName: "Titus", commentaryUnits: 2, studyUnits: 0 },
+    ]);
+    expect(result.total).toBe(10);
+    expect(result.perBook).toEqual([
+      { bookName: "James", commentaryUnits: 3, studyUnits: 5 },
+      { bookName: "Titus", commentaryUnits: 2, studyUnits: 0 },
+    ]);
+  });
+
+  it("empty input → zero", () => {
+    expect(aggregateRemaining([])).toEqual({ perBook: [], total: 0 });
+  });
+
+  it("all-done scope → total 0, no books", () => {
+    const result = aggregateRemaining([
+      { bookName: "James", commentaryUnits: 0, studyUnits: 0 },
+    ]);
+    expect(result.total).toBe(0);
+    expect(result.perBook).toEqual([]);
+  });
+});

--- a/packages/backend-base/src/bible/translation-job.service.ts
+++ b/packages/backend-base/src/bible/translation-job.service.ts
@@ -1,0 +1,582 @@
+/**
+ * Durable, resumable translation QUEUE driven by the local `claude -p`
+ * transport (a Claude subscription). One `translation_jobs` row encodes a user
+ * contract — "translate language X, kinds [...] over a scope" — and this
+ * service computes the missing work and grinds through it sequentially,
+ * persisting progress so it survives process restarts and usage-limit windows.
+ *
+ * The whole pipeline reuses Part A:
+ *   build*Requests (skip-existing) → executeBatchRequestsViaClaude → process*OutputFile(jsonl)
+ *
+ * Resumability rests on one invariant: "done" is NEVER trusted from memory — it
+ * is recomputed from the content tables (`explanations` / `study_translations`)
+ * each pass, because the build*Requests skip-existing path queries those tables
+ * directly. A restart that calls processJob(jobId) again therefore continues
+ * exactly where it left off; already-written units simply become skipped.
+ *
+ * Byline-chunk safety: a whole book's commentary requests are built and run in
+ * ONE executor + ONE writeback call, so the chunked byline custom_ids
+ * (`...|chunk|i|of|n`) are always stitched back together by
+ * processTranslateOutputFile. We never split a book across writeback calls.
+ *
+ * Single-subscription, strictly sequential. Multi-worker concurrency is a later
+ * increment.
+ */
+import { db } from "database";
+import { sql } from "kysely";
+import {
+  BatchOperationService,
+  DEFAULT_MAX_OUTPUT_TOKENS,
+} from "../admin/services/batch-operations.service";
+import { batchMonitoringQueue } from "../queue/batch-monitoring.queue";
+import { batchProcessingQueue } from "../queue/batch-processing.queue";
+import { executeBatchRequestsViaClaude } from "./claude-batch-executor";
+
+/** Commentary explanation types we know how to translate. */
+const COMMENTARY_TYPES = ["summary", "byline", "detailed"] as const;
+type CommentaryType = (typeof COMMENTARY_TYPES)[number];
+
+const DEFAULT_MODEL = "haiku";
+const DEFAULT_SOURCE_LANG = "en";
+const DEFAULT_PAUSE_RETRY_MS = 30 * 60_000;
+const DEFAULT_EFFORT: "low" | "medium" | "high" = "low";
+
+export type TranslationJobStatus =
+  | "pending"
+  | "running"
+  | "paused"
+  | "completed"
+  | "failed";
+
+export interface CreateJobParams {
+  targetLanguageCode: string;
+  kinds: string[];
+  scopeType: "bible" | "book";
+  bookName?: string;
+  chapterNumbers?: number[];
+  model?: string;
+  configDir?: string;
+  sourceLanguageCode?: string;
+}
+
+/** A row of the translation_jobs table, as selected. */
+export interface TranslationJobRow {
+  job_id: string;
+  target_language_code: string;
+  source_language_code: string;
+  kinds: string[];
+  scope_type: string;
+  book_name: string | null;
+  chapter_numbers: number[] | null;
+  model: string;
+  config_dir: string | null;
+  status: string;
+  total_units: number;
+  done_units: number;
+  failed_units: number;
+}
+
+/** Per-book breakdown of the remaining (undone) work. */
+export interface RemainingForBook {
+  bookName: string;
+  /** Commentary build requests still outstanding (one per request, byline may be chunked). */
+  commentaryUnits: number;
+  /** Study build requests still outstanding. */
+  studyUnits: number;
+}
+
+export interface RemainingUnits {
+  perBook: RemainingForBook[];
+  total: number;
+}
+
+export interface ProcessJobOptions {
+  /** How long to sleep before retrying the SAME book after a usage limit. */
+  pauseRetryMs?: number;
+  /** Optional wall-clock budget; when exceeded the loop returns leaving the job 'paused'. */
+  maxRunMs?: number;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Split a mixed `kinds` array into the commentary explanation types (in
+ * canonical order) and whether study content is included. Pure — unit-tested.
+ */
+export function splitKinds(kinds: string[]): {
+  commentaryTypes: CommentaryType[];
+  includeStudy: boolean;
+} {
+  return {
+    commentaryTypes: COMMENTARY_TYPES.filter((t) => kinds.includes(t)),
+    includeStudy: kinds.includes("study"),
+  };
+}
+
+/**
+ * Aggregate per-book commentary/study request counts into the remaining-units
+ * shape: drop books with no outstanding work, sum the rest. Pure — unit-tested.
+ * This is the core delta computation; the DB-querying part (counting requests
+ * per book via the skip-existing builders) feeds raw counts into this.
+ */
+export function aggregateRemaining(
+  counts: Array<{
+    bookName: string;
+    commentaryUnits: number;
+    studyUnits: number;
+  }>,
+): RemainingUnits {
+  const perBook: RemainingForBook[] = [];
+  let total = 0;
+  for (const c of counts) {
+    const sum = c.commentaryUnits + c.studyUnits;
+    if (sum > 0) {
+      perBook.push({
+        bookName: c.bookName,
+        commentaryUnits: c.commentaryUnits,
+        studyUnits: c.studyUnits,
+      });
+      total += sum;
+    }
+  }
+  return { perBook, total };
+}
+
+export class TranslationJobService {
+  private readonly batch: BatchOperationService;
+
+  constructor() {
+    this.batch = new BatchOperationService(
+      db,
+      batchMonitoringQueue,
+      batchProcessingQueue,
+    );
+  }
+
+  /**
+   * Books that hold commentary in the SOURCE language for the requested types.
+   * Derived from the `books` table joined to active source explanations, so
+   * every name is a valid `books.name` (buildBookTranslateRequests throws on an
+   * unknown book name). Returns names sorted by book_id.
+   */
+  private async commentaryBooks(
+    sourceLanguageCode: string,
+    types: CommentaryType[],
+    scopeType: "bible" | "book",
+    bookName?: string,
+  ): Promise<string[]> {
+    if (types.length === 0) return [];
+    if (scopeType === "book") return bookName ? [bookName] : [];
+
+    const conn = db.getOrCreateConnection();
+    const rows = await conn
+      .selectFrom("books")
+      .innerJoin("chapters", "chapters.book_id", "books.book_id")
+      .innerJoin(
+        "explanations",
+        "explanations.chapter_id",
+        "chapters.chapter_id",
+      )
+      .where("explanations.language_code", "=", sourceLanguageCode)
+      .where("explanations.is_active", "=", true)
+      .where("explanations.type", "in", types as never[])
+      .select("books.name as name")
+      .distinct()
+      .orderBy(sql`min(books.book_id)` as never)
+      .groupBy("books.name")
+      .execute();
+    return rows.map((r) => r.name).filter((n): n is string => !!n);
+  }
+
+  /**
+   * Books that hold studies (keyed by `content->>'bookName'`, the
+   * @versemate/studies id space — NOT the `books` table).
+   */
+  private async studyBooks(
+    scopeType: "bible" | "book",
+    bookName?: string,
+  ): Promise<string[]> {
+    const conn = db.getOrCreateConnection();
+    if (scopeType === "book") {
+      if (!bookName) return [];
+      const exists = await conn
+        .selectFrom("studies")
+        .select(conn.fn.countAll().as("n"))
+        .where(sql`content->>'bookName'`, "=", bookName)
+        .executeTakeFirst();
+      return Number(exists?.n ?? 0) > 0 ? [bookName] : [];
+    }
+    const rows = await conn
+      .selectFrom("studies")
+      .select(sql<string>`content->>'bookName'`.as("book_name"))
+      .distinct()
+      .orderBy(sql`content->>'bookName'`)
+      .execute();
+    return rows.map((r) => r.book_name).filter((n): n is string => !!n);
+  }
+
+  /**
+   * Compute the undone work across the job's scope + kinds, organized per book
+   * (so a book is processed atomically). "Undone" = the count of build requests
+   * the skip-existing builders still produce (no active target-language row).
+   */
+  async computeRemainingUnits(job: TranslationJobRow): Promise<RemainingUnits> {
+    const { commentaryTypes, includeStudy } = splitKinds(job.kinds);
+    const scopeType = job.scope_type as "bible" | "book";
+    const chapters = job.chapter_numbers ?? undefined;
+
+    const commBooks = await this.commentaryBooks(
+      job.source_language_code,
+      commentaryTypes,
+      scopeType,
+      job.book_name ?? undefined,
+    );
+    const stdBooks = includeStudy
+      ? await this.studyBooks(scopeType, job.book_name ?? undefined)
+      : [];
+
+    const commSet = new Set(commBooks);
+    const stdSet = new Set(stdBooks);
+    const allBooks = Array.from(new Set([...commBooks, ...stdBooks]));
+
+    const counts: Array<{
+      bookName: string;
+      commentaryUnits: number;
+      studyUnits: number;
+    }> = [];
+
+    for (const bookName of allBooks) {
+      let commentaryUnits = 0;
+      let studyUnits = 0;
+
+      if (commentaryTypes.length > 0 && commSet.has(bookName)) {
+        const reqs = await this.batch.buildBookTranslateRequests(
+          job.model,
+          job.source_language_code,
+          job.target_language_code,
+          commentaryTypes,
+          bookName,
+          DEFAULT_EFFORT,
+          DEFAULT_MAX_OUTPUT_TOKENS,
+          chapters,
+          true,
+        );
+        commentaryUnits = reqs.length;
+      }
+
+      if (includeStudy && stdSet.has(bookName)) {
+        const reqs = await this.batch.buildStudyTranslateRequests(
+          job.model,
+          job.target_language_code,
+          DEFAULT_EFFORT,
+          bookName,
+          true,
+          chapters,
+        );
+        studyUnits = reqs.length;
+      }
+
+      counts.push({ bookName, commentaryUnits, studyUnits });
+    }
+
+    return aggregateRemaining(counts);
+  }
+
+  /** Insert a new pending job, pre-computing total_units (the delta to do). */
+  async createJob(params: CreateJobParams): Promise<TranslationJobRow> {
+    const conn = db.getOrCreateConnection();
+    const model = params.model ?? DEFAULT_MODEL;
+    const sourceLanguageCode = params.sourceLanguageCode ?? DEFAULT_SOURCE_LANG;
+
+    const inserted = await conn
+      .insertInto("translation_jobs")
+      .values({
+        target_language_code: params.targetLanguageCode,
+        source_language_code: sourceLanguageCode,
+        kinds: JSON.stringify(params.kinds),
+        scope_type: params.scopeType,
+        book_name: params.bookName ?? null,
+        chapter_numbers: params.chapterNumbers
+          ? JSON.stringify(params.chapterNumbers)
+          : null,
+        model,
+        config_dir: params.configDir ?? null,
+        status: "pending",
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+
+    const job = this.normalizeRow(inserted);
+    const remaining = await this.computeRemainingUnits(job);
+    await conn
+      .updateTable("translation_jobs")
+      .set({ total_units: remaining.total, updated_at: new Date() })
+      .where("job_id", "=", job.job_id)
+      .execute();
+    job.total_units = remaining.total;
+    return job;
+  }
+
+  /** Read a job row, normalizing jsonb columns to native arrays. */
+  async getJob(jobId: string): Promise<TranslationJobRow> {
+    const conn = db.getOrCreateConnection();
+    const row = await conn
+      .selectFrom("translation_jobs")
+      .selectAll()
+      .where("job_id", "=", jobId)
+      .executeTakeFirstOrThrow();
+    return this.normalizeRow(row);
+  }
+
+  private normalizeRow(row: Record<string, unknown>): TranslationJobRow {
+    const parseArr = (v: unknown): unknown[] | null => {
+      if (v == null) return null;
+      if (Array.isArray(v)) return v;
+      if (typeof v === "string") {
+        try {
+          const parsed = JSON.parse(v);
+          return Array.isArray(parsed) ? parsed : null;
+        } catch {
+          return null;
+        }
+      }
+      return null;
+    };
+    return {
+      job_id: row.job_id as string,
+      target_language_code: row.target_language_code as string,
+      source_language_code: row.source_language_code as string,
+      kinds: (parseArr(row.kinds) ?? []) as string[],
+      scope_type: row.scope_type as string,
+      book_name: (row.book_name as string | null) ?? null,
+      chapter_numbers: parseArr(row.chapter_numbers) as number[] | null,
+      model: row.model as string,
+      config_dir: (row.config_dir as string | null) ?? null,
+      status: row.status as string,
+      total_units: Number(row.total_units ?? 0),
+      done_units: Number(row.done_units ?? 0),
+      failed_units: Number(row.failed_units ?? 0),
+    };
+  }
+
+  private async setStatus(
+    jobId: string,
+    status: TranslationJobStatus,
+    extra?: {
+      pausedUntil?: Date | null;
+      lastError?: string | null;
+    },
+  ): Promise<void> {
+    const conn = db.getOrCreateConnection();
+    await conn
+      .updateTable("translation_jobs")
+      .set({
+        status,
+        paused_until: extra?.pausedUntil ?? null,
+        last_error: extra?.lastError ?? null,
+        updated_at: new Date(),
+      })
+      .where("job_id", "=", jobId)
+      .execute();
+  }
+
+  /**
+   * Persist progress: recompute done = total - remaining so the numbers reflect
+   * reality even across restarts, and accumulate failures.
+   */
+  private async persistProgress(
+    jobId: string,
+    totalUnits: number,
+    remainingTotal: number,
+    failedDelta: number,
+  ): Promise<void> {
+    const conn = db.getOrCreateConnection();
+    const done = Math.max(0, totalUnits - remainingTotal);
+    await conn
+      .updateTable("translation_jobs")
+      .set((eb) => ({
+        done_units: done,
+        failed_units: eb("failed_units", "+", failedDelta),
+        updated_at: new Date(),
+      }))
+      .where("job_id", "=", jobId)
+      .execute();
+  }
+
+  /**
+   * The worker loop. Sequential, single-subscription, resumable.
+   *
+   * Each pass recomputes the remaining work from the DB and grinds book by
+   * book. A book's commentary requests (and separately its study requests) are
+   * each run in ONE executor + ONE writeback so byline chunks stay together.
+   * On a usage limit we persist progress, mark 'paused', sleep pauseRetryMs and
+   * retry the SAME book (the just-written units are now skipped). maxRunMs, if
+   * given, lets a caller bound the run — we return leaving status 'paused' so a
+   * later processJob(jobId) resumes.
+   */
+  async processJob(jobId: string, opts?: ProcessJobOptions): Promise<void> {
+    const pauseRetryMs = opts?.pauseRetryMs ?? DEFAULT_PAUSE_RETRY_MS;
+    const maxRunMs = opts?.maxRunMs;
+    const startedAt = Date.now();
+
+    const budgetExceeded = (): boolean =>
+      maxRunMs != null && Date.now() - startedAt >= maxRunMs;
+
+    try {
+      const job = await this.getJob(jobId);
+      const { commentaryTypes, includeStudy } = splitKinds(job.kinds);
+      const chapters = job.chapter_numbers ?? undefined;
+      const executorOpts = {
+        model: job.model,
+        configDir: job.config_dir ?? undefined,
+      };
+
+      await this.setStatus(jobId, "running");
+
+      // Outer loop: each pass recomputes remaining; ends when nothing remains.
+      // A usage-limit pause inside re-enters this loop after the sleep.
+      for (;;) {
+        const remaining = await this.computeRemainingUnits(job);
+        // Keep total_units honest (sources may have grown since createJob).
+        const totalUnits = Math.max(job.total_units, remaining.total);
+        await this.persistProgress(jobId, totalUnits, remaining.total, 0);
+
+        if (remaining.total === 0) {
+          await this.setStatus(jobId, "completed");
+          console.log(`[TJOB ${jobId}] completed — no remaining units.`);
+          return;
+        }
+
+        for (const book of remaining.perBook) {
+          if (budgetExceeded()) {
+            await this.setStatus(jobId, "paused");
+            console.log(
+              `[TJOB ${jobId}] maxRunMs reached — pausing for a later resume.`,
+            );
+            return;
+          }
+
+          // --- Commentary (one executor + one writeback for the whole book) ---
+          if (commentaryTypes.length > 0 && book.commentaryUnits > 0) {
+            const reqs = await this.batch.buildBookTranslateRequests(
+              job.model,
+              job.source_language_code,
+              job.target_language_code,
+              commentaryTypes,
+              book.bookName,
+              DEFAULT_EFFORT,
+              DEFAULT_MAX_OUTPUT_TOKENS,
+              chapters,
+              true,
+            );
+            if (reqs.length > 0) {
+              console.log(
+                `[TJOB ${jobId}] ${book.bookName}: ${reqs.length} commentary request(s) → claude…`,
+              );
+              const result = await executeBatchRequestsViaClaude(
+                reqs,
+                executorOpts,
+              );
+              if (result.jsonl.trim().length > 0) {
+                await this.batch.processTranslateOutputFile(
+                  `local-${jobId}-${book.bookName}-commentary`,
+                  "",
+                  { model: job.model },
+                  result.jsonl,
+                );
+              }
+              await this.recountAndPersist(job, jobId, result.failed);
+
+              if (result.stoppedByUsageLimit) {
+                await this.handleUsageLimitPause(
+                  jobId,
+                  pauseRetryMs,
+                  budgetExceeded,
+                );
+                if (budgetExceeded()) return;
+                break; // re-enter outer loop, re-build this book (now skipped)
+              }
+            }
+          }
+
+          // --- Study (separate executor + writeback) ---
+          if (includeStudy && book.studyUnits > 0) {
+            const reqs = await this.batch.buildStudyTranslateRequests(
+              job.model,
+              job.target_language_code,
+              DEFAULT_EFFORT,
+              book.bookName,
+              true,
+              chapters,
+            );
+            if (reqs.length > 0) {
+              console.log(
+                `[TJOB ${jobId}] ${book.bookName}: ${reqs.length} study request(s) → claude…`,
+              );
+              const result = await executeBatchRequestsViaClaude(
+                reqs,
+                executorOpts,
+              );
+              if (result.jsonl.trim().length > 0) {
+                await this.batch.processStudyTranslateOutputFile(
+                  `local-${jobId}-${book.bookName}-study`,
+                  "",
+                  { model: job.model },
+                  result.jsonl,
+                );
+              }
+              await this.recountAndPersist(job, jobId, result.failed);
+
+              if (result.stoppedByUsageLimit) {
+                await this.handleUsageLimitPause(
+                  jobId,
+                  pauseRetryMs,
+                  budgetExceeded,
+                );
+                if (budgetExceeded()) return;
+                break;
+              }
+            }
+          }
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`[TJOB ${jobId}] FAILED:`, message);
+      await this.setStatus(jobId, "failed", { lastError: message });
+      throw error;
+    }
+  }
+
+  /** Recompute remaining from the DB and persist done/failed (resume-safe). */
+  private async recountAndPersist(
+    job: TranslationJobRow,
+    jobId: string,
+    failedDelta: number,
+  ): Promise<void> {
+    const remaining = await this.computeRemainingUnits(job);
+    const totalUnits = Math.max(job.total_units, remaining.total);
+    await this.persistProgress(jobId, totalUnits, remaining.total, failedDelta);
+  }
+
+  /**
+   * Mark paused, sleep until the window clears (unless the run budget is up, in
+   * which case return immediately leaving 'paused' for a later resume).
+   */
+  private async handleUsageLimitPause(
+    jobId: string,
+    pauseRetryMs: number,
+    budgetExceeded: () => boolean,
+  ): Promise<void> {
+    const pausedUntil = new Date(Date.now() + pauseRetryMs);
+    await this.setStatus(jobId, "paused", { pausedUntil });
+    console.log(
+      `[TJOB ${jobId}] hit usage limit — paused until ${pausedUntil.toISOString()}.`,
+    );
+    if (budgetExceeded()) return;
+    await sleep(pauseRetryMs);
+    await this.setStatus(jobId, "running");
+  }
+}

--- a/packages/database/migrations/20260607000000-create-translation-jobs-table.ts
+++ b/packages/database/migrations/20260607000000-create-translation-jobs-table.ts
@@ -1,0 +1,64 @@
+import { type Kysely, sql } from "kysely";
+import type Database from "../src/models/Database";
+
+/**
+ * Durable, resumable queue for the local `claude -p` translation worker. One
+ * row = one user contract ("translate language X, kinds [...]" over a scope).
+ * The worker (TranslationJobService.processJob) computes what is missing,
+ * grinds through it sequentially, tracks progress here, and pauses on usage
+ * limits (`status='paused'`, `paused_until`) so a later invocation resumes from
+ * the same row. "Done" is always recomputed from the content tables
+ * (explanations / study_translations) so a process restart is safe.
+ */
+export async function up(db: Kysely<Database>): Promise<void> {
+  console.log("Creating translation_jobs table...");
+
+  await db.schema
+    .createTable("translation_jobs")
+    .addColumn("job_id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    .addColumn("target_language_code", "varchar(10)", (col) => col.notNull())
+    .addColumn("source_language_code", "varchar(10)", (col) =>
+      col.notNull().defaultTo("en"),
+    )
+    // Array of kind strings: commentary types (summary/byline/detailed) and/or
+    // the literal "study".
+    .addColumn("kinds", "jsonb", (col) => col.notNull())
+    // 'bible' | 'book'
+    .addColumn("scope_type", "varchar(10)", (col) => col.notNull())
+    .addColumn("book_name", "varchar(100)")
+    // Optional array of chapter numbers to restrict the scope.
+    .addColumn("chapter_numbers", "jsonb")
+    .addColumn("model", "varchar(50)", (col) => col.notNull())
+    // CLAUDE_CONFIG_DIR of the subscription used to run this job.
+    .addColumn("config_dir", "varchar(255)")
+    // 'pending' | 'running' | 'paused' | 'completed' | 'failed'
+    .addColumn("status", "varchar(20)", (col) =>
+      col.notNull().defaultTo("pending"),
+    )
+    .addColumn("total_units", "integer", (col) => col.notNull().defaultTo(0))
+    .addColumn("done_units", "integer", (col) => col.notNull().defaultTo(0))
+    .addColumn("failed_units", "integer", (col) => col.notNull().defaultTo(0))
+    .addColumn("paused_until", "timestamptz")
+    .addColumn("last_error", "text")
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .addColumn("updated_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("idx_translation_jobs_status")
+    .on("translation_jobs")
+    .column("status")
+    .execute();
+
+  console.log("Successfully created translation_jobs table.");
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema.dropTable("translation_jobs").ifExists().execute();
+}

--- a/packages/database/src/models/public/PublicSchema.ts
+++ b/packages/database/src/models/public/PublicSchema.ts
@@ -36,6 +36,7 @@ import type { default as TopicExplanationsTable } from "./TopicExplanations";
 import type { default as TopicReferencesTable } from "./TopicReferences";
 import type { default as TopicTranslationsTable } from "./TopicTranslations";
 import type { default as TopicsTable } from "./Topics";
+import type { default as TranslationJobsTable } from "./TranslationJobs";
 import type { default as TranslationTemplatesTable } from "./TranslationTemplates";
 import type { default as UserTable } from "./User";
 import type { default as UserProgressTable } from "./UserProgress";
@@ -140,4 +141,6 @@ export default interface PublicSchema {
   study_term_translations: StudyTermTranslationsTable;
 
   study_translations: StudyTranslationsTable;
+
+  translation_jobs: TranslationJobsTable;
 }

--- a/packages/database/src/models/public/TranslationJobs.ts
+++ b/packages/database/src/models/public/TranslationJobs.ts
@@ -1,0 +1,68 @@
+// Hand-written model for the translation_jobs table (no live local DB to
+// regenerate from). Mirrors the generated-model shape; keep nullability/types
+// in sync with migrations/20260607000000-create-translation-jobs-table.ts.
+
+import type { ColumnType, Insertable, Selectable, Updateable } from "kysely";
+
+export type TranslationJobsJobId = string;
+
+/** Represents the table public.translation_jobs */
+export default interface TranslationJobsTable {
+  job_id: ColumnType<
+    TranslationJobsJobId,
+    TranslationJobsJobId | undefined,
+    TranslationJobsJobId
+  >;
+
+  target_language_code: ColumnType<string, string, string>;
+
+  source_language_code: ColumnType<string, string | undefined, string>;
+
+  // jsonb array of kind strings.
+  kinds: ColumnType<unknown, unknown, unknown>;
+
+  scope_type: ColumnType<string, string, string>;
+
+  book_name: ColumnType<string | null, string | null, string | null>;
+
+  // jsonb array of chapter numbers (nullable).
+  chapter_numbers: ColumnType<unknown | null, unknown | null, unknown | null>;
+
+  model: ColumnType<string, string, string>;
+
+  config_dir: ColumnType<string | null, string | null, string | null>;
+
+  status: ColumnType<string, string | undefined, string>;
+
+  total_units: ColumnType<number, number | undefined, number>;
+
+  done_units: ColumnType<number, number | undefined, number>;
+
+  failed_units: ColumnType<number, number | undefined, number>;
+
+  paused_until: ColumnType<
+    Date | null,
+    Date | string | null,
+    Date | string | null
+  >;
+
+  last_error: ColumnType<string | null, string | null, string | null>;
+
+  created_at: ColumnType<
+    Date | null,
+    Date | string | null,
+    Date | string | null
+  >;
+
+  updated_at: ColumnType<
+    Date | null,
+    Date | string | null,
+    Date | string | null
+  >;
+}
+
+export type TranslationJobs = Selectable<TranslationJobsTable>;
+
+export type NewTranslationJobs = Insertable<TranslationJobsTable>;
+
+export type TranslationJobsUpdate = Updateable<TranslationJobsTable>;


### PR DESCRIPTION
## What

Adds a translation path that runs on a **Claude subscription** via local `claude -p` subprocesses instead of the OpenAI Batch API — reusing the existing request-building and writeback **unchanged**. Covers all commentary types (summary/byline/detailed) and study via one mechanism, driven by a resumable queue.

## Approach — "local-content seam"

The OpenAI flow is: **BUILD** requests → submit → download result → **WRITEBACK**. Only the middle (the AI call) is swapped; BUILD and WRITEBACK are reused as-is, so byline chunking and the versioned `explanations` writeback come for free.

- `study-claude-translator.ts` — `runClaudeTranslate()`: per-request `claude -p` transport (`MAX_THINKING_TOKENS=0`, replaced system prompt, JSON envelope; classifies usage-limit vs transient-5xx).
- `claude-batch-executor.ts` — runs a batch of requests, emits OpenAI-output-shaped JSONL the writeback already parses; stops on a usage limit.
- `batch-operations.service.ts` — **additive only**: optional `localContent?` on `processTranslateOutputFile` / `processStudyTranslateOutputFile` (skip the OpenAI download when fed local content); extracted `buildBookTranslateRequests` (+`skipExisting`) / `buildStudyTranslateRequests`. **The OpenAI path is byte-for-byte unchanged.**

## The queue

- `translation_jobs` table + `TranslationJobService` + `run-translation-job.ts` CLI.
- "Done" = an active target-language row exists; the delta is **recomputed from the DB each pass**, so it resumes across crashes/reboots/usage-limit pauses.
- Processes a whole book at a time (keeps byline chunks together for stitching). Pauses on a usage limit and retries after the window.
- Entry: `TARGET_LANG`, `KINDS` (e.g. `summary,byline,study`), `SCOPE`, `BOOK_NAME`, `CLAUDE_MODEL`, `CLAUDE_CONFIG_DIR_TRANSLATE`.

## Verification

- `tsc` clean (backend-base + database), biome clean, 21 batch + 8 queue unit tests pass.
- The `translation_jobs` migration applies via the normal BE deployment.

## Not yet done

- **Not live-tested end-to-end** — pending a dedicated-subscription `claude login` (`CLAUDE_CONFIG_DIR=~/.claude-versemate`). The code is dormant until invoked, and the migration only adds an empty table, so this is safe to merge ahead of the live run.
- v1 caveat: on a *weekly* limit the pause loop polls every 30 min until reset (JSON envelope lacks `resetsAt`); a later tweak (executor uses `stream-json` `rate_limit_event.resetsAt`) would sleep precisely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)