### PR TITLE
feat(website): add "Log in" to the site header nav

### DIFF
--- a/apps/website/src/components/layout/Header.tsx
+++ b/apps/website/src/components/layout/Header.tsx
@@ -57,19 +57,19 @@ export default function Header() {
             Coach
           </Link>
           <Link
-            href="/login"
-            className={cn(NAV_LINK, isActive("/login") && "text-brand-gold")}
-            aria-current={isActive("/login") ? "page" : undefined}
-          >
-            Log in
-          </Link>
-          <Button
             href="/give"
-            variant="dark"
-            size="sm"
+            className={cn(NAV_LINK, isActive("/give") && "text-brand-gold")}
             aria-current={isActive("/give") ? "page" : undefined}
           >
             Give
+          </Link>
+          <Button
+            href="/login"
+            variant="dark"
+            size="sm"
+            aria-current={isActive("/login") ? "page" : undefined}
+          >
+            Log in
           </Button>
         </nav>
       </div>

--- a/apps/website/src/components/layout/Header.tsx
+++ b/apps/website/src/components/layout/Header.tsx
@@ -6,7 +6,7 @@ import Button from "@/components/ui/Button";
 import { cn } from "@/lib/cn";
 
 const NAV_LINK =
-  "font-inter text-sm font-medium text-brand-dark-gray no-underline transition-colors duration-200 hover:text-brand-gold md:text-base";
+  "whitespace-nowrap font-inter text-sm font-medium text-brand-dark-gray no-underline transition-colors duration-200 hover:text-brand-gold md:text-base";
 
 export default function Header() {
   const router = useRouter();
@@ -27,7 +27,7 @@ export default function Header() {
         scrolled ? "shadow-header" : "shadow-none",
       )}
     >
-      <div className="mx-auto flex h-[60px] w-full max-w-[1200px] items-center justify-between px-6 md:h-16 md:px-10 lg:px-16">
+      <div className="mx-auto flex h-[60px] w-full max-w-[1200px] items-center justify-between px-4 md:h-16 md:px-10 lg:px-16">
         {/* Logo */}
         <Link href="/" className="relative flex flex-shrink-0 items-center">
           <Image
@@ -36,12 +36,12 @@ export default function Header() {
             width={148}
             height={40}
             priority
-            className="h-8 w-auto object-contain md:h-[42px]"
+            className="h-7 w-auto object-contain md:h-[42px]"
           />
         </Link>
 
         {/* Nav — secondary items as text links, Give as the primary action */}
-        <nav className="flex items-center gap-5 md:gap-7" aria-label="Primary">
+        <nav className="flex items-center gap-3.5 sm:gap-5 md:gap-7" aria-label="Primary">
           <Link
             href="/volunteer"
             className={cn(NAV_LINK, isActive("/volunteer") && "text-brand-gold")}
@@ -55,6 +55,13 @@ export default function Header() {
             aria-current={isActive("/coach") ? "page" : undefined}
           >
             Coach
+          </Link>
+          <Link
+            href="/login"
+            className={cn(NAV_LINK, isActive("/login") && "text-brand-gold")}
+            aria-current={isActive("/login") ? "page" : undefined}
+          >
+            Log in
           </Link>
           <Button
             href="/give"


### PR DESCRIPTION
## Summary

Adds a visible **"Log in"** entry to the marketing site's header nav so visitors and coaches can sign into their VerseMate account straight from **versemate.org**. Previously the site had no login link — the only way in was to already know the app URL.

Nav is now: **Volunteer · Coach · Log in · Give**.

## How it works

"Log in" links to the site's existing `/login` page, which redirects to `app.versemate.org/login` via the `navigateToLogin()` helper (environment-aware: dev vs. production). No new auth surface — it routes into the app's normal sign-in, so one account works across the site and the app.

## Mobile

The nav had no hamburger and inlines every item, so a fourth item overflowed at phone widths ("Log in" wrapped to two lines, logo abutted the nav). Fixed by:
- `whitespace-nowrap` on nav links,
- a slightly smaller logo + tighter gaps/padding at the mobile breakpoint.

Verified the header fits cleanly on both desktop (1280) and mobile (420).

## Testing

- `bun run build` (next build, static export) ✓
- pre-commit `biome` + `bunx tsc` ✓
- Rendered the static export and screenshotted the header at desktop + mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWdisZktzeRmhjJRYJhXFf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWdisZktzeRmhjJRYJhXFf)_