### PR TITLE
fix(byline): guard against shipping chapters with missing per-verse summaries

### DIFF
--- a/packages/backend-base/src/admin/services/batch-operations.service.ts
+++ b/packages/backend-base/src/admin/services/batch-operations.service.ts
@@ -16,6 +16,7 @@ import { BATCH_MONITORING_QUEUE } from "../../queue/batch-monitoring.queue";
 import { type AiProvider, getAiProvider } from "../../shared/ai";
 import {
   buildBylineChunkPrompts,
+  findVersesMissingSummary,
   shouldUseBylineChunking,
   splitBylineForTranslation,
   stitchBylineChunks,
@@ -2609,6 +2610,8 @@ export class BatchOperationService {
           chapterNumber: number;
           chapterId: number;
           totalChunks: number;
+          firstVerse: number;
+          lastVerse: number;
           chunks: Array<{ chunkIndex: number; text: string }>;
         }
       >();
@@ -2658,15 +2661,29 @@ export class BatchOperationService {
               const chapterId = Number.parseInt(chunkMatch[3], 10);
               const chunkIndex = Number.parseInt(chunkMatch[4], 10);
               const totalChunks = Number.parseInt(chunkMatch[5], 10);
+              const chunkStartVerse = Number.parseInt(chunkMatch[6], 10);
+              const chunkEndVerse = Number.parseInt(chunkMatch[7], 10);
 
               const key = `${chapterId}`;
-              if (!bylineChunkCollector.has(key)) {
+              const existing = bylineChunkCollector.get(key);
+              if (!existing) {
                 bylineChunkCollector.set(key, {
                   chapterNumber,
                   chapterId,
                   totalChunks,
+                  firstVerse: chunkStartVerse,
+                  lastVerse: chunkEndVerse,
                   chunks: [],
                 });
+              } else {
+                existing.firstVerse = Math.min(
+                  existing.firstVerse,
+                  chunkStartVerse,
+                );
+                existing.lastVerse = Math.max(
+                  existing.lastVerse,
+                  chunkEndVerse,
+                );
               }
 
               bylineChunkCollector
@@ -2848,6 +2865,26 @@ export class BatchOperationService {
           }
 
           const stitchedText = stitchBylineChunks(collected.chunks);
+
+          // Never let an incomplete blob become the active version: the batch
+          // path only checks chunk *count* above, so a verse whose summary the
+          // model dropped inside a chunk (the Mark 10:29 bug) would otherwise be
+          // stitched and saved verbatim. Skip the save so the previous good
+          // version stays active; the chapter can be regenerated via
+          // POST /admin/batch-explanations (skipExisting: false).
+          const missingSummaries = findVersesMissingSummary(
+            stitchedText,
+            collected.chapterNumber,
+            collected.firstVerse,
+            collected.lastVerse,
+          );
+          if (missingSummaries.length > 0) {
+            console.warn(
+              `[BATCH] Incomplete byline for chapter ${collected.chapterNumber} (ID: ${collected.chapterId}): missing per-verse summaries for [${missingSummaries.slice(0, 15).join(", ")}${missingSummaries.length > 15 ? ", …" : ""}] — skipping save.`,
+            );
+            errorCount++;
+            continue;
+          }
 
           const chapter = await this.db
             .getOrCreateConnection()

--- a/packages/backend-base/src/shared/byline-chunking.test.ts
+++ b/packages/backend-base/src/shared/byline-chunking.test.ts
@@ -3,6 +3,7 @@ import {
   BYLINE_CHUNK_SIZE,
   BYLINE_CHUNK_THRESHOLD,
   type BylineVerse,
+  findVersesMissingSummary,
   generateChunkedByline,
   shouldUseBylineChunking,
   splitBylineForTranslation,
@@ -444,5 +445,103 @@ describe("splitBylineForTranslation", () => {
       expect(summaries).toBe(headings);
       expect(verseRefs).toBe(headings);
     }
+  });
+});
+
+// --- findVersesMissingSummary (completeness guard for the Mark 10:29 bug) ---
+
+describe("findVersesMissingSummary", () => {
+  const complete = `# Line-by-Line Analysis of Mark 10
+
+## Mark 10:1
+> Getting up, He went...
+### Summary
+Jesus travels to Judea and teaches the crowds.
+### Analysis
+Sets the scene for the teaching that follows.
+
+## Mark 10:2
+> Some Pharisees came...
+### Summary
+The Pharisees test Jesus with a question about divorce.
+`;
+
+  it("returns [] when every requested verse has a non-empty summary", () => {
+    expect(findVersesMissingSummary(complete, 10, 1, 2)).toEqual([]);
+  });
+
+  it("flags a verse whose heading has no summary prose (only blockquote)", () => {
+    const md = `## Mark 10:1
+> a
+### Summary
+Real summary.
+
+## Mark 10:2
+> b
+### Summary
+
+## Mark 10:3
+> c
+### Summary
+Another.`;
+    expect(findVersesMissingSummary(md, 10, 1, 3)).toEqual([2]);
+  });
+
+  it("flags a verse whose heading is missing entirely", () => {
+    const md = `## Mark 10:1
+> a
+### Summary
+First.
+
+## Mark 10:3
+> c
+### Summary
+Third.`;
+    expect(findVersesMissingSummary(md, 10, 1, 3)).toEqual([2]);
+  });
+
+  it("does NOT flag a verse that has prose under a renamed sub-header only", () => {
+    const md = `## Mark 10:1
+> a
+### Analysis
+Analysis-only prose still counts as content.`;
+    expect(findVersesMissingSummary(md, 10, 1, 1)).toEqual([]);
+  });
+
+  it("recognises simple '## N' headings without a book/chapter prefix", () => {
+    const md = `## 1
+> a
+### Summary
+First.
+
+## 2
+> b
+### Summary
+`;
+    expect(findVersesMissingSummary(md, 10, 1, 2)).toEqual([2]);
+  });
+
+  it("only checks the requested [start, end] range", () => {
+    const md = `## Mark 10:1
+> a
+### Summary
+
+## Mark 10:2
+> b
+### Summary
+Present.`;
+    // verse 1's summary is empty but out of range → only verse 2 is checked
+    expect(findVersesMissingSummary(md, 10, 2, 2)).toEqual([]);
+  });
+
+  it("flags a trailing verse whose summary was truncated away", () => {
+    const md = `## Mark 10:51
+> a
+### Summary
+Bartimaeus asks to see.
+
+## Mark 10:52
+> b`;
+    expect(findVersesMissingSummary(md, 10, 51, 52)).toEqual([52]);
   });
 });

--- a/packages/backend-base/src/shared/byline-chunking.ts
+++ b/packages/backend-base/src/shared/byline-chunking.ts
@@ -110,6 +110,62 @@ function collectVerseMentionsForChapter(
   return [...chapterMentions, ...simpleMentions];
 }
 
+/**
+ * Returns the verse numbers in [startVerse, endVerse] that either have no
+ * `## …:V` heading or whose heading is not followed by any non-empty summary
+ * prose (the `>` blockquote verse text and `###` sub-headers such as
+ * `### Summary` / `### Analysis` do not count as prose). An empty array means
+ * every requested verse has a non-empty summary.
+ *
+ * This is the completeness guard that was missing when Mark 10:29 shipped
+ * without a summary — the mobile "Verse Insight" tooltip then showed
+ * "No specific insight available for this verse". Unlike the reverted VER-120
+ * quality gate (which required ≥3 sentences and, worse, wired a remediation
+ * loop into backend startup — see PR #253), this only checks *presence* of a
+ * non-empty summary, never rejects legitimately short content, and runs purely
+ * at generation time.
+ */
+export function findVersesMissingSummary(
+  output: string,
+  chapterNumber: number,
+  startVerse: number,
+  endVerse: number,
+): number[] {
+  const chapterHeading = new RegExp(
+    `\\b${chapterNumber}\\s*[:\\-]\\s*(\\d{1,3})\\b`,
+  );
+  const simpleHeading = /^##\s*(\d{1,3})\b/;
+  const proseLength = new Map<number, number>();
+  let current: number | null = null;
+
+  for (const line of output.replace(/\r\n/g, "\n").split("\n")) {
+    if (line.startsWith("## ")) {
+      const cv = line.match(chapterHeading);
+      const simple = line.match(simpleHeading);
+      current = cv
+        ? Number.parseInt(cv[1], 10)
+        : simple
+          ? Number.parseInt(simple[1], 10)
+          : null;
+      if (current !== null && !proseLength.has(current)) {
+        proseLength.set(current, 0);
+      }
+      continue;
+    }
+    if (current === null) continue;
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith(">") || trimmed.startsWith("#"))
+      continue;
+    proseLength.set(current, (proseLength.get(current) ?? 0) + trimmed.length);
+  }
+
+  const missing: number[] = [];
+  for (let v = startVerse; v <= endVerse; v++) {
+    if ((proseLength.get(v) ?? 0) === 0) missing.push(v);
+  }
+  return missing;
+}
+
 function validateChunkCoverage({
   output,
   chapterNumber,
@@ -146,6 +202,20 @@ function validateChunkCoverage({
           : !hasStart
             ? "missing-start-verse"
             : "missing-end-verse",
+      mentionsInRange,
+    };
+  }
+
+  const missingSummaries = findVersesMissingSummary(
+    output,
+    chapterNumber,
+    startVerse,
+    endVerse,
+  );
+  if (missingSummaries.length > 0) {
+    return {
+      valid: false,
+      reason: `missing-verse-summaries:${missingSummaries.slice(0, 12).join(",")}`,
       mentionsInRange,
     };
   }


### PR DESCRIPTION
## Problem
The mobile "Verse Insight" tooltip shows **"No specific insight available for this verse"** when a chapter's by-line content was generated without a summary for that verse — reported by Andy (2026-06-27, Mark 10:29). It's a **content** gap, not a client bug (the app reads local-first, so it happens online too).

## Root cause — no completeness validation anywhere
- **Production (Batch API)** stitch-and-save only checks chunk *count* (the `collected.chunks.length < collected.totalChunks` guard). Anything the model omits *inside* a chunk — a dropped verse, or a verse with no `### Summary` — is stitched and saved verbatim, then served without checks. Mark 10 (52 verses) is chunked 1–40 / 41–52, so verse 29 lives inside chunk 0.
- **Sync chunker** `validateChunkCoverage` only checks the **first and last** verse of each chunk — interior verses are never verified.
- The one prior guard (VER-120) was reverted in #253 — but **because it wired a runaway remediation loop into backend startup** (re-ran every deploy, hours of GPT calls, real money), *not* because generation-time validation is wrong.

## Fix
Add `findVersesMissingSummary()` and wire it in **at generation time only** (no startup hook, no auto-remediation):
1. `validateChunkCoverage()` now fails a chunk when any verse in its range lacks a non-empty summary → the existing bounded retry kicks in, then throws rather than shipping a gap. Covers the sync queue, pregenerate, and regeneration paths.
2. The Batch API stitch-and-save loop **skips the save** (mirroring the existing chunk-count guard) when the stitched blob is missing per-verse summaries, so an incomplete blob never becomes `is_active`. The chapter's verse range is taken from the chunk `custom_id`s.

The check only verifies **presence** of a non-empty summary (the `>` blockquote and `###` sub-headers don't count) — it never rejects legitimately short content, unlike the reverted ≥3-sentence quality gate.

## Testing
- `packages/backend-base/src/shared/byline-chunking.test.ts`: **36/36 pass** (7 new for `findVersesMissingSummary`; the existing `generateChunkedByline` tests still pass, confirming valid content isn't rejected).
- Detector validated against **126 live chapters** (Mark/John/Revelation/Leviticus/Psalms 1–50): **0 false positives**, and it correctly flags a synthetic missing-summary.
- Biome clean; `tsc --noEmit` reports no errors in the changed files.

## Backfill
Historical gaps are already fixable via `POST /admin/batch-explanations` with `{ explanationTypes: ["byline"], chapters: [...], skipExisting: false }` (how the current content was corrected). A standalone gap **detector** (the deleted `audit-byline-summaries.ts`) no longer exists — worth re-adding as a follow-up, but out of scope here.

## Related
Client-side hardening (so a future gap degrades gracefully instead of a dead-end message): verse-mate/verse-mate-mobile#355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
