### PR TITLE
build(database): bundle seed-daily-verses into dist for prod seeding (GH-265)

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -2,7 +2,7 @@
   "name": "database",
   "module": "index.ts",
   "scripts": {
-    "build": "bun build ./src/migrator.ts ./src/seeder.ts ./src/actions/fix-migration.ts --target bun --minify --outdir ./dist",
+    "build": "bun build ./src/migrator.ts ./src/seeder.ts ./src/actions/fix-migration.ts ./src/actions/seed-daily-verses.ts --target bun --minify --outdir ./dist",
     "migrate:deploy": "bun ./src/migrator.ts migrate-deploy",
     "migrate:dev": "bun ./src/migrator.ts migrate-dev",
     "migrate:down": "bun ./src/migrator.ts migrate-down",


### PR DESCRIPTION
## Why
The Verse-of-the-Day widget shows its fallback because `GET /bible/verse-of-the-day` returns `{empty:true}` — the prod `daily_verses` pool was never seeded.

Root cause: the seed never runs in prod.
- Backend container `CMD` runs only `migrator.js migrate-deploy` then starts the server — no seed.
- The database `build` script bundled only `migrator`/`seeder`/`fix-migration`, so `seed-daily-verses.ts` was never compiled into `dist/`. The prod image ships `dist/` only (no `src/`), so there was no way to run the seed in the container.

## Change
Add `./src/actions/seed-daily-verses.ts` to the build entrypoints → compiles to `dist/actions/seed-daily-verses.js` (verified locally). Dockerfile already copies `packages/database/dist` → `/app/dist`.

## Seed after deploy (in the backend container, POSTGRES_URL already set)
```bash
bun run ./dist/actions/seed-daily-verses.js
```
Idempotent (skips existing verses; tags upsert on slug); skips refs whose NASB1995 content isn't loaded yet.

Related: verse-mate-mobile #349 (blank-widget crash + reader-style UI).