### PR TITLE
fix(coach): register shared error handler so /coach/* returns 401/403 not 504

### DIFF
--- a/packages/backend-base/src/coach/coach.plugin.ts
+++ b/packages/backend-base/src/coach/coach.plugin.ts
@@ -1,5 +1,6 @@
 import { Elysia, t } from "elysia";
 import { authDerive } from "../auth/auth.utils";
+import { createErrorHandler } from "../common/error-handler";
 import {
   ForbiddenError,
   NotFoundError,
@@ -131,6 +132,7 @@ const TrendsSchema = t.Object({
 
 const plugin = new Elysia()
   .use(shared)
+  .onError(createErrorHandler("coach plugin"))
   .state((state) => ({
     ...state,
     coachService: new CoachService(state.db),


### PR DESCRIPTION
## Problem

All `/coach/*` endpoints return **504** in prod instead of the intended **401/403**.

The coach code merged in #273 is live (App Platform auto-deployed on the `:main` push, migration `20260719000000-create-coach-zoom-links` applied, `coach_zoom_links` table exists). But the runtime logs show:

```
.get("/trends", async ({ store: { coachService }, currentUserId }) => {
    throw new UnauthorizedError("Authentication required");
UnauthorizedError: Authentication required
...
error: Expected a Response object, but received '{ error: "UNAUTHORIZED", message: "Authentication required" }'
```

## Root cause

`coach.plugin.ts` throws `UnauthorizedError`/`ForbiddenError` but — unlike **every other plugin** (`auth`, `bible`, `user`, `admin`, `lemma`, `audio`, `offline`) — never registered the shared `createErrorHandler`. With no plugin-scoped `onError` to map the thrown `ApiError` into a response (`set.status` + `error.toResponse()`), Elysia can't emit a valid `Response`, logs *"Expected a Response object"*, and the App Platform edge returns 504.

## Fix

Add `.onError(createErrorHandler("coach plugin"))` right after `.use(shared)`, matching the existing pattern in all sibling plugins. One-line behavioural fix, no schema/API change.

## Verification

- CI (backend typecheck + tests).
- Post-deploy: `curl -si https://api.versemate.org/coach/me` → **401** (was 504); `/coach/admin/coaches` → 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)