### PR TITLE
feat(backend): add on-page coaching feedback to report payload

### DIFF
--- a/packages/backend-base/src/coach/coach.data.json
+++ b/packages/backend-base/src/coach/coach.data.json
@@ -167,6 +167,24 @@
             "Apples don't make trees alive — they prove they are alive",
             "What you do is what you believe"
           ],
+          "feedback": {
+            "headline": "An exceptional session — strongest in Newcomer Welcome and Application Questions, with the clearest next step in Session Structure & Flow.",
+            "strengths": [
+              "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "Homework was referenced and rewarded, differentiating the members who prepared."
+            ],
+            "improvements": [
+              "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+              "Discussion drifted from the text; a few more passages would ground the teaching.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture."
+            ],
+            "recommendations": [
+              "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+              "Next time, pre-mark 3 cross-references to pull in during the densest teaching block.",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds."
+            ]
+          },
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
@@ -278,6 +296,24 @@
             "Mercy triumphs over judgment",
             "The royal law is love your neighbor"
           ],
+          "feedback": {
+            "headline": "An exceptional session — strongest in Newcomer Welcome and Session Structure & Flow, with the clearest next step in Scripture Engagement.",
+            "strengths": [
+              "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+              "Discussion outweighed lecture — the room did the thinking, not just the leader."
+            ],
+            "improvements": [
+              "Discussion drifted from the text; a few more passages would ground the teaching.",
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded."
+            ],
+            "recommendations": [
+              "Next time, pre-mark 3 cross-references to pull in during the densest teaching block.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas."
+            ]
+          },
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
@@ -389,6 +425,24 @@
             "Religion that God accepts is active",
             "The mirror you forget is a wasted word"
           ],
+          "feedback": {
+            "headline": "A strong session — strongest in Newcomer Welcome and Session Structure & Flow, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+              "Transitions between segments lost momentum, so the session’s shape was harder to feel."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+              "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp."
+            ]
+          },
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         }
@@ -510,6 +564,24 @@
             "Devote yourselves to prayer",
             "Let your speech be seasoned with salt"
           ],
+          "feedback": {
+            "headline": "An on target session — strongest in Session Structure & Flow and Scripture Engagement, with the clearest next step in Facilitation vs. Lecture.",
+            "strengths": [
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "A high share of the room contributed substantively, called on by name."
+            ],
+            "improvements": [
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "Questions stayed heady; few moved the group to first-person, personal application.",
+              "The session leaned audio-only; a visual anchor would aid retention."
+            ],
+            "recommendations": [
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term."
+            ]
+          },
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
@@ -620,6 +692,24 @@
             "Work as unto the Lord",
             "Philemon: welcome him as you would welcome me"
           ],
+          "feedback": {
+            "headline": "An on target session — strongest in Scripture Engagement and Homework References, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Homework was referenced and rewarded, differentiating the members who prepared.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+              "The newcomer welcome was brief, missing a chance to enfold guests into the room."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+              "Next time, open by inviting two regulars to give a 60-second testimony before introductions."
+            ]
+          },
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
@@ -730,6 +820,24 @@
             "You died and your life is hidden with Christ",
             "Set your mind on things above"
           ],
+          "feedback": {
+            "headline": "A developing session — strongest in Homework References and Session Structure & Flow, with the clearest next step in Facilitation vs. Lecture.",
+            "strengths": [
+              "Homework was referenced and rewarded, differentiating the members who prepared.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse."
+            ],
+            "improvements": [
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "Questions stayed heady; few moved the group to first-person, personal application.",
+              "The session leaned audio-only; a visual anchor would aid retention."
+            ],
+            "recommendations": [
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term."
+            ]
+          },
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         }
@@ -852,6 +960,24 @@
             "Seek the Lord, all you humble of the land",
             "God rejoices over you with singing"
           ],
+          "feedback": {
+            "headline": "A strong session — strongest in Facilitation vs. Lecture and Application Questions, with the clearest next step in Newcomer Welcome.",
+            "strengths": [
+              "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place."
+            ],
+            "improvements": [
+              "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded."
+            ],
+            "recommendations": [
+              "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas."
+            ]
+          },
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         }
@@ -974,6 +1100,24 @@
             "Tear your clothes, turn your heart",
             "Partial reform is not reform"
           ],
+          "feedback": {
+            "headline": "A strong session — strongest in Vulnerability / Authenticity and Session Structure & Flow, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+              "Homework went unmentioned, reducing its pull on the group."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+              "Next time, ask two members to share one thing from their homework in the first 10 minutes."
+            ]
+          },
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         }
@@ -1096,6 +1240,24 @@
             "The kings fall but the promise holds",
             "Exile is discipline, not abandonment"
           ],
+          "feedback": {
+            "headline": "An on target session — strongest in Scripture Engagement and Session Structure & Flow, with the clearest next step in Newcomer Welcome.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+              "Discussion outweighed lecture — the room did the thinking, not just the leader."
+            ],
+            "improvements": [
+              "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+              "Teaching stayed at arm’s length; little personal cost was modeled.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded."
+            ],
+            "recommendations": [
+              "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+              "Next time, open one teaching point with a first-person example that cost you something.",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas."
+            ]
+          },
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         }
@@ -1218,6 +1380,24 @@
             "The heart is deceitful above all things",
             "Seek the welfare of the city"
           ],
+          "feedback": {
+            "headline": "A strong session — strongest in Scripture Engagement and Session Structure & Flow, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+              "Discussion outweighed lecture — the room did the thinking, not just the leader."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+              "Homework went unmentioned, reducing its pull on the group."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+              "Next time, ask two members to share one thing from their homework in the first 10 minutes."
+            ]
+          },
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         }

--- a/packages/backend-base/src/coach/coach.plugin.ts
+++ b/packages/backend-base/src/coach/coach.plugin.ts
@@ -44,6 +44,12 @@ const ReportSchema = t.Object({
   clusters: t.Array(ClusterSchema),
   dimensions: t.Array(DimensionSchema),
   bigIdeas: t.Array(t.String()),
+  feedback: t.Object({
+    headline: t.String(),
+    strengths: t.Array(t.String()),
+    improvements: t.Array(t.String()),
+    recommendations: t.Array(t.String()),
+  }),
   docUrl: t.String(),
   pdfUrl: t.String(),
 });

--- a/packages/backend-base/src/coach/coach.service.test.ts
+++ b/packages/backend-base/src/coach/coach.service.test.ts
@@ -32,6 +32,12 @@ function report(over: Partial<CoachReport>): CoachReport {
       { n: 2, name: "Newcomer Welcome", score: null },
     ],
     bigIdeas: [],
+    feedback: {
+      headline: "",
+      strengths: [],
+      improvements: [],
+      recommendations: [],
+    },
     docUrl: "",
     pdfUrl: "",
     ...over,

--- a/packages/backend-base/src/coach/coach.service.ts
+++ b/packages/backend-base/src/coach/coach.service.ts
@@ -38,8 +38,17 @@ export interface CoachReport {
   clusters: CoachCluster[];
   dimensions: CoachDimension[];
   bigIdeas: string[];
+  feedback: CoachFeedback;
   docUrl: string;
   pdfUrl: string;
+}
+
+/** Coaching feedback rendered directly on the portal (no Google Docs hop). */
+export interface CoachFeedback {
+  headline: string;
+  strengths: string[];
+  improvements: string[];
+  recommendations: string[];
 }
 
 interface CoachRecord {


### PR DESCRIPTION
## Summary

Adds a `feedback` object to each coach report so the portal can render coaching feedback **directly on the page** (no Google Docs hop) and generate a per-session PDF from it.

```
feedback: { headline, strengths[], improvements[], recommendations[] }
```

The content is derived from the session's 12-dimension scores by the coaching pipeline (`bible-study-coaching`'s `export-coach-portal-data.js`) and bundled here in `coach.data.json` — so the written feedback always matches the score shown (top dimensions → strengths, lowest → growth areas + transferable "next time" recommendations).

## Changes

- `CoachReport` gains `feedback: CoachFeedback`
- `ReportSchema` validates the new object (so `/coach/reports`, `/coach/admin/coaches/:id/reports` return it)
- refreshed bundled `coach.data.json`

## Testing

- `bun test src/coach` — 7/7 ✓
- `bunx tsc --noEmit` (apps/backend) ✓ + pre-commit `biome`/`tsc` ✓

## Related

- Dataset: `andytryba/bible-study-coaching` (feedback derivation)
- UI: `verse-mate/verse-mate-web` (renders feedback + PDF download)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWdisZktzeRmhjJRYJhXFf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWdisZktzeRmhjJRYJhXFf)_