### PR TITLE
ci: run backend CI on pull requests

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -19,6 +19,8 @@ on:
   push:
     branches: [main]
     tags: ['v*.*.*']
+  pull_request:
+    branches: [main]
 
 jobs:
   # ============================================


### PR DESCRIPTION
## What

Adds a `pull_request` trigger (`branches: [main]`) to `.github/workflows/backend-ci.yml` so backend CI (lint, type-check, tests) runs on PRs — not just on push to `main`/tags as today.

## Why

GitHub evaluates `pull_request` triggers from the **base branch's** copy of the workflow. Because `main` only has a `push` trigger, backend CI never runs on any PR — including feature PRs like #266 (Verse-of-the-Day backend, GH-265), whose new service/integration/admin tests therefore never execute before merge. The PR's green status today comes only from the Cloudflare Workers preview build.

Landing this on `main` activates PR-triggered runs for all current and future backend PRs.

## Scope

Intentionally **trigger-only**. The Test job's `continue-on-error` / `|| true` (non-blocking) behavior is left untouched here so this change can't red-line unrelated open PRs that may carry pre-existing test failures. PRs that want blocking tests carry that change on their own branch (e.g. #266 already does).

## After merge

#266 (and other open backend PRs) will run backend CI on their next push/sync, using their own branch's workflow version.