### PR TITLE
Pass report.sections through the /coach API

### DIFF
--- a/packages/backend-base/src/coach/coach.data.json
+++ b/packages/backend-base/src/coach/coach.data.json
@@ -206,6 +206,7 @@
                 "paragraphs": [
                   "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
                   "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 20+ cross-references across 13 books — the widest book range of the arc to date (James, Hebrews, Acts, 2 Peter, Jude, 1 John, Matthew ×3, 1 Thessalonians, Job, Psalms, 2 Corinthians, Leviticus, Deuteronomy)"
                 ]
               },
@@ -214,6 +215,7 @@
                 "paragraphs": [
                   "Application questions pushed members from concept to life, several at the reason/apply level.",
                   "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 6 DOK-scored questions (within 5–7 target); 50/50 DOK 4/DOK 3 split; 5+ first-person confessions including the leader's own unresolved disclosure"
                 ]
               },
@@ -222,33 +224,73 @@
                 "paragraphs": [
                   "Prayer was delegated to members, opening and closing the group in shared voice.",
                   "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: Opening (Hunter) AND closing (Cole) delegated and both captured in the recording"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Delegated open/close, book-level Big Idea review, multi-reader scripture, deep teaching, and a strong wrap-up all present. Dip from a full 5 due to the ~11-min whiteboard/timeline detour and the explicitly skipped Day-4 exercise pulling time from the blueprint's later steps"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 12+ substantive contributors of ~13 (~90%+) — high percentage of a much smaller room; fewer peer-to-peer chains than L8's arc-best session"
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Facilitation vs. Lecture is the clearest growth area (3/5)",
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
                 "paragraphs": [
                   "Leader talk crowded out discussion; the balance leaned toward lecture.",
                   "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: ~40–45% discussion-only, above target; the ~6-min uninterrupted prophecy-chart narration is the main driver. Socratic technique excellent elsewhere (Psalm 73 walk-through, wealth discussion) but this dip is real, not just optics"
                 ]
               },
               {
-                "title": "Visual Aids is the clearest growth area (3/5)",
+                "title": "Visual Aids is a growth area (3/5)",
                 "paragraphs": [
                   "The session leaned audio-only; a visual anchor would aid retention.",
                   "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: One prophecy-timeline chart ultimately delivered via screen-share, but a ~5-min failed live-whiteboard attempt preceded it; no on-screen Greek/Hebrew word-study tool this week (a step back from L8's word studies)"
                 ]
               },
               {
-                "title": "Memory Reinforcement is the clearest growth area (3/5)",
+                "title": "Memory Reinforcement is a growth area (3/5)",
                 "paragraphs": [
                   "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
                   "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: Brief, functional book-level review at open (~5 min), but the formal cold cumulative recall drill was skipped for a 2nd consecutive week despite being named as the arc's top priority gap"
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (3/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Homework named explicitly ('the math they gave us in the homework', 'the one thing exercise... day four') but the specific Day-4 exercise was explicitly skipped rather than adapted for Zoom"
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (3/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: No in-session apprentice handoff or delegated facilitation window this week; arc-long pattern holds"
                 ]
               }
             ],
@@ -257,25 +299,81 @@
                 "title": "Next session — Facilitation vs. Lecture",
                 "paragraphs": [
                   "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Visual Aids",
                 "paragraphs": [
                   "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Memory Reinforcement",
                 "paragraphs": [
                   "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 80% × weight 33 → 26.40 pts",
+                "Building Ministry: 60% × weight 31 → 18.60 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 90% × weight 18 → 16.20 pts",
+                "Base (sum of cluster contributions): 73.80 / 100",
+                "Session bonuses: newcomer growth +5",
+                "Session score: 78.8 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Delegated open/close, book-level Big Idea review, multi-reader scripture, deep teaching, and a strong wrap-up all present. Dip from a full 5 due to the ~11-min whiteboard/timeline detour and the explicitly skipped Day-4 exercise pulling time from the blueprint's later steps",
+                "Newcomer Welcome (N/A): No first-timers this week (week 9 of 10). Cluster max reduced 15→10, not penalized",
+                "Scripture Engagement (5/5): 20+ cross-references across 13 books — the widest book range of the arc to date (James, Hebrews, Acts, 2 Peter, Jude, 1 John, Matthew ×3, 1 Thessalonians, Job, Psalms, 2 Corinthians, Leviticus, Deuteronomy)",
+                "Facilitation vs. Lecture (3/5): ~40–45% discussion-only, above target; the ~6-min uninterrupted prophecy-chart narration is the main driver. Socratic technique excellent elsewhere (Psalm 73 walk-through, wealth discussion) but this dip is real, not just optics",
+                "Application Questions (5/5): 6 DOK-scored questions (within 5–7 target); 50/50 DOK 4/DOK 3 split; 5+ first-person confessions including the leader's own unresolved disclosure",
+                "Participant Engagement (4/5): 12+ substantive contributors of ~13 (~90%+) — high percentage of a much smaller room; fewer peer-to-peer chains than L8's arc-best session",
+                "Visual Aids (3/5): One prophecy-timeline chart ultimately delivered via screen-share, but a ~5-min failed live-whiteboard attempt preceded it; no on-screen Greek/Hebrew word-study tool this week (a step back from L8's word studies)",
+                "Vulnerability / Authenticity (4/5): Bryan's own live, unresolved financial-fear disclosure plus the sales-integrity testimony; high member-vulnerability floor. Consistent with the 4/5 Thursday baseline (±1 swing cap applied)",
+                "Memory Reinforcement (3/5): Brief, functional book-level review at open (~5 min), but the formal cold cumulative recall drill was skipped for a 2nd consecutive week despite being named as the arc's top priority gap",
+                "Homework References (3/5): Homework named explicitly ('the math they gave us in the homework', 'the one thing exercise... day four') but the specific Day-4 exercise was explicitly skipped rather than adapted for Zoom",
+                "Prayer (5/5): Opening (Hunter) AND closing (Cole) delegated and both captured in the recording",
+                "Leader Development (3/5): No in-session apprentice handoff or delegated facilitation window this week; arc-long pattern holds"
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
@@ -428,6 +526,7 @@
                 "paragraphs": [
                   "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
                   "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: John (first-timer), Eric, Mike welcomed with full member testimonies and Guarantee; Bryan personally engaged John ('why did you decide to show up?'); +3.0 newcomer bonus applied"
                 ]
               },
@@ -436,6 +535,7 @@
                 "paragraphs": [
                   "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
                   "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 19 cross-references across 12+ books — James primary + Titus 1, Rom 3/5/6, Heb 11, Eph 2, 2 Cor 5/13, 1 Cor 6, Matt 7, Gal 5, John 3/13; 80%+ of discussion scripture-grounded"
                 ]
               },
@@ -444,33 +544,73 @@
                 "paragraphs": [
                   "Prayer was delegated to members, opening and closing the group in shared voice.",
                   "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: Opening prayer delegated (member at 00:00); group commissioning prayer for Brendan and Glenn (3+ spontaneous member prayers at close); one of the strongest prayer moments of the James arc"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 10-step blueprint followed; opening prayer delegated, newcomer welcome complete with testimonies, Guarantee delivered, Big Ideas review, cross-ref arc, closing commissioning prayer; no formal Ebbinghaus drill"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture anchored the session (4/5)",
+                "paragraphs": [
+                  "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: ~35-40% discussion-only leader talk (excludes welcome, excludes reading); good Socratic method; some teaching monologues in cross-ref sections"
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Visual Aids is the clearest growth area (3/5)",
+                "title": "Visual Aids is a growth area (3/5)",
                 "paragraphs": [
                   "The session leaned audio-only; a visual anchor would aid retention.",
                   "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: Blue Letter Bible used on-screen for G1344 word study (resolves James/Paul discrepancy); no color-coded chart, no two-column reference board; improvement from 2/5"
                 ]
               },
               {
-                "title": "Vulnerability / Authenticity is the clearest growth area (3/5)",
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
                 "paragraphs": [
                   "Teaching stayed at arm’s length; little personal cost was modeled.",
                   "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: 3 vulnerability moments (personal guarantee story 3/5, Christmas tree theft 2/5, naming rights 3/5); one below baseline; +/-1 cap applied; no high-cost disclosure"
                 ]
               },
               {
-                "title": "Memory Reinforcement is the clearest growth area (3/5)",
+                "title": "Memory Reinforcement is a growth area (3/5)",
                 "paragraphs": [
                   "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
                   "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: Informal James tests recall at open (Bryan-led); new bumper sticks generated by members; no formal Ebbinghaus retrieval drill; 9th consecutive session without it"
+                ]
+              },
+              {
+                "title": "Application Questions is a growth area (4/5)",
+                "paragraphs": [
+                  "Questions stayed heady; few moved the group to first-person, personal application.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 6-7 DOK-scored Big Idea questions; strong evidence card bookend; functional atheist concept stayed intellectual; John's card not retrieved at close"
+                ]
+              },
+              {
+                "title": "Participant Engagement is a growth area (4/5)",
+                "paragraphs": [
+                  "A few voices carried the discussion; quieter members went unheard.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 15+ substantive contributors; ~75% of group; two member-generated bumper stickers; peer-to-peer exchanges; no quiet member flag"
                 ]
               }
             ],
@@ -479,25 +619,81 @@
                 "title": "Next session — Visual Aids",
                 "paragraphs": [
                   "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Vulnerability / Authenticity",
                 "paragraphs": [
                   "Next time, open one teaching point with a first-person example that cost you something.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Memory Reinforcement",
                 "paragraphs": [
                   "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Application Questions",
+                "paragraphs": [
+                  "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Participant Engagement",
+                "paragraphs": [
+                  "Next time, name one quiet regular early and invite their read on a passage.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 76% × weight 33 → 25.08 pts",
+                "Building Ministry: 86.7% × weight 31 → 26.87 pts",
+                "Engaging People: 80% × weight 18 → 14.40 pts",
+                "Being Real: 80% × weight 18 → 14.40 pts",
+                "Base (sum of cluster contributions): 80.75 / 100",
+                "Session bonuses: newcomer growth +3, group-size +2.5",
+                "Session score: 86.25 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): 10-step blueprint followed; opening prayer delegated, newcomer welcome complete with testimonies, Guarantee delivered, Big Ideas review, cross-ref arc, closing commissioning prayer; no formal Ebbinghaus drill",
+                "Newcomer Welcome (5/5): John (first-timer), Eric, Mike welcomed with full member testimonies and Guarantee; Bryan personally engaged John ('why did you decide to show up?'); +3.0 newcomer bonus applied",
+                "Scripture Engagement (5/5): 19 cross-references across 12+ books — James primary + Titus 1, Rom 3/5/6, Heb 11, Eph 2, 2 Cor 5/13, 1 Cor 6, Matt 7, Gal 5, John 3/13; 80%+ of discussion scripture-grounded",
+                "Facilitation vs. Lecture (4/5): ~35-40% discussion-only leader talk (excludes welcome, excludes reading); good Socratic method; some teaching monologues in cross-ref sections",
+                "Application Questions (4/5): 6-7 DOK-scored Big Idea questions; strong evidence card bookend; functional atheist concept stayed intellectual; John's card not retrieved at close",
+                "Participant Engagement (4/5): 15+ substantive contributors; ~75% of group; two member-generated bumper stickers; peer-to-peer exchanges; no quiet member flag",
+                "Visual Aids (3/5): Blue Letter Bible used on-screen for G1344 word study (resolves James/Paul discrepancy); no color-coded chart, no two-column reference board; improvement from 2/5",
+                "Vulnerability / Authenticity (3/5): 3 vulnerability moments (personal guarantee story 3/5, Christmas tree theft 2/5, naming rights 3/5); one below baseline; +/-1 cap applied; no high-cost disclosure",
+                "Memory Reinforcement (3/5): Informal James tests recall at open (Bryan-led); new bumper sticks generated by members; no formal Ebbinghaus retrieval drill; 9th consecutive session without it",
+                "Homework References (4/5): The Guarantee delivered twice — in welcome and mid-lesson as personal testimony; Precept homework implicit; 'five days a week' framing present; no explicit 'Power of Four' reference",
+                "Prayer (5/5): Opening prayer delegated (member at 00:00); group commissioning prayer for Brendan and Glenn (3+ spontaneous member prayers at close); one of the strongest prayer moments of the James arc",
+                "Leader Development (4/5): Brendan publicly commissioned for Camp Tejas — Bryan named it his 'first leader role,' called it 'a big deal'; group gathered and prayed; Glenn Gordon (men's pastor) also affirmed; fully observable in-session signal"
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
@@ -644,6 +840,7 @@
                 "paragraphs": [
                   "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
                   "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 15 confirmed cross-references across 8 books; Romans 2:11 ('God shows no partiality') as concise closing anchor; discussion 75-80% scripture-grounded"
                 ]
               },
@@ -652,6 +849,7 @@
                 "paragraphs": [
                   "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
                   "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: Full 10-step blueprint executed; closing prayer not delegated (Bryan ran it himself, session overran); ran ~10 min long"
                 ]
               },
@@ -660,33 +858,73 @@
                 "paragraphs": [
                   "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
                   "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: Jordan, Caleb, Matt welcomed; 12-min intro with 4-5 member testimonies + Bryan's full origin story; The Guarantee not formally delivered"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 9-10 Big Idea questions; 40% DOK 4; 'why is this in the Bible?' opener generated excellent theological framing"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 15+ named contributors; 7+ scripture readers; member felony story as session's highest-depth disclosure"
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Facilitation vs. Lecture is the clearest growth area (3/5)",
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
                 "paragraphs": [
                   "Leader talk crowded out discussion; the balance leaned toward lecture.",
                   "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: ~33-38% leader talk (discussion only); strong Socratic calling by name; 3-4 longer teaching sections pull ratio above target"
                 ]
               },
               {
-                "title": "Memory Reinforcement is the clearest growth area (3/5)",
+                "title": "Memory Reinforcement is a growth area (3/5)",
                 "paragraphs": [
                   "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
                   "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: Comprehensive James ch.1 Big Ideas review (~14 min, 6 ideas, member-participatory); bumper sticker generation at close; guided not unsupported Ebbinghaus recall"
                 ]
               },
               {
-                "title": "Homework References is the clearest growth area (3/5)",
+                "title": "Homework References is a growth area (3/5)",
                 "paragraphs": [
                   "Homework went unmentioned, reducing its pull on the group.",
                   "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: Directed Caleb and Jordan to contact Lance or John for homework materials; explained 5-day format at close [02:04]; The Guarantee not formally delivered"
+                ]
+              },
+              {
+                "title": "Prayer is a growth area (3/5)",
+                "paragraphs": [
+                  "Prayer was leader-only or rushed; the group’s voice was thin.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Opening prayer delegated to a member (at start of recording); closing prayer not delegated — Bryan led it himself due to time pressure at 9:11 AM; prayer chain not referenced"
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (3/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Background signals only (directing newcomers through Lance/John); no visible in-session apprenticeship; multiplication model referenced in newcomer welcome"
                 ]
               }
             ],
@@ -695,25 +933,81 @@
                 "title": "Next session — Facilitation vs. Lecture",
                 "paragraphs": [
                   "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Memory Reinforcement",
                 "paragraphs": [
                   "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Homework References",
                 "paragraphs": [
                   "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Prayer",
+                "paragraphs": [
+                  "Next time, ask one member to open and a different member to close in prayer.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 80% × weight 33 → 26.40 pts",
+                "Building Ministry: 66.7% × weight 31 → 20.67 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 70% × weight 18 → 12.60 pts",
+                "Base (sum of cluster contributions): 72.27 / 100",
+                "Session bonuses: newcomer growth +2",
+                "Session score: 74.27 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Full 10-step blueprint executed; closing prayer not delegated (Bryan ran it himself, session overran); ran ~10 min long",
+                "Newcomer Welcome (4/5): Jordan, Caleb, Matt welcomed; 12-min intro with 4-5 member testimonies + Bryan's full origin story; The Guarantee not formally delivered",
+                "Scripture Engagement (5/5): 15 confirmed cross-references across 8 books; Romans 2:11 ('God shows no partiality') as concise closing anchor; discussion 75-80% scripture-grounded",
+                "Facilitation vs. Lecture (3/5): ~33-38% leader talk (discussion only); strong Socratic calling by name; 3-4 longer teaching sections pull ratio above target",
+                "Application Questions (4/5): 9-10 Big Idea questions; 40% DOK 4; 'why is this in the Bible?' opener generated excellent theological framing",
+                "Participant Engagement (4/5): 15+ named contributors; 7+ scripture readers; member felony story as session's highest-depth disclosure",
+                "Visual Aids (4/5): VerseMate on screen for the Greek/Hebrew word definitions (royal law, partiality, 'face value'); growth edge is a board for the cumulative 'riches' list, which stayed in the room's memory",
+                "Vulnerability / Authenticity (4/5): 3 moments: political partiality confession [00:52]; James Jones / adoption closing story [02:03]; shorts ministry church judgment story [02:03]",
+                "Memory Reinforcement (3/5): Comprehensive James ch.1 Big Ideas review (~14 min, 6 ideas, member-participatory); bumper sticker generation at close; guided not unsupported Ebbinghaus recall",
+                "Homework References (3/5): Directed Caleb and Jordan to contact Lance or John for homework materials; explained 5-day format at close [02:04]; The Guarantee not formally delivered",
+                "Prayer (3/5): Opening prayer delegated to a member (at start of recording); closing prayer not delegated — Bryan led it himself due to time pressure at 9:11 AM; prayer chain not referenced",
+                "Leader Development (3/5): Background signals only (directing newcomers through Lance/John); no visible in-session apprenticeship; multiplication model referenced in newcomer welcome"
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
@@ -860,6 +1154,7 @@
                 "paragraphs": [
                   "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
                   "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 22+ cross-references — arc high; 80-85% discussion grounded in scripture; first scripture within 15 min"
                 ]
               },
@@ -868,6 +1163,7 @@
                 "paragraphs": [
                   "Costly personal honesty set a tone of safety, and members disclosed in turn.",
                   "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 4 disclosures: Muslim partiality [01:07:38]; political/car partiality [01:04:08]; pornography/social media trap [01:30:02]; shorts ministry backstory [~00:50]"
                 ]
               },
@@ -876,33 +1172,73 @@
                 "paragraphs": [
                   "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
                   "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: Full 10-step blueprint executed; Big Ideas review in Q&A/guided-themes format (not unsupported Ebbinghaus recall)"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 9 Big Idea questions; 44% DOK 4 (above 25% benchmark); royal law question at arc's highest single-question yield"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 14+ named contributors; 8+ scripture readers; 8-member application close"
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Visual Aids is the clearest growth area (2/5)",
+                "title": "Visual Aids is a growth area (2/5)",
                 "paragraphs": [
                   "The session leaned audio-only; a visual anchor would aid retention.",
                   "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: None used — no whiteboard, no BLB word studies, no diagrams in the arc's highest-density content session"
                 ]
               },
               {
-                "title": "Newcomer Welcome is the clearest growth area (3/5)",
+                "title": "Newcomer Welcome is a growth area (3/5)",
                 "paragraphs": [
                   "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
                   "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: Chris and John welcomed; homework instructions given at close; The Guarantee and formal member testimony protocol not executed"
                 ]
               },
               {
-                "title": "Facilitation vs. Lecture is the clearest growth area (3/5)",
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
                 "paragraphs": [
                   "Leader talk crowded out discussion; the balance leaned toward lecture.",
                   "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: ~32-35% leader talk (discussion only); three theological bridge monologues pulled ratio up in middle third"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Guided-themes Big Ideas review (not unsupported Ebbinghaus retrieval); no formal bumper-sticker generation at close"
+                ]
+              },
+              {
+                "title": "Prayer is a growth area (3.5/5)",
+                "paragraphs": [
+                  "Prayer was leader-only or rushed; the group’s voice was thin.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Closing prayer delegated to Marco [02:01-02:03] — on-topic (learning + application); opening prayer not captured in transcript; no prayer chain reference"
                 ]
               }
             ],
@@ -911,25 +1247,81 @@
                 "title": "Next session — Visual Aids",
                 "paragraphs": [
                   "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Newcomer Welcome",
                 "paragraphs": [
                   "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Facilitation vs. Lecture",
                 "paragraphs": [
                   "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Prayer",
+                "paragraphs": [
+                  "Next time, ask one member to open and a different member to close in prayer.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 72% × weight 33 → 23.76 pts",
+                "Building Ministry: 70% × weight 31 → 21.70 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 85% × weight 18 → 15.30 pts",
+                "Base (sum of cluster contributions): 73.36 / 100",
+                "Session bonuses: newcomer growth +2, group-size +1",
+                "Session score: 76.36 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Full 10-step blueprint executed; Big Ideas review in Q&A/guided-themes format (not unsupported Ebbinghaus recall)",
+                "Newcomer Welcome (3/5): Chris and John welcomed; homework instructions given at close; The Guarantee and formal member testimony protocol not executed",
+                "Scripture Engagement (5/5): 22+ cross-references — arc high; 80-85% discussion grounded in scripture; first scripture within 15 min",
+                "Facilitation vs. Lecture (3/5): ~32-35% leader talk (discussion only); three theological bridge monologues pulled ratio up in middle third",
+                "Application Questions (4/5): 9 Big Idea questions; 44% DOK 4 (above 25% benchmark); royal law question at arc's highest single-question yield",
+                "Participant Engagement (4/5): 14+ named contributors; 8+ scripture readers; 8-member application close",
+                "Visual Aids (2/5): None used — no whiteboard, no BLB word studies, no diagrams in the arc's highest-density content session",
+                "Vulnerability / Authenticity (5/5): 4 disclosures: Muslim partiality [01:07:38]; political/car partiality [01:04:08]; pornography/social media trap [01:30:02]; shorts ministry backstory [~00:50]",
+                "Memory Reinforcement (3/5): Guided-themes Big Ideas review (not unsupported Ebbinghaus retrieval); no formal bumper-sticker generation at close",
+                "Homework References (4/5): Explicit homework instructions to both newcomers at close [02:03:23]; referenced during session; The Guarantee not formally delivered",
+                "Prayer (3.5/5): Closing prayer delegated to Marco [02:01-02:03] — on-topic (learning + application); opening prayer not captured in transcript; no prayer chain reference",
+                "Leader Development (3.5/5): Lance bringing 2 newcomers signals multiplication; Bryan directing newcomers through Lance and John shows distributed pastoral network; no in-training leader like Russell in Thursday group"
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
@@ -1076,6 +1468,7 @@
                 "paragraphs": [
                   "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
                   "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 5 newcomers; 3 member testimonies (Keith, Brendan, Russ); Bryan testimony + The Guarantee delivered"
                 ]
               },
@@ -1084,6 +1477,7 @@
                 "paragraphs": [
                   "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
                   "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: Full 10-step blueprint executed; Big Ideas review Q&A style rather than formal retrieval"
                 ]
               },
@@ -1092,33 +1486,73 @@
                 "paragraphs": [
                   "Application questions pushed members from concept to life, several at the reason/apply level.",
                   "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 8-10 Big Idea questions; DOK 3-4 majority; Weston application at highest DOK 4 quality"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 15+ named contributors; 8+ scripture readers; 6-member Big Ideas close"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity anchored the session (4/5)",
+                "paragraphs": [
+                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 4 disclosures: VerseMate coaching [01:32:25]; Facebook [01:01:36]; adopted son [01:04:59]; wife's health [00:25:16]"
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Scripture Engagement is the clearest growth area (3/5)",
+                "title": "Scripture Engagement is a growth area (3/5)",
                 "paragraphs": [
                   "Discussion drifted from the text; a few more passages would ground the teaching.",
                   "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: 4 cross-references vs. 6+ benchmark; newcomer welcome consumed cross-referencing time"
                 ]
               },
               {
-                "title": "Facilitation vs. Lecture is the clearest growth area (3/5)",
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
                 "paragraphs": [
                   "Leader talk crowded out discussion; the balance leaned toward lecture.",
                   "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: ~38-42% leader talk (discussion only); consistent growth lever across all sessions"
                 ]
               },
               {
-                "title": "Visual Aids is the clearest growth area (3/5)",
+                "title": "Visual Aids is a growth area (3/5)",
                 "paragraphs": [
                   "The session leaned audio-only; a visual anchor would aid retention.",
                   "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: Sin progression diagram (collaborative); no BLB word studies; no maps"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Q&A review not formal Ebbinghaus unsupported retrieval; consistent growth lever"
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (4/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: The Guarantee delivered explicitly [00:09:07]; homework exhorted at close [02:06:00]"
                 ]
               }
             ],
@@ -1127,25 +1561,81 @@
                 "title": "Next session — Scripture Engagement",
                 "paragraphs": [
                   "Next time, pre-mark 3 cross-references to pull in during the densest teaching block.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Facilitation vs. Lecture",
                 "paragraphs": [
                   "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Visual Aids",
                 "paragraphs": [
                   "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 68% × weight 33 → 22.44 pts",
+                "Building Ministry: 86.7% × weight 31 → 26.87 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 80% × weight 18 → 14.40 pts",
+                "Base (sum of cluster contributions): 76.31 / 100",
+                "Session bonuses: newcomer growth +5, group-size +3",
+                "Session score: 84.31 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Full 10-step blueprint executed; Big Ideas review Q&A style rather than formal retrieval",
+                "Newcomer Welcome (5/5): 5 newcomers; 3 member testimonies (Keith, Brendan, Russ); Bryan testimony + The Guarantee delivered",
+                "Scripture Engagement (3/5): 4 cross-references vs. 6+ benchmark; newcomer welcome consumed cross-referencing time",
+                "Facilitation vs. Lecture (3/5): ~38-42% leader talk (discussion only); consistent growth lever across all sessions",
+                "Application Questions (4/5): 8-10 Big Idea questions; DOK 3-4 majority; Weston application at highest DOK 4 quality",
+                "Participant Engagement (4/5): 15+ named contributors; 8+ scripture readers; 6-member Big Ideas close",
+                "Visual Aids (3/5): Sin progression diagram (collaborative); no BLB word studies; no maps",
+                "Vulnerability / Authenticity (4/5): 4 disclosures: VerseMate coaching [01:32:25]; Facebook [01:01:36]; adopted son [01:04:59]; wife's health [00:25:16]",
+                "Memory Reinforcement (3/5): Q&A review not formal Ebbinghaus unsupported retrieval; consistent growth lever",
+                "Homework References (4/5): The Guarantee delivered explicitly [00:09:07]; homework exhorted at close [02:06:00]",
+                "Prayer (4/5): Opening delegated; closing delegated; prayer chain + session email list promoted at close",
+                "Leader Development (4/5): Russell in training; Colt brought newcomer after 2 weeks; Brennan baptism; multiple multiplication signals"
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
@@ -1292,6 +1782,7 @@
                 "paragraphs": [
                   "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
                   "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 9 cross-references; 2 BLB Greek word studies; exceeds 6+ benchmark"
                 ]
               },
@@ -1300,6 +1791,7 @@
                 "paragraphs": [
                   "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
                   "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: Strong blueprint adherence; Big Ideas review informal but present; both prayers captured"
                 ]
               },
@@ -1308,33 +1800,73 @@
                 "paragraphs": [
                   "Application questions pushed members from concept to life, several at the reason/apply level.",
                   "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 11 Big Idea questions; DOK 2–4; 36% DOK 4; distributed throughout + full go-around"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 15+ named contributors; 8 scripture readers; ~15 go-around participants"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity anchored the session (4/5)",
+                "paragraphs": [
+                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 4 Bryan disclosures; cascade of member vulnerability; Cole's conversion testimony; Marcus tongue confession"
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Facilitation vs. Lecture is the clearest growth area (3/5)",
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
                 "paragraphs": [
                   "Leader talk crowded out discussion; the balance leaned toward lecture.",
                   "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: ~41% leader talk; first-half teaching blocks pull above 30% benchmark; second half recovers"
                 ]
               },
               {
-                "title": "Visual Aids is the clearest growth area (3/5)",
+                "title": "Visual Aids is a growth area (3/5)",
                 "paragraphs": [
                   "The session leaned audio-only; a visual anchor would aid retention.",
                   "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: BLB for 2 word studies; no slides, whiteboard, or maps"
                 ]
               },
               {
-                "title": "Memory Reinforcement is the clearest growth area (3/5)",
+                "title": "Memory Reinforcement is a growth area (3/5)",
                 "paragraphs": [
                   "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
                   "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: Informal review at start (not formal recall drill); 6 bumper stickers surfaced; no formal closing drill"
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (3/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: No explicit Guarantee; one casual next-week reference; one member disclosed weak homework week"
+                ]
+              },
+              {
+                "title": "Prayer is a growth area (4/5)",
+                "paragraphs": [
+                  "Prayer was leader-only or rushed; the group’s voice was thin.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Opening prayer delegated (captured at recording start); closing prayer delegated to member (on-topic, referenced James themes); prayer chain (Craig Rooker follow-up)"
                 ]
               }
             ],
@@ -1343,25 +1875,81 @@
                 "title": "Next session — Facilitation vs. Lecture",
                 "paragraphs": [
                   "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Visual Aids",
                 "paragraphs": [
                   "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Memory Reinforcement",
                 "paragraphs": [
                   "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Prayer",
+                "paragraphs": [
+                  "Next time, ask one member to open and a different member to close in prayer.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 76% × weight 33 → 25.08 pts",
+                "Building Ministry: 70% × weight 31 → 21.70 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 80% × weight 18 → 14.40 pts",
+                "Base (sum of cluster contributions): 73.78 / 100",
+                "Session bonuses: group-size +1.5",
+                "Session score: 75.28 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Strong blueprint adherence; Big Ideas review informal but present; both prayers captured",
+                "Newcomer Welcome (N/A): No newcomers — Building Ministry max reduced proportionally",
+                "Scripture Engagement (5/5): 9 cross-references; 2 BLB Greek word studies; exceeds 6+ benchmark",
+                "Facilitation vs. Lecture (3/5): ~41% leader talk; first-half teaching blocks pull above 30% benchmark; second half recovers",
+                "Application Questions (4/5): 11 Big Idea questions; DOK 2–4; 36% DOK 4; distributed throughout + full go-around",
+                "Participant Engagement (4/5): 15+ named contributors; 8 scripture readers; ~15 go-around participants",
+                "Visual Aids (3/5): BLB for 2 word studies; no slides, whiteboard, or maps",
+                "Vulnerability / Authenticity (4/5): 4 Bryan disclosures; cascade of member vulnerability; Cole's conversion testimony; Marcus tongue confession",
+                "Memory Reinforcement (3/5): Informal review at start (not formal recall drill); 6 bumper stickers surfaced; no formal closing drill",
+                "Homework References (3/5): No explicit Guarantee; one casual next-week reference; one member disclosed weak homework week",
+                "Prayer (4/5): Opening prayer delegated (captured at recording start); closing prayer delegated to member (on-topic, referenced James themes); prayer chain (Craig Rooker follow-up)",
+                "Leader Development (4/5): Hunter's baptism June 6; Brendan praised publicly; Pocan's son running couples class — three multiplication signals in one session"
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
@@ -1508,6 +2096,7 @@
                 "paragraphs": [
                   "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
                   "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 4 newcomers, all engaged. Strong existing-member testimonies (Brendan, Andy Truebert, Austin). The Guarantee delivered. Personal challenge to Mauricio. Missed: Eddie’s hurt not acknowledged before theological pivot."
                 ]
               },
@@ -1516,6 +2105,7 @@
                 "paragraphs": [
                   "Application questions pushed members from concept to life, several at the reason/apply level.",
                   "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 9 Big Idea questions, all DOK 2–4. DOK distribution: 33% Level 4, 45% Level 3, 22% Level 2. Questions distributed throughout; strong synthesis round at close. No DOK 1 questions scored. Matches Bryan’s best recent sessions on question quality."
                 ]
               },
@@ -1524,33 +2114,73 @@
                 "paragraphs": [
                   "A high share of the room contributed substantively, called on by name.",
                   "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 20+ named voices; 10+ with substantive contributions; >40% of named participants contributed. Quiet members called on directly. All 4 newcomers gave substantive introductions. Estimated participation rate ~75–80%."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity anchored the session (4/5)",
+                "paragraphs": [
+                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Stillborn first child disclosure is the highest-cost vulnerability in Bryan’s recent arc. Trials breakdown disclosure and heart attack reference add supporting depth. Weighted by depth: stillborn carries the score. Missed: Eddie’s vulnerability could have been reciprocated earlier."
+                ]
+              },
+              {
+                "title": "Homework References anchored the session (4/5)",
+                "paragraphs": [
+                  "Homework was referenced and rewarded, differentiating the members who prepared.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: The Guarantee delivered with full conviction and personal story. Multiple references to the 5-day homework rhythm. BLB instruction is direct homework skill-transfer. Closing prompt: “you’ve got five days to study a few verses.” Slightly below May 22 (5/5) due to less explicit homework tracking this session."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Session Structure & Flow is the clearest growth area (3/5)",
+                "title": "Session Structure & Flow is a growth area (3/5)",
                 "paragraphs": [
                   "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
                   "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: Blueprint followed (newcomer welcome → overview → scripture → application → Big Ideas → closing prayer). Opening prayer not captured. No formal cumulative Big Ideas review from L1. Ran over by ~8 min."
                 ]
               },
               {
-                "title": "Scripture Engagement is the clearest growth area (3/5)",
+                "title": "Scripture Engagement is a growth area (3/5)",
                 "paragraphs": [
                   "Discussion drifted from the text; a few more passages would ground the teaching.",
                   "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: 1 cross-reference passage (Rom 5:3–5) plus 7 Greek word studies via BLB. Cross-ref count (2 passages) is well below the 6+ benchmark. Bryan acknowledged skipping prepared cross-refs. Word study depth is excellent but doesn’t substitute for parallel-text density."
                 ]
               },
               {
-                "title": "Facilitation vs. Lecture is the clearest growth area (3/5)",
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
                 "paragraphs": [
                   "Leader talk crowded out discussion; the balance leaned toward lecture.",
                   "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: Leader talk ratio ~45% with reading, ~38% discussion-only. Above the Lifeway 30% target. BLB teaching block (~5 min) and Guarantee pitch (~4 min) are the primary drivers. Strong back-and-forth throughout; 20+ distinct voices compensate partially."
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (3/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: BLB on screen with Strong’s Concordance — excellent and extensively used. No color-coded charts, maps, or structural diagrams this session. BLB was the single visual aid tool."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: No L1 Big Ideas review from memory at session start. Strong canonical close (5 Big Ideas surfaced with full group input). Bumper stickers: “joy is a verdict,” “holiness not happiness,” “tested faith produces maturity,” “partial obedience is disobedience” (referenced). 4 bumper stickers, slightly below the 5–7 target."
                 ]
               }
             ],
@@ -1559,25 +2189,81 @@
                 "title": "Next session — Session Structure & Flow",
                 "paragraphs": [
                   "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Scripture Engagement",
                 "paragraphs": [
                   "Next time, pre-mark 3 cross-references to pull in during the densest teaching block.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Facilitation vs. Lecture",
                 "paragraphs": [
                   "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 64% × weight 33 → 21.12 pts",
+                "Building Ministry: 73.3% × weight 31 → 22.73 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 70% × weight 18 → 12.60 pts",
+                "Base (sum of cluster contributions): 69.05 / 100",
+                "Session bonuses: newcomer growth +5, group-size +3",
+                "Session score: 77.05 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3/5): Blueprint followed (newcomer welcome → overview → scripture → application → Big Ideas → closing prayer). Opening prayer not captured. No formal cumulative Big Ideas review from L1. Ran over by ~8 min.",
+                "Newcomer Welcome (4/5): 4 newcomers, all engaged. Strong existing-member testimonies (Brendan, Andy Truebert, Austin). The Guarantee delivered. Personal challenge to Mauricio. Missed: Eddie’s hurt not acknowledged before theological pivot.",
+                "Scripture Engagement (3/5): 1 cross-reference passage (Rom 5:3–5) plus 7 Greek word studies via BLB. Cross-ref count (2 passages) is well below the 6+ benchmark. Bryan acknowledged skipping prepared cross-refs. Word study depth is excellent but doesn’t substitute for parallel-text density.",
+                "Facilitation vs. Lecture (3/5): Leader talk ratio ~45% with reading, ~38% discussion-only. Above the Lifeway 30% target. BLB teaching block (~5 min) and Guarantee pitch (~4 min) are the primary drivers. Strong back-and-forth throughout; 20+ distinct voices compensate partially.",
+                "Application Questions (4/5): 9 Big Idea questions, all DOK 2–4. DOK distribution: 33% Level 4, 45% Level 3, 22% Level 2. Questions distributed throughout; strong synthesis round at close. No DOK 1 questions scored. Matches Bryan’s best recent sessions on question quality.",
+                "Participant Engagement (4/5): 20+ named voices; 10+ with substantive contributions; >40% of named participants contributed. Quiet members called on directly. All 4 newcomers gave substantive introductions. Estimated participation rate ~75–80%.",
+                "Visual Aids (3/5): BLB on screen with Strong’s Concordance — excellent and extensively used. No color-coded charts, maps, or structural diagrams this session. BLB was the single visual aid tool.",
+                "Vulnerability / Authenticity (4/5): Stillborn first child disclosure is the highest-cost vulnerability in Bryan’s recent arc. Trials breakdown disclosure and heart attack reference add supporting depth. Weighted by depth: stillborn carries the score. Missed: Eddie’s vulnerability could have been reciprocated earlier.",
+                "Memory Reinforcement (3/5): No L1 Big Ideas review from memory at session start. Strong canonical close (5 Big Ideas surfaced with full group input). Bumper stickers: “joy is a verdict,” “holiness not happiness,” “tested faith produces maturity,” “partial obedience is disobedience” (referenced). 4 bumper stickers, slightly below the 5–7 target.",
+                "Homework References (4/5): The Guarantee delivered with full conviction and personal story. Multiple references to the 5-day homework rhythm. BLB instruction is direct homework skill-transfer. Closing prompt: “you’ve got five days to study a few verses.” Slightly below May 22 (5/5) due to less explicit homework tracking this session.",
+                "Prayer (3/5): Closing prayer: delegated to Russell, on-topic, scripture-connected, well-executed (“help us to be perfected by the trials that we go through and help us to have your viewpoint”). Opening prayer: not captured in recording. Prayer chain referenced multiple times in context. Score reflects only the closing prayer being visible.",
+                "Leader Development (3/5): Group is past split threshold. Bryan stated “we don’t have a leader” directly. 22 groups total, Austin Stone partnership, Brendan’s baptism — multiplication is visible in the program. But no in-session apprenticeship moment; no member given a facilitation window; no named apprentice. 2 Tim 2:2 mechanism not active in this session."
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
@@ -1724,6 +2410,7 @@
                 "paragraphs": [
                   "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
                   "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: Two newcomers (Anthony, Graham). Members gave testimonies before newcomers spoke. Bryan shared personal story. Both newcomers introduced with follow-up commitments (Luke’s number; Tristan for Anthony). Homework push at close."
                 ]
               },
@@ -1732,6 +2419,7 @@
                 "paragraphs": [
                   "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
                   "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 9 cross-references cited and read (benchmark: 6+). Blue Letter Bible with Strong’s Concordance on shared screen. Greek word studies for “consider” and “joy.” All 12 James verses read and interrogated."
                 ]
               },
@@ -1740,33 +2428,73 @@
                 "paragraphs": [
                   "Homework was referenced and rewarded, differentiating the members who prepared.",
                   "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: “The Guarantee” invoked multiple times. Bryan’s 25-year personal testimony to homework at close. “Best 25 bucks you’ll ever spend” to Anthony. 5-day homework framing delivered. Next session assignment implied (last verses of chapter 1)."
+                ]
+              },
+              {
+                "title": "Prayer anchored the session (5/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Opening prayer (Nandan) — substantive, scripture-connected, delegated appropriately. Closing prayer (Hunter) — on-topic, applied lesson themes, beautiful. Prayer chain infrastructure referenced. First session with both prayers fully captured and scored at maximum."
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Blueprint executed: newcomer welcome, historical context, scripture, deep Socratic study, closing application, delegated prayer. No audible Big Ideas review from L1. 8 min over 2h target."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Facilitation vs. Lecture is the clearest growth area (3/5)",
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
                 "paragraphs": [
                   "Leader talk crowded out discussion; the balance leaned toward lecture.",
                   "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: Discussion-only ratio ~33% leader talk; above 30% Lifeway benchmark. Three monologues exceeded 90 sec. Consistent with all prior sessions in this arc."
                 ]
               },
               {
-                "title": "Visual Aids is the clearest growth area (3/5)",
+                "title": "Visual Aids is a growth area (3/5)",
                 "paragraphs": [
                   "The session leaned audio-only; a visual anchor would aid retention.",
                   "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: BLB shared on screen with Strong’s Concordance; Greek word studies presented. No color-coded charts or structural diagrams. Ernest photo used for humor/engagement. Better than L1 (2/5 overview session), below full-study benchmark."
                 ]
               },
               {
-                "title": "Memory Reinforcement is the clearest growth area (3/5)",
+                "title": "Memory Reinforcement is a growth area (3/5)",
                 "paragraphs": [
                   "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
                   "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: No audible Big Ideas review from L1 at session start. Closing application round (“tell your wife”) functioned as strong memory anchoring. Four memorable bumper stickers surfaced. Consistent with L1 score."
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (3/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Hunter’s role as prayer chain manager and scribe is visible. Baptism announced. No formal teaching or facilitation role during the session. 2 Tim 2:2 multiplication principle not yet visible in session mechanics. Same as L1."
+                ]
+              },
+              {
+                "title": "Application Questions is a growth area (4/5)",
+                "paragraphs": [
+                  "Questions stayed heady; few moved the group to first-person, personal application.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 8 Big Idea questions; 25% DOK 4, 50% DOK 3, 25% DOK 2. Strong closing application round (“tell your wife”) functioned as full-room application synthesis."
                 ]
               }
             ],
@@ -1775,25 +2503,81 @@
                 "title": "Next session — Facilitation vs. Lecture",
                 "paragraphs": [
                   "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Visual Aids",
                 "paragraphs": [
                   "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Memory Reinforcement",
                 "paragraphs": [
                   "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Application Questions",
+                "paragraphs": [
+                  "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 76% × weight 33 → 25.08 pts",
+                "Building Ministry: 86.7% × weight 31 → 26.87 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 90% × weight 18 → 16.20 pts",
+                "Base (sum of cluster contributions): 80.75 / 100",
+                "Session bonuses: group-size +1",
+                "Session score: 81.75 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Blueprint executed: newcomer welcome, historical context, scripture, deep Socratic study, closing application, delegated prayer. No audible Big Ideas review from L1. 8 min over 2h target.",
+                "Newcomer Welcome (5/5): Two newcomers (Anthony, Graham). Members gave testimonies before newcomers spoke. Bryan shared personal story. Both newcomers introduced with follow-up commitments (Luke’s number; Tristan for Anthony). Homework push at close.",
+                "Scripture Engagement (5/5): 9 cross-references cited and read (benchmark: 6+). Blue Letter Bible with Strong’s Concordance on shared screen. Greek word studies for “consider” and “joy.” All 12 James verses read and interrogated.",
+                "Facilitation vs. Lecture (3/5): Discussion-only ratio ~33% leader talk; above 30% Lifeway benchmark. Three monologues exceeded 90 sec. Consistent with all prior sessions in this arc.",
+                "Application Questions (4/5): 8 Big Idea questions; 25% DOK 4, 50% DOK 3, 25% DOK 2. Strong closing application round (“tell your wife”) functioned as full-room application synthesis.",
+                "Participant Engagement (4/5): 17+ named voices; 8 scripture readers; 6 questioners; ~85–90% participation rate. Quiet members called by name. Both newcomers contributed substantively.",
+                "Visual Aids (3/5): BLB shared on screen with Strong’s Concordance; Greek word studies presented. No color-coded charts or structural diagrams. Ernest photo used for humor/engagement. Better than L1 (2/5 overview session), below full-study benchmark.",
+                "Vulnerability / Authenticity (4/5): Four Bryan disclosures weighted by depth: faith journey at 39, fax machine prayer, two largest trials (20–30 yrs later insight), homework humility. Clint’s suicidal disclosure handled pastorally without moralizing or rescue. Group vulnerability culture intact.",
+                "Memory Reinforcement (3/5): No audible Big Ideas review from L1 at session start. Closing application round (“tell your wife”) functioned as strong memory anchoring. Four memorable bumper stickers surfaced. Consistent with L1 score.",
+                "Homework References (5/5): “The Guarantee” invoked multiple times. Bryan’s 25-year personal testimony to homework at close. “Best 25 bucks you’ll ever spend” to Anthony. 5-day homework framing delivered. Next session assignment implied (last verses of chapter 1).",
+                "Prayer (5/5): Opening prayer (Nandan) — substantive, scripture-connected, delegated appropriately. Closing prayer (Hunter) — on-topic, applied lesson themes, beautiful. Prayer chain infrastructure referenced. First session with both prayers fully captured and scored at maximum.",
+                "Leader Development (3/5): Hunter’s role as prayer chain manager and scribe is visible. Baptism announced. No formal teaching or facilitation role during the session. 2 Tim 2:2 multiplication principle not yet visible in session mechanics. Same as L1."
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
@@ -1940,6 +2724,7 @@
                 "paragraphs": [
                   "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
                   "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 8–9 newcomers; 2 member testimonials before introductions; Bryan personally organized follow-up calls (Steven, Bryce, Mike, Thomas each assigned a newcomer). Best of the series."
                 ]
               },
@@ -1948,6 +2733,7 @@
                 "paragraphs": [
                   "Homework was referenced and rewarded, differentiating the members who prepared.",
                   "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: “The Guarantee” delivered in full; 5-day hard-work framing; workbooks distributed at close; next-week assignment (James 1:1–11, memorize vv. 2–11) given explicitly. Highest Dim 10 score of the series."
                 ]
               },
@@ -1956,33 +2742,73 @@
                 "paragraphs": [
                   "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
                   "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: Blueprint well-executed: newcomer welcome, context overview, full-book reading, closing prayer. No Big Ideas review (appropriate for L1). Ran 14 min over target duration."
+                ]
+              },
+              {
+                "title": "Scripture Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: All 5 chapters of James read in order, paragraph by paragraph. Cross-references: ~4 (below the 6+ benchmark). Overview format partly explains; parallel texts in L2–10 will address."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 9 Big Idea questions; 22% DOK 4, 44% DOK 3. Even distribution across chapters 1–3; compressed in 4–5 due to pacing. DOK ceiling lower than deep-study sessions (67% DOK 3-4 vs. L6’s 89%)."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Visual Aids is the clearest growth area (2/5)",
+                "title": "Visual Aids is a growth area (2/5)",
                 "paragraphs": [
                   "The session leaned audio-only; a visual anchor would aid retention.",
                   "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: Scripture screen only; no BLB, no structural chart, no color-coded visual. Chiasm described verbally without a diagram. Lowest single score; directly addressable in L2."
                 ]
               },
               {
-                "title": "Facilitation vs. Lecture is the clearest growth area (3/5)",
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
                 "paragraphs": [
                   "Leader talk crowded out discussion; the balance leaned toward lecture.",
                   "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: Discussion-only ratio ~38% leader talk; above 30% benchmark. Three extended monologues; context-setting demands partly justify the gap. Same dimension score as L6 and L7."
                 ]
               },
               {
-                "title": "Vulnerability / Authenticity is the clearest growth area (3/5)",
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
                 "paragraphs": [
                   "Teaching stayed at arm’s length; little personal cost was modeled.",
                   "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: 3 moderate-depth moments. Brother-in-law disclosure is Bryan’s highest-cost personal share this session; depth slightly below L7’s peak. Weight: 1 family share + 1 relational directness + 1 personal-story entry."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Lesson 1: no prior Big Ideas to review. Bryan actively taught the importance of scripture memorization; Brendan’s prayer testimony demonstrated the practice. Foundation set for L2 review pattern."
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (3/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Follow-up calls assigned through existing members (Steven, Bryce, Mike, Thomas). Prayer chain accountability invoked. No visible apprentice in formal co-teaching or leadership-in-action role. Opportunity missed with 25+ men and 8-9 newcomers."
                 ]
               }
             ],
@@ -1991,25 +2817,81 @@
                 "title": "Next session — Visual Aids",
                 "paragraphs": [
                   "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Facilitation vs. Lecture",
                 "paragraphs": [
                   "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Vulnerability / Authenticity",
                 "paragraphs": [
                   "Next time, open one teaching point with a first-person example that cost you something.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 68% × weight 33 → 22.44 pts",
+                "Building Ministry: 86.7% × weight 31 → 26.87 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 70% × weight 18 → 12.60 pts",
+                "Base (sum of cluster contributions): 74.51 / 100",
+                "Session bonuses: newcomer growth +5, group-size +3",
+                "Session score: 82.51 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Blueprint well-executed: newcomer welcome, context overview, full-book reading, closing prayer. No Big Ideas review (appropriate for L1). Ran 14 min over target duration.",
+                "Newcomer Welcome (5/5): 8–9 newcomers; 2 member testimonials before introductions; Bryan personally organized follow-up calls (Steven, Bryce, Mike, Thomas each assigned a newcomer). Best of the series.",
+                "Scripture Engagement (4/5): All 5 chapters of James read in order, paragraph by paragraph. Cross-references: ~4 (below the 6+ benchmark). Overview format partly explains; parallel texts in L2–10 will address.",
+                "Facilitation vs. Lecture (3/5): Discussion-only ratio ~38% leader talk; above 30% benchmark. Three extended monologues; context-setting demands partly justify the gap. Same dimension score as L6 and L7.",
+                "Application Questions (4/5): 9 Big Idea questions; 22% DOK 4, 44% DOK 3. Even distribution across chapters 1–3; compressed in 4–5 due to pacing. DOK ceiling lower than deep-study sessions (67% DOK 3-4 vs. L6’s 89%).",
+                "Participant Engagement (4/5): 15+ named voices; 11+ scripture readers; ~58–65% participation rate. Engagement thinned in chapters 4–5 as pacing picked up. Maintained above L6 baseline overall.",
+                "Visual Aids (2/5): Scripture screen only; no BLB, no structural chart, no color-coded visual. Chiasm described verbally without a diagram. Lowest single score; directly addressable in L2.",
+                "Vulnerability / Authenticity (3/5): 3 moderate-depth moments. Brother-in-law disclosure is Bryan’s highest-cost personal share this session; depth slightly below L7’s peak. Weight: 1 family share + 1 relational directness + 1 personal-story entry.",
+                "Memory Reinforcement (3/5): Lesson 1: no prior Big Ideas to review. Bryan actively taught the importance of scripture memorization; Brendan’s prayer testimony demonstrated the practice. Foundation set for L2 review pattern.",
+                "Homework References (5/5): “The Guarantee” delivered in full; 5-day hard-work framing; workbooks distributed at close; next-week assignment (James 1:1–11, memorize vv. 2–11) given explicitly. Highest Dim 10 score of the series.",
+                "Prayer (4/5): Multi-voice closing prayer (5–6 men, 8 min) for Fred’s EO speech. Opening prayer not captured (pre-recording). Prayer chain infrastructure emphasized with accountability language. Strong community prayer culture demonstrated.",
+                "Leader Development (3/5): Follow-up calls assigned through existing members (Steven, Bryce, Mike, Thomas). Prayer chain accountability invoked. No visible apprentice in formal co-teaching or leadership-in-action role. Opportunity missed with 25+ men and 8-9 newcomers."
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
@@ -2156,6 +3038,7 @@
                 "paragraphs": [
                   "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
                   "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 7 passages across 4 books; 82% verse-grounded; every teaching move anchored to text"
                 ]
               },
@@ -2164,6 +3047,7 @@
                 "paragraphs": [
                   "On-screen word study and visuals reinforced the teaching multi-modally.",
                   "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: Three aids deployed synchronously — best of the arc (chart + live text + Big Ideas slide)"
                 ]
               },
@@ -2172,33 +3056,73 @@
                 "paragraphs": [
                   "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
                   "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: Strong open (newcomer + chart + Big Ideas); closing truncated by run-over past 9:00 target"
+                ]
+              },
+              {
+                "title": "Newcomer Welcome anchored the session (4/5)",
+                "paragraphs": [
+                  "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Walker introduced; Keith's Guarantee pitch. 7 min vs. 7–25 range — intro-only, no integration post-[06:00]"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 9 Big Ideas at 89% DOK 3-4; count regressed from L5 (11); spacing clustered first/last thirds"
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Facilitation vs. Lecture is the clearest growth area (3/5)",
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
                 "paragraphs": [
                   "Leader talk crowded out discussion; the balance leaned toward lecture.",
                   "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: 62% leader talk (discussion only); regressed from L5 (58%); middle hour heavily leader-led"
                 ]
               },
               {
-                "title": "Participant Engagement is the clearest growth area (3/5)",
+                "title": "Participant Engagement is a growth area (3/5)",
                 "paragraphs": [
                   "A few voices carried the discussion; quieter members went unheard.",
                   "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: 53% contribution rate; same core 5–6; Walker not pulled into substantive Q&A"
                 ]
               },
               {
-                "title": "Vulnerability / Authenticity is the clearest growth area (3/5)",
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
                 "paragraphs": [
                   "Teaching stayed at arm’s length; little personal cost was modeled.",
                   "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: 3 moderate moments; depth regressed from L5 (no marital-accountability-level disclosure)"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Big Ideas review cursory (~2 min vs. L5's 8 min); ‘Stone-cold’ and ‘Bad company’ referenced but not group-recited"
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (4/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Explicit Precept reference at [39:48]; Power of Four implicit; prayer chain call commitment at [120:27]"
                 ]
               }
             ],
@@ -2207,25 +3131,81 @@
                 "title": "Next session — Facilitation vs. Lecture",
                 "paragraphs": [
                   "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Participant Engagement",
                 "paragraphs": [
                   "Next time, name one quiet regular early and invite their read on a passage.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Vulnerability / Authenticity",
                 "paragraphs": [
                   "Next time, open one teaching point with a first-person example that cost you something.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 84% × weight 33 → 27.72 pts",
+                "Building Ministry: 80% × weight 31 → 24.80 pts",
+                "Engaging People: 60% × weight 18 → 10.80 pts",
+                "Being Real: 70% × weight 18 → 12.60 pts",
+                "Base (sum of cluster contributions): 75.92 / 100",
+                "Session bonuses: group-size +1",
+                "Session score: 76.92 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Strong open (newcomer + chart + Big Ideas); closing truncated by run-over past 9:00 target",
+                "Newcomer Welcome (4/5): Walker introduced; Keith's Guarantee pitch. 7 min vs. 7–25 range — intro-only, no integration post-[06:00]",
+                "Scripture Engagement (5/5): 7 passages across 4 books; 82% verse-grounded; every teaching move anchored to text",
+                "Facilitation vs. Lecture (3/5): 62% leader talk (discussion only); regressed from L5 (58%); middle hour heavily leader-led",
+                "Application Questions (4/5): 9 Big Ideas at 89% DOK 3-4; count regressed from L5 (11); spacing clustered first/last thirds",
+                "Participant Engagement (3/5): 53% contribution rate; same core 5–6; Walker not pulled into substantive Q&A",
+                "Visual Aids (5/5): Three aids deployed synchronously — best of the arc (chart + live text + Big Ideas slide)",
+                "Vulnerability / Authenticity (3/5): 3 moderate moments; depth regressed from L5 (no marital-accountability-level disclosure)",
+                "Memory Reinforcement (3/5): Big Ideas review cursory (~2 min vs. L5's 8 min); ‘Stone-cold’ and ‘Bad company’ referenced but not group-recited",
+                "Homework References (4/5): Explicit Precept reference at [39:48]; Power of Four implicit; prayer chain call commitment at [120:27]",
+                "Prayer (4/5): Closing prayer delegated at [127:10] but rushed; opening prayer presumed pre-record",
+                "Leader Development (4/5): Russell operated chart at [07:00–09:30]; apprenticeship visible but not actively coached in real time"
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
@@ -2372,6 +3352,7 @@
                 "paragraphs": [
                   "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
                   "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: Excellent 10-step adherence"
                 ]
               },
@@ -2380,6 +3361,7 @@
                 "paragraphs": [
                   "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
                   "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 7 passages across 6 books, OT-NT bridge"
                 ]
               },
@@ -2388,33 +3370,73 @@
                 "paragraphs": [
                   "Application questions pushed members from concept to life, several at the reason/apply level.",
                   "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
                   "From the session: 11 Big Ideas, 45% DOK 4"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement anchored the session (5/5)",
+                "paragraphs": [
+                  "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Strong cumulative Big Ideas review"
+                ]
+              },
+              {
+                "title": "Prayer anchored the session (5/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Delegated opening, closing present"
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Facilitation vs. Lecture is the clearest growth area (4/5)",
+                "title": "Facilitation vs. Lecture is a growth area (4/5)",
                 "paragraphs": [
                   "Leader talk crowded out discussion; the balance leaned toward lecture.",
                   "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: 58% discussion-only; improved but above target"
                 ]
               },
               {
-                "title": "Participant Engagement is the clearest growth area (4/5)",
+                "title": "Participant Engagement is a growth area (4/5)",
                 "paragraphs": [
                   "A few voices carried the discussion; quieter members went unheard.",
                   "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: 50% asking questions; improved but below 70-80%"
                 ]
               },
               {
-                "title": "Visual Aids is the clearest growth area (4/5)",
+                "title": "Visual Aids is a growth area (4/5)",
                 "paragraphs": [
                   "The session leaned audio-only; a visual anchor would aid retention.",
                   "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
                   "From the session: Kings chart used effectively"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (4/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 4 moments weighted by depth"
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (4/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Referenced throughout session"
                 ]
               }
             ],
@@ -2423,25 +3445,81 @@
                 "title": "Next session — Facilitation vs. Lecture",
                 "paragraphs": [
                   "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Participant Engagement",
                 "paragraphs": [
                   "Next time, name one quiet regular early and invite their read on a passage.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Visual Aids",
                 "paragraphs": [
                   "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 96% × weight 33 → 31.68 pts",
+                "Building Ministry: 80% × weight 31 → 24.80 pts",
+                "Engaging People: 80% × weight 18 → 14.40 pts",
+                "Being Real: 90% × weight 18 → 16.20 pts",
+                "Base (sum of cluster contributions): 87.08 / 100",
+                "Session bonuses: group-size +0.5",
+                "Session score: 87.58 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (5/5): Excellent 10-step adherence",
+                "Newcomer Welcome (N/A): No newcomers present",
+                "Scripture Engagement (5/5): 7 passages across 6 books, OT-NT bridge",
+                "Facilitation vs. Lecture (4/5): 58% discussion-only; improved but above target",
+                "Application Questions (5/5): 11 Big Ideas, 45% DOK 4",
+                "Participant Engagement (4/5): 50% asking questions; improved but below 70-80%",
+                "Visual Aids (4/5): Kings chart used effectively",
+                "Vulnerability / Authenticity (4/5): 4 moments weighted by depth",
+                "Memory Reinforcement (5/5): Strong cumulative Big Ideas review",
+                "Homework References (4/5): Referenced throughout session",
+                "Prayer (5/5): Delegated opening, closing present",
+                "Leader Development (4/5): Russell mentioned, group leadership evident"
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         }
@@ -2601,44 +3679,82 @@
                 "title": "Session Structure & Flow anchored the session (4/5)",
                 "paragraphs": [
                   "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding."
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               },
               {
                 "title": "Scripture Engagement anchored the session (4/5)",
                 "paragraphs": [
                   "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session."
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               },
               {
                 "title": "Participant Engagement anchored the session (4/5)",
                 "paragraphs": [
                   "A high share of the room contributed substantively, called on by name.",
-                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room."
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Homework References anchored the session (4/5)",
+                "paragraphs": [
+                  "Homework was referenced and rewarded, differentiating the members who prepared.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Prayer anchored the session (4/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Facilitation vs. Lecture is the clearest growth area (3/5)",
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
                 "paragraphs": [
                   "Leader talk crowded out discussion; the balance leaned toward lecture.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking."
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
-                "title": "Application Questions is the clearest growth area (3/5)",
+                "title": "Application Questions is a growth area (3/5)",
                 "paragraphs": [
                   "Questions stayed heady; few moved the group to first-person, personal application.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application."
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
-                "title": "Visual Aids is the clearest growth area (3/5)",
+                "title": "Visual Aids is a growth area (3/5)",
                 "paragraphs": [
                   "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention."
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ],
@@ -2647,25 +3763,60 @@
                 "title": "Next session — Facilitation vs. Lecture",
                 "paragraphs": [
                   "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Application Questions",
                 "paragraphs": [
                   "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Visual Aids",
                 "paragraphs": [
                   "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 68% × weight 33 → 22.44 pts",
+                "Building Ministry: 70% × weight 31 → 21.70 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 70% × weight 18 → 12.60 pts",
+                "Base (sum of cluster contributions): 69.34 / 100",
+                "Session score: 69.34 / 100"
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
@@ -2814,44 +3965,82 @@
                 "title": "Scripture Engagement anchored the session (4/5)",
                 "paragraphs": [
                   "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session."
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               },
               {
                 "title": "Homework References anchored the session (4/5)",
                 "paragraphs": [
                   "Homework was referenced and rewarded, differentiating the members who prepared.",
-                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement."
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               },
               {
                 "title": "Session Structure & Flow anchored the session (3/5)",
                 "paragraphs": [
                   "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding."
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Newcomer Welcome anchored the session (3/5)",
+                "paragraphs": [
+                  "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture anchored the session (3/5)",
+                "paragraphs": [
+                  "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Visual Aids is the clearest growth area (2/5)",
+                "title": "Visual Aids is a growth area (2/5)",
                 "paragraphs": [
                   "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention."
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
-                "title": "Session Structure & Flow is the clearest growth area (3/5)",
+                "title": "Application Questions is a growth area (3/5)",
                 "paragraphs": [
-                  "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding."
+                  "Questions stayed heady; few moved the group to first-person, personal application.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
-                "title": "Newcomer Welcome is the clearest growth area (3/5)",
+                "title": "Participant Engagement is a growth area (3/5)",
                 "paragraphs": [
-                  "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
-                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF)."
+                  "A few voices carried the discussion; quieter members went unheard.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ],
@@ -2860,25 +4049,61 @@
                 "title": "Next session — Visual Aids",
                 "paragraphs": [
                   "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
-                "title": "Next session — Session Structure & Flow",
+                "title": "Next session — Application Questions",
                 "paragraphs": [
-                  "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
-                "title": "Next session — Newcomer Welcome",
+                "title": "Next session — Participant Engagement",
                 "paragraphs": [
-                  "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "Next time, name one quiet regular early and invite their read on a passage.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 60% × weight 33 → 19.80 pts",
+                "Building Ministry: 66.7% × weight 31 → 20.67 pts",
+                "Engaging People: 60% × weight 18 → 10.80 pts",
+                "Being Real: 60% × weight 18 → 10.80 pts",
+                "Base (sum of cluster contributions): 62.07 / 100",
+                "Session bonuses: newcomer growth +1",
+                "Session score: 63.07 / 100"
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
@@ -3027,44 +4252,82 @@
                 "title": "Homework References anchored the session (4/5)",
                 "paragraphs": [
                   "Homework was referenced and rewarded, differentiating the members who prepared.",
-                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement."
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               },
               {
                 "title": "Session Structure & Flow anchored the session (3/5)",
                 "paragraphs": [
                   "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding."
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               },
               {
                 "title": "Scripture Engagement anchored the session (3/5)",
                 "paragraphs": [
                   "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session."
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (3/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity anchored the session (3/5)",
+                "paragraphs": [
+                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Facilitation vs. Lecture is the clearest growth area (2/5)",
+                "title": "Facilitation vs. Lecture is a growth area (2/5)",
                 "paragraphs": [
                   "Leader talk crowded out discussion; the balance leaned toward lecture.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking."
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
-                "title": "Application Questions is the clearest growth area (2/5)",
+                "title": "Application Questions is a growth area (2/5)",
                 "paragraphs": [
                   "Questions stayed heady; few moved the group to first-person, personal application.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application."
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
-                "title": "Visual Aids is the clearest growth area (2/5)",
+                "title": "Visual Aids is a growth area (2/5)",
                 "paragraphs": [
                   "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention."
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (2/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (2/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ],
@@ -3073,25 +4336,60 @@
                 "title": "Next session — Facilitation vs. Lecture",
                 "paragraphs": [
                   "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Application Questions",
                 "paragraphs": [
                   "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Visual Aids",
                 "paragraphs": [
                   "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 48% × weight 33 → 15.84 pts",
+                "Building Ministry: 60% × weight 31 → 18.60 pts",
+                "Engaging People: 50% × weight 18 → 9.00 pts",
+                "Being Real: 60% × weight 18 → 10.80 pts",
+                "Base (sum of cluster contributions): 54.24 / 100",
+                "Session score: 54.24 / 100"
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         }
@@ -3252,44 +4550,82 @@
                 "title": "Facilitation vs. Lecture anchored the session (5/5)",
                 "paragraphs": [
                   "Discussion outweighed lecture — the room did the thinking, not just the leader.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking."
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               },
               {
                 "title": "Application Questions anchored the session (5/5)",
                 "paragraphs": [
                   "Application questions pushed members from concept to life, several at the reason/apply level.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application."
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               },
               {
                 "title": "Session Structure & Flow anchored the session (4/5)",
                 "paragraphs": [
                   "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding."
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Scripture Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Newcomer Welcome is the clearest growth area (3/5)",
+                "title": "Newcomer Welcome is a growth area (3/5)",
                 "paragraphs": [
                   "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
-                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF)."
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
-                "title": "Visual Aids is the clearest growth area (3/5)",
+                "title": "Visual Aids is a growth area (3/5)",
                 "paragraphs": [
                   "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention."
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
-                "title": "Memory Reinforcement is the clearest growth area (3/5)",
+                "title": "Memory Reinforcement is a growth area (3/5)",
                 "paragraphs": [
                   "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session."
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (3/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (4/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ],
@@ -3298,25 +4634,61 @@
                 "title": "Next session — Newcomer Welcome",
                 "paragraphs": [
                   "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Visual Aids",
                 "paragraphs": [
                   "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Memory Reinforcement",
                 "paragraphs": [
                   "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 76% × weight 33 → 25.08 pts",
+                "Building Ministry: 66.7% × weight 31 → 20.67 pts",
+                "Engaging People: 90% × weight 18 → 16.20 pts",
+                "Being Real: 80% × weight 18 → 14.40 pts",
+                "Base (sum of cluster contributions): 76.35 / 100",
+                "Session bonuses: newcomer growth +1",
+                "Session score: 77.35 / 100"
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         }
@@ -3477,44 +4849,82 @@
                 "title": "Vulnerability / Authenticity anchored the session (5/5)",
                 "paragraphs": [
                   "Costly personal honesty set a tone of safety, and members disclosed in turn.",
-                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn."
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               },
               {
                 "title": "Session Structure & Flow anchored the session (4/5)",
                 "paragraphs": [
                   "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding."
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               },
               {
                 "title": "Scripture Engagement anchored the session (4/5)",
                 "paragraphs": [
                   "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session."
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture anchored the session (4/5)",
+                "paragraphs": [
+                  "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Visual Aids is the clearest growth area (3/5)",
+                "title": "Visual Aids is a growth area (3/5)",
                 "paragraphs": [
                   "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention."
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
-                "title": "Memory Reinforcement is the clearest growth area (3/5)",
+                "title": "Memory Reinforcement is a growth area (3/5)",
                 "paragraphs": [
                   "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session."
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
-                "title": "Homework References is the clearest growth area (3/5)",
+                "title": "Homework References is a growth area (3/5)",
                 "paragraphs": [
                   "Homework went unmentioned, reducing its pull on the group.",
-                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement."
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (3/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Participant Engagement is a growth area (4/5)",
+                "paragraphs": [
+                  "A few voices carried the discussion; quieter members went unheard.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ],
@@ -3523,25 +4933,60 @@
                 "title": "Next session — Visual Aids",
                 "paragraphs": [
                   "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Memory Reinforcement",
                 "paragraphs": [
                   "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Homework References",
                 "paragraphs": [
                   "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Participant Engagement",
+                "paragraphs": [
+                  "Next time, name one quiet regular early and invite their read on a passage.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 72% × weight 33 → 23.76 pts",
+                "Building Ministry: 60% × weight 31 → 18.60 pts",
+                "Engaging People: 80% × weight 18 → 14.40 pts",
+                "Being Real: 90% × weight 18 → 16.20 pts",
+                "Base (sum of cluster contributions): 72.96 / 100",
+                "Session score: 72.96 / 100"
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         }
@@ -3702,44 +5147,82 @@
                 "title": "Scripture Engagement anchored the session (5/5)",
                 "paragraphs": [
                   "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session."
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               },
               {
                 "title": "Session Structure & Flow anchored the session (4/5)",
                 "paragraphs": [
                   "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding."
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               },
               {
                 "title": "Facilitation vs. Lecture anchored the session (4/5)",
                 "paragraphs": [
                   "Discussion outweighed lecture — the room did the thinking, not just the leader.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking."
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Newcomer Welcome is the clearest growth area (3/5)",
+                "title": "Newcomer Welcome is a growth area (3/5)",
                 "paragraphs": [
                   "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
-                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF)."
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
-                "title": "Vulnerability / Authenticity is the clearest growth area (3/5)",
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
                 "paragraphs": [
                   "Teaching stayed at arm’s length; little personal cost was modeled.",
-                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn."
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
-                "title": "Memory Reinforcement is the clearest growth area (3/5)",
+                "title": "Memory Reinforcement is a growth area (3/5)",
                 "paragraphs": [
                   "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session."
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (3/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Prayer is a growth area (3/5)",
+                "paragraphs": [
+                  "Prayer was leader-only or rushed; the group’s voice was thin.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ],
@@ -3748,25 +5231,61 @@
                 "title": "Next session — Newcomer Welcome",
                 "paragraphs": [
                   "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Vulnerability / Authenticity",
                 "paragraphs": [
                   "Next time, open one teaching point with a first-person example that cost you something.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Memory Reinforcement",
                 "paragraphs": [
                   "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Prayer",
+                "paragraphs": [
+                  "Next time, ask one member to open and a different member to close in prayer.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 80% × weight 33 → 26.40 pts",
+                "Building Ministry: 60% × weight 31 → 18.60 pts",
+                "Engaging People: 80% × weight 18 → 14.40 pts",
+                "Being Real: 60% × weight 18 → 10.80 pts",
+                "Base (sum of cluster contributions): 70.20 / 100",
+                "Session bonuses: newcomer growth +1",
+                "Session score: 71.2 / 100"
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         }
@@ -3927,44 +5446,82 @@
                 "title": "Scripture Engagement anchored the session (5/5)",
                 "paragraphs": [
                   "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session."
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               },
               {
                 "title": "Session Structure & Flow anchored the session (4/5)",
                 "paragraphs": [
                   "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding."
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               },
               {
                 "title": "Facilitation vs. Lecture anchored the session (4/5)",
                 "paragraphs": [
                   "Discussion outweighed lecture — the room did the thinking, not just the leader.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking."
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Visual Aids is the clearest growth area (3/5)",
+                "title": "Visual Aids is a growth area (3/5)",
                 "paragraphs": [
                   "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention."
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
-                "title": "Memory Reinforcement is the clearest growth area (3/5)",
+                "title": "Memory Reinforcement is a growth area (3/5)",
                 "paragraphs": [
                   "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session."
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
-                "title": "Homework References is the clearest growth area (3/5)",
+                "title": "Homework References is a growth area (3/5)",
                 "paragraphs": [
                   "Homework went unmentioned, reducing its pull on the group.",
-                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement."
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (3/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (4/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ],
@@ -3973,25 +5530,60 @@
                 "title": "Next session — Visual Aids",
                 "paragraphs": [
                   "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Memory Reinforcement",
                 "paragraphs": [
                   "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
                 "title": "Next session — Homework References",
                 "paragraphs": [
                   "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one."
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               }
             ]
           },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 76% × weight 33 → 25.08 pts",
+                "Building Ministry: 60% × weight 31 → 18.60 pts",
+                "Engaging People: 80% × weight 18 → 14.40 pts",
+                "Being Real: 80% × weight 18 → 14.40 pts",
+                "Base (sum of cluster contributions): 72.48 / 100",
+                "Session score: 72.48 / 100"
+              ]
+            }
+          ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         }

--- a/packages/backend-base/src/coach/coach.schema.ts
+++ b/packages/backend-base/src/coach/coach.schema.ts
@@ -29,6 +29,24 @@ export const FeedbackPointSchema = t.Object({
   paragraphs: t.Array(t.String()),
 });
 
+// A timestamped moment inside a report section (e.g. a Key Moment or a Session
+// Flow Timeline entry). `timestamp` is a display string ("[50:03]"), optional.
+export const MomentSchema = t.Object({
+  timestamp: t.Optional(t.String()),
+  detail: t.String(),
+});
+
+// A generic, ordered report section (Key Moments, Session Flow Timeline,
+// Vulnerability Moments, Question Classification, Score Composition, …). Any
+// mix of paragraphs, bullets, and timestamped moments. Declared so Elysia
+// passes `report.sections` through instead of stripping it.
+export const SectionSchema = t.Object({
+  title: t.String(),
+  paragraphs: t.Optional(t.Array(t.String())),
+  bullets: t.Optional(t.Array(t.String())),
+  moments: t.Optional(t.Array(MomentSchema)),
+});
+
 export const ReportSchema = t.Object({
   id: t.String(),
   date: t.String(),
@@ -58,6 +76,9 @@ export const ReportSchema = t.Object({
     improvementsProse: t.Optional(t.Array(FeedbackPointSchema)),
     recommendationsProse: t.Optional(t.Array(FeedbackPointSchema)),
   }),
+  // Ordered PDF-parity sections rendered after Recommendations. Optional so
+  // reports generated before this feature still validate.
+  sections: t.Optional(t.Array(SectionSchema)),
   docUrl: t.String(),
   pdfUrl: t.String(),
 });

--- a/packages/backend-base/src/coach/coach.service.test.ts
+++ b/packages/backend-base/src/coach/coach.service.test.ts
@@ -150,6 +150,61 @@ describe("ReportSchema prose fields", () => {
   });
 });
 
+describe("ReportSchema sections field", () => {
+  // Same Elysia-stripping guard as the prose fields: report.sections must be
+  // declared in ReportSchema or the response clean step deletes it. Covers a
+  // section carrying paragraphs, bullets, and timestamped moments.
+  it("keeps report.sections (paragraphs, bullets, moments) through the schema", () => {
+    const withSections = report({
+      sections: [
+        {
+          title: "Key moments",
+          moments: [
+            {
+              timestamp: "[50:03]",
+              detail: "Leader shared a coping mechanism.",
+            },
+            { detail: "A moment with no timestamp still survives." },
+          ],
+        },
+        {
+          title: "Monologue inventory",
+          bullets: ["3 stretches over 90s (max 2:40) — all teaching."],
+          paragraphs: ["Optional narrative context for the section."],
+        },
+      ],
+    });
+
+    expect(Value.Check(ReportSchema, withSections)).toBe(true);
+    const cleaned = Value.Clean(
+      ReportSchema,
+      structuredClone(withSections),
+    ) as CoachReport;
+
+    expect(cleaned.sections?.length).toBe(2);
+    expect(cleaned.sections?.[0]).toEqual({
+      title: "Key moments",
+      moments: [
+        { timestamp: "[50:03]", detail: "Leader shared a coping mechanism." },
+        { detail: "A moment with no timestamp still survives." },
+      ],
+    });
+    expect(cleaned.sections?.[1]?.bullets).toEqual([
+      "3 stretches over 90s (max 2:40) — all teaching.",
+    ]);
+  });
+
+  it("a report without sections still validates (optional)", () => {
+    const noSections = report({});
+    expect(Value.Check(ReportSchema, noSections)).toBe(true);
+    const cleaned = Value.Clean(
+      ReportSchema,
+      structuredClone(noSections),
+    ) as CoachReport;
+    expect(cleaned.sections).toBeUndefined();
+  });
+});
+
 describe("CoachService admin oversight", () => {
   it("lists every coach with a newest-first latest summary", () => {
     const coaches = svc.listCoaches();

--- a/packages/backend-base/src/coach/coach.service.ts
+++ b/packages/backend-base/src/coach/coach.service.ts
@@ -41,6 +41,9 @@ export interface CoachReport {
   dimensions: CoachDimension[];
   bigIdeas: string[];
   feedback: CoachFeedback;
+  /** Ordered PDF-parity sections rendered after Recommendations. Optional so
+   *  reports generated before prose/sections export still type-check. */
+  sections?: CoachSection[];
   docUrl: string;
   pdfUrl: string;
 }
@@ -50,6 +53,22 @@ export interface CoachReport {
 export interface CoachFeedbackPoint {
   title: string;
   paragraphs: string[];
+}
+
+/** A timestamped moment inside a report section (Key Moment, timeline entry). */
+export interface CoachMoment {
+  timestamp?: string;
+  detail: string;
+}
+
+/** A generic, ordered report section — Key Moments, Session Flow Timeline,
+ *  Score Composition, per-dimension notes, etc. Any mix of paragraphs,
+ *  bullets, and timestamped moments. */
+export interface CoachSection {
+  title: string;
+  paragraphs?: string[];
+  bullets?: string[];
+  moments?: CoachMoment[];
 }
 
 /** Coaching feedback rendered directly on the portal (no Google Docs hop). */


### PR DESCRIPTION
## Summary

The Bible-Coach pipeline now emits an ordered `report.sections` array (Key Moments, Session Flow Timeline, Score Composition, per-dimension notes, etc.) alongside the prose. Same rule as the prose fields: **Elysia strips any response property not in the schema**, so `sections` must be declared in `ReportSchema` or it's dropped before reaching the portal.

## Changes

- **`coach.schema.ts`** — add `MomentSchema` (`{ timestamp?, detail }`) and `SectionSchema` (`{ title, paragraphs?, bullets?, moments? }`), and wire optional `sections` into `ReportSchema`. `ReportSchema` is shared by `/coach/reports` and `/coach/admin/coaches/:id/reports`, so the one edit covers both.
- **`coach.service.ts`** — add `CoachMoment` / `CoachSection` interfaces and optional `sections` on `CoachReport`. Optional so reports generated before this feature still type-check.
- **`coach.data.json`** — refreshed from the pipeline; reports now carry `Score composition` + `Coaching notes by dimension` sections (and the deepened 5-per-section prose).
- **`coach.service.test.ts`** — regression test that a report carrying `sections` with paragraphs, bullets, and timestamped moments survives `Value.Clean(ReportSchema, …)` (the exact step Elysia uses to strip undeclared fields), plus that a section-free report still validates.

## The contract

```ts
interface CoachMoment  { timestamp?: string; detail: string; }
interface CoachSection { title: string; paragraphs?: string[]; bullets?: string[]; moments?: CoachMoment[]; }
// report.sections?: CoachSection[]  — ordered, rendered after Recommendations
```

All optional/additive — a report without `sections` validates and renders as before.

## Verify

- `bun tsc` — clean.
- `bun test src/coach/coach.service.test.ts` — 11 pass, including the new sections stripping-regression test.
- `/coach/reports` returns `reports[].sections` for a coach whose data has them (proves the schema isn't stripping it).

## Landing order

Additive and order-independent with the pipeline PR (andytryba/bible-study-coaching #36): until both land the portal simply shows no extra sections, so nothing breaks in prod. This PR is what lets `report.sections` actually reach the portal once `coach.data.json` carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EStqy8KBpFJHPfvnW37xYn

---
_Generated by [Claude Code](https://claude.ai/code/session_01EStqy8KBpFJHPfvnW37xYn)_