### PR TITLE
MOBILE-1001: richer verse-by-verse insights (#8)

### DIFF
--- a/packages/backend-base/src/bible/explanation-queue.ts
+++ b/packages/backend-base/src/bible/explanation-queue.ts
@@ -43,17 +43,23 @@ passage in a clear, organized way, summarize based on section sub-titles (e.g. B
       return {
         prompt: `# ${bookName} ${chapterNumber}: Verse-by-Verse Analysis
 
-Provide a verse-by-verse explanation of this chapter. For each verse:
+Provide a rich, verse-by-verse explanation of this chapter. For each verse:
 1. Quote the verse using blockquote format (>)
-2. Provide a clear summary
-3. Include relevant key takeaways
-4. Add key definitions as appropriate
-5. Highlight theological themes as appropriate
+2. Provide a substantial summary — at least 3-4 full sentences that explain what the
+   verse says, what it means in its immediate context, and why it matters. Do NOT
+   write one-line or superficial summaries; every verse deserves genuine depth,
+   including short, transitional, or greeting verses.
+3. Include relevant key takeaways as full sentences
+4. Add key definitions of important Hebrew/Greek terms, names, or places as appropriate
+5. Highlight theological themes and, where helpful, cross-references to related passages
 
 CRITICAL INSTRUCTIONS:
+- Aim for consistent richness across the whole chapter — do not let later verses become
+  thinner than earlier ones, and never reduce a verse to a single short sentence.
 - Keep chronological order at all times
 - Do not group verses unless absolutely necessary
 - Ensure takeaways and themes are full sentences
+- Explain the meaning and significance, not just a paraphrase of the wording
 - Use proper markdown formatting with line breaks`,
         temperature: 0.2,
       };


### PR DESCRIPTION
## MOBILE-1001 #8 — Richer verse-by-verse insights

### Where this came from
Reported by **Andy Tryba** in Slack (2026-06-09), part of a batch of mobile/reader bug reports:

> **Bug: 1 Timothy verse insights too short (perhaps audit all to be rich)**

This is the **only backend-touching item** in that batch — bugs #1–#7 and #9 were all mobile-app fixes and live in the companion PR **verse-mate/verse-mate-mobile#345**. "Verse insights too short" is a *content* problem, and the verse-by-verse content is generated server-side, so it needed a change here in `verse-mate`.

### Root cause
The `byline` (verse-by-verse) generation prompt in `packages/backend-base/src/bible/explanation-queue.ts` only asked for "a clear summary" per verse with no depth guidance. For some books (e.g. 1 Timothy, which isn't in the popular-chapters pre-generation list and was likely generated on-demand/early), that produced one-line, shallow summaries.

### Change
Strengthen the `byline` prompt (+11/−5, one file) to require:
- a substantial summary per verse — **≥3–4 full sentences** explaining what the verse says, what it means in context, and why it matters (no one-liners, even for short/greeting verses);
- **consistent depth across the whole chapter** (no thinning toward the end);
- key Hebrew/Greek term definitions and cross-references where helpful;
- meaning/significance, not just paraphrase.

Temperature (0.2) and output structure are unchanged; this only enriches the instruction text.

### Scope — important
This improves **future generations and regenerations only**. It does **not** retroactively rewrite already-stored explanations. The "audit all to be rich" part of Andy's report is an **ops follow-up** (needs prod DB + OpenAI):

1. Audit existing byline content for shortness (1 Timothy = `book_id 54`; drop the filter to audit all books):
   ```sql
   SELECT b.name, c.chapter_number,
          LENGTH(e.explanation) AS len,
          ROUND(LENGTH(e.explanation)::numeric / NULLIF(c.verse_count,0)) AS approx_per_verse
   FROM explanations e
   JOIN chapters c ON e.chapter_id = c.chapter_id
   JOIN books   b ON c.book_id   = b.book_id
   WHERE e.is_active = true AND e.type = 'byline' AND e.language_code = 'en'
     AND c.book_id = 54
   ORDER BY approx_per_verse ASC NULLS LAST;
   ```
   Flag rows with `approx_per_verse` below ~250 chars for regeneration.
2. Regenerate flagged chapters (creates a new active version, keeps history):
   ```
   POST /admin/explanation/regenerate
   { "book_id": 54, "chapter_number": <n>, "explanationType": "byline" }
   ```
   Suggested: regenerate 1 Timothy first to confirm the new prompt yields richer output, then batch the rest.

### Verification
Prompt-only change — the template literal is balanced and the chunking/non-chunking generation paths still operate on the changed string (no `{verseRange}` placeholder regressions). Backend CI is green.

---
🔗 Companion mobile PR: **verse-mate/verse-mate-mobile#345**
