### PR TITLE
feat(backend): expose per-dimension coach notes

### DIFF
--- a/packages/backend-base/src/coach/coach.data.json
+++ b/packages/backend-base/src/coach/coach.data.json
@@ -103,62 +103,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 4
+              "score": 4,
+              "note": "Delegated open/close, book-level Big Idea review, multi-reader scripture, deep teaching, and a strong wrap-up all present. Dip from a full 5 due to the ~11-min whiteboard/timeline detour and the explicitly skipped Day-4 exercise pulling time from the blueprint's later steps"
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": null
+              "score": null,
+              "note": "No first-timers this week (week 9 of 10). Cluster max reduced 15→10, not penalized"
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 5
+              "score": 5,
+              "note": "20+ cross-references across 13 books — the widest book range of the arc to date (James, Hebrews, Acts, 2 Peter, Jude, 1 John, Matthew ×3, 1 Thessalonians, Job, Psalms, 2 Corinthians, Leviticus, Deuteronomy)"
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 3
+              "score": 3,
+              "note": "~40–45% discussion-only, above target; the ~6-min uninterrupted prophecy-chart narration is the main driver. Socratic technique excellent elsewhere (Psalm 73 walk-through, wealth discussion) but this dip is real, not just optics"
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 5
+              "score": 5,
+              "note": "6 DOK-scored questions (within 5–7 target); 50/50 DOK 4/DOK 3 split; 5+ first-person confessions including the leader's own unresolved disclosure"
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 4
+              "score": 4,
+              "note": "12+ substantive contributors of ~13 (~90%+) — high percentage of a much smaller room; fewer peer-to-peer chains than L8's arc-best session"
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 3
+              "score": 3,
+              "note": "One prophecy-timeline chart ultimately delivered via screen-share, but a ~5-min failed live-whiteboard attempt preceded it; no on-screen Greek/Hebrew word-study tool this week (a step back from L8's word studies)"
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 4
+              "score": 4,
+              "note": "Bryan's own live, unresolved financial-fear disclosure plus the sales-integrity testimony; high member-vulnerability floor. Consistent with the 4/5 Thursday baseline (±1 swing cap applied)"
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 3
+              "score": 3,
+              "note": "Brief, functional book-level review at open (~5 min), but the formal cold cumulative recall drill was skipped for a 2nd consecutive week despite being named as the arc's top priority gap"
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 3
+              "score": 3,
+              "note": "Homework named explicitly ('the math they gave us in the homework', 'the one thing exercise... day four') but the specific Day-4 exercise was explicitly skipped rather than adapted for Zoom"
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 5
+              "score": 5,
+              "note": "Opening (Hunter) AND closing (Cole) delegated and both captured in the recording"
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 3
+              "score": 3,
+              "note": "No in-session apprentice handoff or delegated facilitation window this week; arc-long pattern holds"
             }
           ],
           "bigIdeas": [
@@ -233,62 +245,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 4
+              "score": 4,
+              "note": "10-step blueprint followed; opening prayer delegated, newcomer welcome complete with testimonies, Guarantee delivered, Big Ideas review, cross-ref arc, closing commissioning prayer; no formal Ebbinghaus drill"
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": 5
+              "score": 5,
+              "note": "John (first-timer), Eric, Mike welcomed with full member testimonies and Guarantee; Bryan personally engaged John ('why did you decide to show up?'); +3.0 newcomer bonus applied"
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 5
+              "score": 5,
+              "note": "19 cross-references across 12+ books — James primary + Titus 1, Rom 3/5/6, Heb 11, Eph 2, 2 Cor 5/13, 1 Cor 6, Matt 7, Gal 5, John 3/13; 80%+ of discussion scripture-grounded"
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 4
+              "score": 4,
+              "note": "~35-40% discussion-only leader talk (excludes welcome, excludes reading); good Socratic method; some teaching monologues in cross-ref sections"
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 4
+              "score": 4,
+              "note": "6-7 DOK-scored Big Idea questions; strong evidence card bookend; functional atheist concept stayed intellectual; John's card not retrieved at close"
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 4
+              "score": 4,
+              "note": "15+ substantive contributors; ~75% of group; two member-generated bumper stickers; peer-to-peer exchanges; no quiet member flag"
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 3
+              "score": 3,
+              "note": "Blue Letter Bible used on-screen for G1344 word study (resolves James/Paul discrepancy); no color-coded chart, no two-column reference board; improvement from 2/5"
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 3
+              "score": 3,
+              "note": "3 vulnerability moments (personal guarantee story 3/5, Christmas tree theft 2/5, naming rights 3/5); one below baseline; +/-1 cap applied; no high-cost disclosure"
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 3
+              "score": 3,
+              "note": "Informal James tests recall at open (Bryan-led); new bumper sticks generated by members; no formal Ebbinghaus retrieval drill; 9th consecutive session without it"
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 4
+              "score": 4,
+              "note": "The Guarantee delivered twice — in welcome and mid-lesson as personal testimony; Precept homework implicit; 'five days a week' framing present; no explicit 'Power of Four' reference"
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 5
+              "score": 5,
+              "note": "Opening prayer delegated (member at 00:00); group commissioning prayer for Brendan and Glenn (3+ spontaneous member prayers at close); one of the strongest prayer moments of the James arc"
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 4
+              "score": 4,
+              "note": "Brendan publicly commissioned for Camp Tejas — Bryan named it his 'first leader role,' called it 'a big deal'; group gathered and prayed; Glenn Gordon (men's pastor) also affirmed; fully observable in-session signal"
             }
           ],
           "bigIdeas": [
@@ -364,62 +388,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 4
+              "score": 4,
+              "note": "Full 10-step blueprint executed; closing prayer not delegated (Bryan ran it himself, session overran); ran ~10 min long"
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": 4
+              "score": 4,
+              "note": "Jordan, Caleb, Matt welcomed; 12-min intro with 4-5 member testimonies + Bryan's full origin story; The Guarantee not formally delivered"
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 5
+              "score": 5,
+              "note": "15 confirmed cross-references across 8 books; Romans 2:11 ('God shows no partiality') as concise closing anchor; discussion 75-80% scripture-grounded"
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 3
+              "score": 3,
+              "note": "~33-38% leader talk (discussion only); strong Socratic calling by name; 3-4 longer teaching sections pull ratio above target"
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 4
+              "score": 4,
+              "note": "9-10 Big Idea questions; 40% DOK 4; 'why is this in the Bible?' opener generated excellent theological framing"
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 4
+              "score": 4,
+              "note": "15+ named contributors; 7+ scripture readers; member felony story as session's highest-depth disclosure"
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 4
+              "score": 4,
+              "note": "VerseMate on screen for the Greek/Hebrew word definitions (royal law, partiality, 'face value'); growth edge is a board for the cumulative 'riches' list, which stayed in the room's memory"
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 4
+              "score": 4,
+              "note": "3 moments: political partiality confession [00:52]; James Jones / adoption closing story [02:03]; shorts ministry church judgment story [02:03]"
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 3
+              "score": 3,
+              "note": "Comprehensive James ch.1 Big Ideas review (~14 min, 6 ideas, member-participatory); bumper sticker generation at close; guided not unsupported Ebbinghaus recall"
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 3
+              "score": 3,
+              "note": "Directed Caleb and Jordan to contact Lance or John for homework materials; explained 5-day format at close [02:04]; The Guarantee not formally delivered"
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 3
+              "score": 3,
+              "note": "Opening prayer delegated to a member (at start of recording); closing prayer not delegated — Bryan led it himself due to time pressure at 9:11 AM; prayer chain not referenced"
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 3
+              "score": 3,
+              "note": "Background signals only (directing newcomers through Lance/John); no visible in-session apprenticeship; multiplication model referenced in newcomer welcome"
             }
           ],
           "bigIdeas": [],
@@ -489,62 +525,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 4
+              "score": 4,
+              "note": "Full 10-step blueprint executed; Big Ideas review in Q&A/guided-themes format (not unsupported Ebbinghaus recall)"
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": 3
+              "score": 3,
+              "note": "Chris and John welcomed; homework instructions given at close; The Guarantee and formal member testimony protocol not executed"
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 5
+              "score": 5,
+              "note": "22+ cross-references — arc high; 80-85% discussion grounded in scripture; first scripture within 15 min"
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 3
+              "score": 3,
+              "note": "~32-35% leader talk (discussion only); three theological bridge monologues pulled ratio up in middle third"
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 4
+              "score": 4,
+              "note": "9 Big Idea questions; 44% DOK 4 (above 25% benchmark); royal law question at arc's highest single-question yield"
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 4
+              "score": 4,
+              "note": "14+ named contributors; 8+ scripture readers; 8-member application close"
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 2
+              "score": 2,
+              "note": "None used — no whiteboard, no BLB word studies, no diagrams in the arc's highest-density content session"
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 5
+              "score": 5,
+              "note": "4 disclosures: Muslim partiality [01:07:38]; political/car partiality [01:04:08]; pornography/social media trap [01:30:02]; shorts ministry backstory [~00:50]"
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 3
+              "score": 3,
+              "note": "Guided-themes Big Ideas review (not unsupported Ebbinghaus retrieval); no formal bumper-sticker generation at close"
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 4
+              "score": 4,
+              "note": "Explicit homework instructions to both newcomers at close [02:03:23]; referenced during session; The Guarantee not formally delivered"
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 3.5
+              "score": 3.5,
+              "note": "Closing prayer delegated to Marco [02:01-02:03] — on-topic (learning + application); opening prayer not captured in transcript; no prayer chain reference"
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 3.5
+              "score": 3.5,
+              "note": "Lance bringing 2 newcomers signals multiplication; Bryan directing newcomers through Lance and John shows distributed pastoral network; no in-training leader like Russell in Thursday group"
             }
           ],
           "bigIdeas": [],
@@ -614,62 +662,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 4
+              "score": 4,
+              "note": "Full 10-step blueprint executed; Big Ideas review Q&A style rather than formal retrieval"
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": 5
+              "score": 5,
+              "note": "5 newcomers; 3 member testimonies (Keith, Brendan, Russ); Bryan testimony + The Guarantee delivered"
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 3
+              "score": 3,
+              "note": "4 cross-references vs. 6+ benchmark; newcomer welcome consumed cross-referencing time"
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 3
+              "score": 3,
+              "note": "~38-42% leader talk (discussion only); consistent growth lever across all sessions"
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 4
+              "score": 4,
+              "note": "8-10 Big Idea questions; DOK 3-4 majority; Weston application at highest DOK 4 quality"
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 4
+              "score": 4,
+              "note": "15+ named contributors; 8+ scripture readers; 6-member Big Ideas close"
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 3
+              "score": 3,
+              "note": "Sin progression diagram (collaborative); no BLB word studies; no maps"
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 4
+              "score": 4,
+              "note": "4 disclosures: VerseMate coaching [01:32:25]; Facebook [01:01:36]; adopted son [01:04:59]; wife's health [00:25:16]"
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 3
+              "score": 3,
+              "note": "Q&A review not formal Ebbinghaus unsupported retrieval; consistent growth lever"
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 4
+              "score": 4,
+              "note": "The Guarantee delivered explicitly [00:09:07]; homework exhorted at close [02:06:00]"
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 4
+              "score": 4,
+              "note": "Opening delegated; closing delegated; prayer chain + session email list promoted at close"
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 4
+              "score": 4,
+              "note": "Russell in training; Colt brought newcomer after 2 weeks; Brennan baptism; multiple multiplication signals"
             }
           ],
           "bigIdeas": [],
@@ -739,62 +799,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 4
+              "score": 4,
+              "note": "Strong blueprint adherence; Big Ideas review informal but present; both prayers captured"
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": null
+              "score": null,
+              "note": "No newcomers — Building Ministry max reduced proportionally"
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 5
+              "score": 5,
+              "note": "9 cross-references; 2 BLB Greek word studies; exceeds 6+ benchmark"
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 3
+              "score": 3,
+              "note": "~41% leader talk; first-half teaching blocks pull above 30% benchmark; second half recovers"
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 4
+              "score": 4,
+              "note": "11 Big Idea questions; DOK 2–4; 36% DOK 4; distributed throughout + full go-around"
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 4
+              "score": 4,
+              "note": "15+ named contributors; 8 scripture readers; ~15 go-around participants"
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 3
+              "score": 3,
+              "note": "BLB for 2 word studies; no slides, whiteboard, or maps"
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 4
+              "score": 4,
+              "note": "4 Bryan disclosures; cascade of member vulnerability; Cole's conversion testimony; Marcus tongue confession"
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 3
+              "score": 3,
+              "note": "Informal review at start (not formal recall drill); 6 bumper stickers surfaced; no formal closing drill"
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 3
+              "score": 3,
+              "note": "No explicit Guarantee; one casual next-week reference; one member disclosed weak homework week"
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 4
+              "score": 4,
+              "note": "Opening prayer delegated (captured at recording start); closing prayer delegated to member (on-topic, referenced James themes); prayer chain (Craig Rooker follow-up)"
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 4
+              "score": 4,
+              "note": "Hunter's baptism June 6; Brendan praised publicly; Pocan's son running couples class — three multiplication signals in one session"
             }
           ],
           "bigIdeas": [],
@@ -864,62 +936,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 3
+              "score": 3,
+              "note": "Blueprint followed (newcomer welcome → overview → scripture → application → Big Ideas → closing prayer). Opening prayer not captured. No formal cumulative Big Ideas review from L1. Ran over by ~8 min."
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": 4
+              "score": 4,
+              "note": "4 newcomers, all engaged. Strong existing-member testimonies (Brendan, Andy Truebert, Austin). The Guarantee delivered. Personal challenge to Mauricio. Missed: Eddie’s hurt not acknowledged before theological pivot."
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 3
+              "score": 3,
+              "note": "1 cross-reference passage (Rom 5:3–5) plus 7 Greek word studies via BLB. Cross-ref count (2 passages) is well below the 6+ benchmark. Bryan acknowledged skipping prepared cross-refs. Word study depth is excellent but doesn’t substitute for parallel-text density."
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 3
+              "score": 3,
+              "note": "Leader talk ratio ~45% with reading, ~38% discussion-only. Above the Lifeway 30% target. BLB teaching block (~5 min) and Guarantee pitch (~4 min) are the primary drivers. Strong back-and-forth throughout; 20+ distinct voices compensate partially."
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 4
+              "score": 4,
+              "note": "9 Big Idea questions, all DOK 2–4. DOK distribution: 33% Level 4, 45% Level 3, 22% Level 2. Questions distributed throughout; strong synthesis round at close. No DOK 1 questions scored. Matches Bryan’s best recent sessions on question quality."
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 4
+              "score": 4,
+              "note": "20+ named voices; 10+ with substantive contributions; >40% of named participants contributed. Quiet members called on directly. All 4 newcomers gave substantive introductions. Estimated participation rate ~75–80%."
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 3
+              "score": 3,
+              "note": "BLB on screen with Strong’s Concordance — excellent and extensively used. No color-coded charts, maps, or structural diagrams this session. BLB was the single visual aid tool."
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 4
+              "score": 4,
+              "note": "Stillborn first child disclosure is the highest-cost vulnerability in Bryan’s recent arc. Trials breakdown disclosure and heart attack reference add supporting depth. Weighted by depth: stillborn carries the score. Missed: Eddie’s vulnerability could have been reciprocated earlier."
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 3
+              "score": 3,
+              "note": "No L1 Big Ideas review from memory at session start. Strong canonical close (5 Big Ideas surfaced with full group input). Bumper stickers: “joy is a verdict,” “holiness not happiness,” “tested faith produces maturity,” “partial obedience is disobedience” (referenced). 4 bumper stickers, slightly below the 5–7 target."
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 4
+              "score": 4,
+              "note": "The Guarantee delivered with full conviction and personal story. Multiple references to the 5-day homework rhythm. BLB instruction is direct homework skill-transfer. Closing prompt: “you’ve got five days to study a few verses.” Slightly below May 22 (5/5) due to less explicit homework tracking this session."
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 3
+              "score": 3,
+              "note": "Closing prayer: delegated to Russell, on-topic, scripture-connected, well-executed (“help us to be perfected by the trials that we go through and help us to have your viewpoint”). Opening prayer: not captured in recording. Prayer chain referenced multiple times in context. Score reflects only the closing prayer being visible."
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 3
+              "score": 3,
+              "note": "Group is past split threshold. Bryan stated “we don’t have a leader” directly. 22 groups total, Austin Stone partnership, Brendan’s baptism — multiplication is visible in the program. But no in-session apprenticeship moment; no member given a facilitation window; no named apprentice. 2 Tim 2:2 mechanism not active in this session."
             }
           ],
           "bigIdeas": [],
@@ -989,62 +1073,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 4
+              "score": 4,
+              "note": "Blueprint executed: newcomer welcome, historical context, scripture, deep Socratic study, closing application, delegated prayer. No audible Big Ideas review from L1. 8 min over 2h target."
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": 5
+              "score": 5,
+              "note": "Two newcomers (Anthony, Graham). Members gave testimonies before newcomers spoke. Bryan shared personal story. Both newcomers introduced with follow-up commitments (Luke’s number; Tristan for Anthony). Homework push at close."
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 5
+              "score": 5,
+              "note": "9 cross-references cited and read (benchmark: 6+). Blue Letter Bible with Strong’s Concordance on shared screen. Greek word studies for “consider” and “joy.” All 12 James verses read and interrogated."
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 3
+              "score": 3,
+              "note": "Discussion-only ratio ~33% leader talk; above 30% Lifeway benchmark. Three monologues exceeded 90 sec. Consistent with all prior sessions in this arc."
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 4
+              "score": 4,
+              "note": "8 Big Idea questions; 25% DOK 4, 50% DOK 3, 25% DOK 2. Strong closing application round (“tell your wife”) functioned as full-room application synthesis."
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 4
+              "score": 4,
+              "note": "17+ named voices; 8 scripture readers; 6 questioners; ~85–90% participation rate. Quiet members called by name. Both newcomers contributed substantively."
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 3
+              "score": 3,
+              "note": "BLB shared on screen with Strong’s Concordance; Greek word studies presented. No color-coded charts or structural diagrams. Ernest photo used for humor/engagement. Better than L1 (2/5 overview session), below full-study benchmark."
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 4
+              "score": 4,
+              "note": "Four Bryan disclosures weighted by depth: faith journey at 39, fax machine prayer, two largest trials (20–30 yrs later insight), homework humility. Clint’s suicidal disclosure handled pastorally without moralizing or rescue. Group vulnerability culture intact."
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 3
+              "score": 3,
+              "note": "No audible Big Ideas review from L1 at session start. Closing application round (“tell your wife”) functioned as strong memory anchoring. Four memorable bumper stickers surfaced. Consistent with L1 score."
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 5
+              "score": 5,
+              "note": "“The Guarantee” invoked multiple times. Bryan’s 25-year personal testimony to homework at close. “Best 25 bucks you’ll ever spend” to Anthony. 5-day homework framing delivered. Next session assignment implied (last verses of chapter 1)."
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 5
+              "score": 5,
+              "note": "Opening prayer (Nandan) — substantive, scripture-connected, delegated appropriately. Closing prayer (Hunter) — on-topic, applied lesson themes, beautiful. Prayer chain infrastructure referenced. First session with both prayers fully captured and scored at maximum."
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 3
+              "score": 3,
+              "note": "Hunter’s role as prayer chain manager and scribe is visible. Baptism announced. No formal teaching or facilitation role during the session. 2 Tim 2:2 multiplication principle not yet visible in session mechanics. Same as L1."
             }
           ],
           "bigIdeas": [],
@@ -1114,62 +1210,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 4
+              "score": 4,
+              "note": "Blueprint well-executed: newcomer welcome, context overview, full-book reading, closing prayer. No Big Ideas review (appropriate for L1). Ran 14 min over target duration."
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": 5
+              "score": 5,
+              "note": "8–9 newcomers; 2 member testimonials before introductions; Bryan personally organized follow-up calls (Steven, Bryce, Mike, Thomas each assigned a newcomer). Best of the series."
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 4
+              "score": 4,
+              "note": "All 5 chapters of James read in order, paragraph by paragraph. Cross-references: ~4 (below the 6+ benchmark). Overview format partly explains; parallel texts in L2–10 will address."
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 3
+              "score": 3,
+              "note": "Discussion-only ratio ~38% leader talk; above 30% benchmark. Three extended monologues; context-setting demands partly justify the gap. Same dimension score as L6 and L7."
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 4
+              "score": 4,
+              "note": "9 Big Idea questions; 22% DOK 4, 44% DOK 3. Even distribution across chapters 1–3; compressed in 4–5 due to pacing. DOK ceiling lower than deep-study sessions (67% DOK 3-4 vs. L6’s 89%)."
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 4
+              "score": 4,
+              "note": "15+ named voices; 11+ scripture readers; ~58–65% participation rate. Engagement thinned in chapters 4–5 as pacing picked up. Maintained above L6 baseline overall."
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 2
+              "score": 2,
+              "note": "Scripture screen only; no BLB, no structural chart, no color-coded visual. Chiasm described verbally without a diagram. Lowest single score; directly addressable in L2."
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 3
+              "score": 3,
+              "note": "3 moderate-depth moments. Brother-in-law disclosure is Bryan’s highest-cost personal share this session; depth slightly below L7’s peak. Weight: 1 family share + 1 relational directness + 1 personal-story entry."
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 3
+              "score": 3,
+              "note": "Lesson 1: no prior Big Ideas to review. Bryan actively taught the importance of scripture memorization; Brendan’s prayer testimony demonstrated the practice. Foundation set for L2 review pattern."
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 5
+              "score": 5,
+              "note": "“The Guarantee” delivered in full; 5-day hard-work framing; workbooks distributed at close; next-week assignment (James 1:1–11, memorize vv. 2–11) given explicitly. Highest Dim 10 score of the series."
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 4
+              "score": 4,
+              "note": "Multi-voice closing prayer (5–6 men, 8 min) for Fred’s EO speech. Opening prayer not captured (pre-recording). Prayer chain infrastructure emphasized with accountability language. Strong community prayer culture demonstrated."
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 3
+              "score": 3,
+              "note": "Follow-up calls assigned through existing members (Steven, Bryce, Mike, Thomas). Prayer chain accountability invoked. No visible apprentice in formal co-teaching or leadership-in-action role. Opportunity missed with 25+ men and 8-9 newcomers."
             }
           ],
           "bigIdeas": [],
@@ -1239,62 +1347,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 4
+              "score": 4,
+              "note": "Strong open (newcomer + chart + Big Ideas); closing truncated by run-over past 9:00 target"
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": 4
+              "score": 4,
+              "note": "Walker introduced; Keith's Guarantee pitch. 7 min vs. 7–25 range — intro-only, no integration post-[06:00]"
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 5
+              "score": 5,
+              "note": "7 passages across 4 books; 82% verse-grounded; every teaching move anchored to text"
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 3
+              "score": 3,
+              "note": "62% leader talk (discussion only); regressed from L5 (58%); middle hour heavily leader-led"
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 4
+              "score": 4,
+              "note": "9 Big Ideas at 89% DOK 3-4; count regressed from L5 (11); spacing clustered first/last thirds"
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 3
+              "score": 3,
+              "note": "53% contribution rate; same core 5–6; Walker not pulled into substantive Q&A"
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 5
+              "score": 5,
+              "note": "Three aids deployed synchronously — best of the arc (chart + live text + Big Ideas slide)"
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 3
+              "score": 3,
+              "note": "3 moderate moments; depth regressed from L5 (no marital-accountability-level disclosure)"
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 3
+              "score": 3,
+              "note": "Big Ideas review cursory (~2 min vs. L5's 8 min); ‘Stone-cold’ and ‘Bad company’ referenced but not group-recited"
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 4
+              "score": 4,
+              "note": "Explicit Precept reference at [39:48]; Power of Four implicit; prayer chain call commitment at [120:27]"
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 4
+              "score": 4,
+              "note": "Closing prayer delegated at [127:10] but rushed; opening prayer presumed pre-record"
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 4
+              "score": 4,
+              "note": "Russell operated chart at [07:00–09:30]; apprenticeship visible but not actively coached in real time"
             }
           ],
           "bigIdeas": [],
@@ -1364,62 +1484,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 5
+              "score": 5,
+              "note": "Excellent 10-step adherence"
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": null
+              "score": null,
+              "note": "No newcomers present"
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 5
+              "score": 5,
+              "note": "7 passages across 6 books, OT-NT bridge"
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 4
+              "score": 4,
+              "note": "58% discussion-only; improved but above target"
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 5
+              "score": 5,
+              "note": "11 Big Ideas, 45% DOK 4"
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 4
+              "score": 4,
+              "note": "50% asking questions; improved but below 70-80%"
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 4
+              "score": 4,
+              "note": "Kings chart used effectively"
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 4
+              "score": 4,
+              "note": "4 moments weighted by depth"
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 5
+              "score": 5,
+              "note": "Strong cumulative Big Ideas review"
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 4
+              "score": 4,
+              "note": "Referenced throughout session"
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 5
+              "score": 5,
+              "note": "Delegated opening, closing present"
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 4
+              "score": 4,
+              "note": "Russell mentioned, group leadership evident"
             }
           ],
           "bigIdeas": [],
@@ -1500,62 +1632,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": null
+              "score": null,
+              "note": ""
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 3
+              "score": 3,
+              "note": ""
             }
           ],
           "bigIdeas": [
@@ -1628,62 +1772,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 2
+              "score": 2,
+              "note": ""
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 3
+              "score": 3,
+              "note": ""
             }
           ],
           "bigIdeas": [
@@ -1756,62 +1912,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": null
+              "score": null,
+              "note": ""
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 2
+              "score": 2,
+              "note": ""
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 2
+              "score": 2,
+              "note": ""
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 2
+              "score": 2,
+              "note": ""
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 2
+              "score": 2,
+              "note": ""
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 2
+              "score": 2,
+              "note": ""
             }
           ],
           "bigIdeas": [
@@ -1895,62 +2063,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 5
+              "score": 5,
+              "note": ""
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 5
+              "score": 5,
+              "note": ""
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 4
+              "score": 4,
+              "note": ""
             }
           ],
           "bigIdeas": [
@@ -2035,62 +2215,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": null
+              "score": null,
+              "note": ""
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 5
+              "score": 5,
+              "note": ""
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 3
+              "score": 3,
+              "note": ""
             }
           ],
           "bigIdeas": [
@@ -2175,62 +2367,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 5
+              "score": 5,
+              "note": ""
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 3
+              "score": 3,
+              "note": ""
             }
           ],
           "bigIdeas": [
@@ -2315,62 +2519,74 @@
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": null
+              "score": null,
+              "note": ""
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 5
+              "score": 5,
+              "note": ""
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 3
+              "score": 3,
+              "note": ""
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 4
+              "score": 4,
+              "note": ""
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 3
+              "score": 3,
+              "note": ""
             }
           ],
           "bigIdeas": [

--- a/packages/backend-base/src/coach/coach.plugin.ts
+++ b/packages/backend-base/src/coach/coach.plugin.ts
@@ -24,6 +24,7 @@ const DimensionSchema = t.Object({
   n: t.Number(),
   name: t.String(),
   score: t.Union([t.Number(), t.Null()]),
+  note: t.Optional(t.String()),
 });
 
 const ReportSchema = t.Object({

--- a/packages/backend-base/src/coach/coach.service.ts
+++ b/packages/backend-base/src/coach/coach.service.ts
@@ -18,6 +18,8 @@ export interface CoachDimension {
   n: number;
   name: string;
   score: number | null;
+  /** Coach's per-dimension rationale ("why this score"); may be empty. */
+  note?: string;
 }
 
 export interface CoachReport {


### PR DESCRIPTION
## Summary

Adds an optional **`note`** to the dimension schema/type so `/coach/*` returns each dimension's coaching rationale ("why this score") alongside the 1–5 score. Refreshes the bundled dataset with the notes (real per-dimension notes for Bryan's sessions; empty for synthetic leaders).

- `CoachDimension` gains `note?: string`; `DimensionSchema` adds `t.Optional(t.String())`.
- Report shape otherwise unchanged.

## Testing

- `bun test src/coach` — 7/7 ✓; `bunx tsc --noEmit` (apps/backend) ✓; pre-commit biome/tsc ✓.

## Related

- Dataset (extracts the notes): `andytryba/bible-study-coaching` #34
- UI (shows the note in the dimension detail): `verse-mate/verse-mate-web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWdisZktzeRmhjJRYJhXFf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWdisZktzeRmhjJRYJhXFf)_