### PR TITLE
Refresh coach.data.json with full-depth report content

### DIFF
--- a/packages/backend-base/src/coach/coach.data.json
+++ b/packages/backend-base/src/coach/coach.data.json
@@ -180,197 +180,264 @@
             "Let your yes be yes — a sales superpower before it was scripture"
           ],
           "feedback": {
-            "headline": "A strong session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Facilitation vs. Lecture.",
+            "headline": "A content-dense session and a genuine leader confession, slowed by a detour and a smaller room.",
             "strengths": [
-              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-              "Application questions pushed members from concept to life, several at the reason/apply level.",
-              "Prayer was delegated to members, opening and closing the group in shared voice."
+              "The 'Lord of Sabaoth' Chain: Turning a Military Title Into a Doctrine of Certainty",
+              "Job's Full Arc Read Aloud, Not Summarized",
+              "A Vocational Testimony Landed the Integrity Passage Without Preaching It"
             ],
             "improvements": [
-              "Leader talk crowded out discussion; the balance leaned toward lecture.",
-              "The session leaned audio-only; a visual anchor would aid retention.",
-              "Prior Big Ideas weren’t reviewed, so last week’s themes faded."
+              "The Prophecy-Timeline Explanation Ran ~6 Minutes Without a Question",
+              "A Sharp Attendance Drop Went Unacknowledged In-Session",
+              "Reading Assignments Were Reassigned Mid-Passage Several Times"
             ],
             "recommendations": [
-              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-              "Next time, put one word-study lookup or a simple table on screen during the key term.",
-              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas."
+              "Pre-Build Any Visual as a Static Slide Before the Session",
+              "Adapt a Written Homework Exercise for Zoom Rather Than Skipping It",
+              "Open the Arc's Final Lesson (L10) With the Cold Cumulative Recall Drill"
             ],
             "overview": [
-              "A strong session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Facilitation vs. Lecture. It scored 78.8/100 under the v3 weighted model.",
-              "The session played to its strengths in Scripture Engagement and Application Questions; the recommendations below turn Facilitation vs. Lecture into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+              "A content-dense session and a genuine leader confession, slowed by a detour and a smaller room.",
+              "This report carries the full written coaching for the session: 5 areas of strength, 5 areas for improvement, and 5 recommendations for next session, scored 78.8/100 on the v3 weighted model."
             ],
             "strengthsProse": [
               {
-                "title": "Scripture Engagement anchored the session (5/5)",
+                "title": "The 'Lord of Sabaoth' Chain: Turning a Military Title Into a Doctrine of Certainty",
                 "paragraphs": [
-                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 20+ cross-references across 13 books — the widest book range of the arc to date (James, Hebrews, Acts, 2 Peter, Jude, 1 John, Matthew ×3, 1 Thessalonians, Job, Psalms, 2 Corinthians, Leviticus, Deuteronomy)"
+                  "Working through James 5:1–6, Bryan noticed the unusual title \"Lord of Sabaoth\" and unpacked it as a military term — \"it's almost like it's like the Lord of hosts, like the Lord of a big-time army... it's reached, it's reached, it's escalated all the way to his desk. He knows\" [00:26:03]. Rather than a throwaway word study, this became the hinge for the whole \"last days\" cross-reference chain that followed — Hebrews 1:2, Acts 2:17–18, 2 Peter 3:3–4, Jude 1:18, and 1 John 2:18 were each pulled in to answer a single question: \"based on these cross-references... what time frame is he referring to in this passage?\" [00:23:50]. The room landed the answer together — \"we're literally in the last blink of time\" — with six different New Testament authors converging on the same point. This is three-source parallel reading executed across a wider span of the canon than any prior session in the arc (13 books total this week), and it turned an obscure phrase into the load-bearing doctrine of the lesson."
                 ]
               },
               {
-                "title": "Application Questions anchored the session (5/5)",
+                "title": "Job's Full Arc Read Aloud, Not Summarized",
                 "paragraphs": [
-                  "Application questions pushed members from concept to life, several at the reason/apply level.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 6 DOK-scored questions (within 5–7 target); 50/50 DOK 4/DOK 3 split; 5+ first-person confessions including the leader's own unresolved disclosure"
+                  "Rather than tell the room \"Job endured and was blessed,\" Bryan had the group read Job 1 in full (the catastrophe cascade — four messengers, each ending \"I alone have escaped to tell you\" [01:03:59–01:07:00]), Job's response (\"naked I came from my mother's womb, and naked shall I return... blessed be the name of the Lord\" [01:07:17]), the second round with Job's wife (\"do you still hold fast your integrity? Curse God and die\" [01:24:57]), and the restoration in chapter 42 (\"the Lord restored the fortunes of Job... twofold\" [01:12:57]). Reading the actual narrative — not a summary — let the room feel the scale of the loss before hearing the payoff, and Bryan's aside (\"that's why I left the wife behind, I got that order there\" [01:24:53]) kept the density from feeling like a lecture. When Bryan then asked \"how would you define patience... how is it defined by his life?\" [01:14:57], the room had the full textual evidence to answer with, not just the one-line summary most groups settle for."
                 ]
               },
               {
-                "title": "Prayer anchored the session (5/5)",
+                "title": "A Vocational Testimony Landed the Integrity Passage Without Preaching It",
                 "paragraphs": [
-                  "Prayer was delegated to members, opening and closing the group in shared voice.",
-                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
-                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Opening (Hunter) AND closing (Cole) delegated and both captured in the recording"
+                  "On James 5:12 and the \"let your yes be yes\" teaching, Bryan told a specific, concrete story from his own sales career rather than a generic exhortation: \"one thing I figured out early in my sales career... I was very careful what I said, and then I did everything I said. That became like a superpower in sales for me... whenever I would say anything in my favor, I had so much power, because they knew I was saying it and they knew it had to be true\" [01:38:56–01:39:00]. This is the kind of illustration that translates an ancient command (do not swear oaths; let your word alone be binding) into a category modern men already understand — professional credibility — without diluting the text's point. It also modeled the technique itself: state something true and specific, then let the specificity do the persuading."
                 ]
               },
               {
-                "title": "Session Structure & Flow anchored the session (4/5)",
+                "title": "The Psalm 73 Walk-Through: From 'Life Isn't Fair' to 'I Went Into the Sanctuary'",
                 "paragraphs": [
-                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Delegated open/close, book-level Big Idea review, multi-reader scripture, deep teaching, and a strong wrap-up all present. Dip from a full 5 due to the ~11-min whiteboard/timeline detour and the explicitly skipped Day-4 exercise pulling time from the blueprint's later steps"
+                  "Reading Psalm 73 in three chunks, Bryan let the psalmist's own emotional arc do the teaching. After verses 1–9 (\"my feet came close to stumbling... I was envious of the arrogant\"), he asked simply \"what's his gripe?\" [01:19:01] and got a full paraphrase back (\"what is the point of being the righteous man... when the rich and wealthy are living high on the hog\"). After verses 15–20 (the turning point — \"until I went into the sanctuary of God... I perceived their end\"), Bryan asked \"so what straightened him out?\" [01:20:53] and the room named the mechanism precisely: \"going to the sanctuary of God... I perceived their end\" — a real member quoted the exact hinge of the psalm back, unprompted with jargon. This is a clean model of letting a psalm's structure (complaint → sanctuary → resolution) teach the room how lament actually resolves, rather than skipping to the moral."
                 ]
               },
               {
-                "title": "Participant Engagement anchored the session (4/5)",
+                "title": "Real, Unresolved Peer Coaching on Financial Fear",
                 "paragraphs": [
-                  "A high share of the room contributed substantively, called on by name.",
-                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
-                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 12+ substantive contributors of ~13 (~90%+) — high percentage of a much smaller room; fewer peer-to-peer chains than L8's arc-best session"
+                  "When Bryan set up the closing hypothetical (\"let's say I've got this problem [being scared about money]... how are you gonna coach me out of this?\" [02:01:26]), the room didn't respond with platitudes — it stacked three distinct, concrete coping practices: Marcus's \"the birds always eat, the Lord's always gonna take care of you... do you believe what he says?\" [02:02:19]; a member's specific gun-store testimony (\"I was working at a gun store making 24 bucks an hour... gave money to a friend to help with his car... two days later my friend hits me up for this job, I triple my income\" [02:04:34]); and another member's prayer-journal practice (\"write out some prayers... six months later you look back at it... it's a very tangible thing\" [02:05:38]). Three different men offered three different, reproducible practices in response to a real leader vulnerability — that is peer discipleship functioning exactly as the model intends."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "title": "The Prophecy-Timeline Explanation Ran ~6 Minutes Without a Question",
                 "paragraphs": [
-                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: ~40–45% discussion-only, above target; the ~6-min uninterrupted prophecy-chart narration is the main driver. Socratic technique excellent elsewhere (Psalm 73 walk-through, wealth discussion) but this dip is real, not just optics"
+                  "Once the chart was finally shared at [01:44:32], Bryan narrated the whole tribulation → millennium → new-heaven-and-earth sequence essentially solo through [01:50:49] — \"this is when Armageddon happens... this is when Jesus comes back with the sword... at the end of the tribulation he establishes his reign on Earth for a thousand years... Satan is let out... this is when planet Earth is destroyed\" [01:47:00–01:48:19]. The content is valuable and the visual is a real upgrade over a verbal-only description, but for roughly six minutes the room listened rather than reasoned. The fix costs nothing in prep: pause every 60–90 seconds and ask \"what does this next segment tell you?\" before advancing the chart — same visual, same content, but the room stays in the answering seat instead of the listening seat."
                 ]
               },
               {
-                "title": "Visual Aids is a growth area (3/5)",
+                "title": "A Sharp Attendance Drop Went Unacknowledged In-Session",
                 "paragraphs": [
-                  "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: One prophecy-timeline chart ultimately delivered via screen-share, but a ~5-min failed live-whiteboard attempt preceded it; no on-screen Greek/Hebrew word-study tool this week (a step back from L8's word studies)"
+                  "Attendance fell from ~18 last week to ~13 this week — Mark Perry, Darrell, Nandan, Vince, Scott, Frank, Nan, Mike, Chris Gallagher, and Chris Jones were all absent, with no \"we missed so-and-so\" moment or stated plan to follow up in the recording. This matters beyond headcount: Mike (the seeker Bryan was actively drawing toward baptism last week — \"you need to call me sometime\") and Chris Jones (who confessed a specific work conviction last week and was pointed to James 4:7–10) are exactly the two men whose threads most needed a check-in this week, and neither was mentioned. The fix is a five-minute task outside the session: a personal text to each absent member this week, and a one-line public update next Thursday (\"talked to Mike this week, here's where he's at\")."
                 ]
               },
               {
-                "title": "Memory Reinforcement is a growth area (3/5)",
+                "title": "Reading Assignments Were Reassigned Mid-Passage Several Times",
                 "paragraphs": [
-                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Brief, functional book-level review at open (~5 min), but the formal cold cumulative recall drill was skipped for a 2nd consecutive week despite being named as the arc's top priority gap"
+                  "Bryan corrected himself on who was reading more than once this session — \"Cole, are you where you can read?... Sean read, I know. Marco, I don't think you read. Read us James 5, 7 through 11\" [00:36:31–00:36:35]; and again on the reference itself, \"Ricky, Matthew 21, 33 through 41... 23 33 to 40... Matthew 21... I said 23. I think you're 23. I said Matthew 21 verse 33... I'm going 23. I apologize\" [00:59:38–00:59:19]. Each correction cost 15–30 seconds of cross-talk in an already reading-heavy session (20+ reading turns). A one-line prep list — who reads which verse, in order, written down before the session starts — would remove this friction entirely on a night this dense with cross-references."
                 ]
               },
               {
-                "title": "Homework References is a growth area (3/5)",
+                "title": "The Day-4 Homework Exercise Was Named, Then Replaced Rather Than Adapted",
                 "paragraphs": [
-                  "Homework went unmentioned, reducing its pull on the group.",
-                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Homework named explicitly ('the math they gave us in the homework', 'the one thing exercise... day four') but the specific Day-4 exercise was explicitly skipped rather than adapted for Zoom"
+                  "Bryan told the room directly, \"so now I skipped the one thing exercise they gave us in day four... it's so darn hard to do this on Zoom\" [01:39:18], and substituted an unplanned attempt to hand-draw a prophecy timeline instead. The instinct to visualize the timeline was good, but \"hard to do on Zoom\" was true of the ORIGINAL exercise only if it required an in-person format — a \"day four\" written exercise can usually be Zoom-adapted rather than dropped: e.g., \"type your one thing in the chat right now\" and read two or three aloud. With one lesson plus a wrap-up week left in the arc, a skipped exercise from the workbook doesn't get a second pass."
                 ]
               },
               {
-                "title": "Leader Development is a growth area (3/5)",
+                "title": "A Written-Ahead Wrap-Up Question Delivered Live Lost Some Precision",
                 "paragraphs": [
-                  "No in-session development of another leader was observable this week.",
-                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: No in-session apprentice handoff or delegated facilitation window this week; arc-long pattern holds"
+                  "Bryan told the room mid-question, \"these questions are great when I write them down, and then when I try to say it, they don't come out right\" [01:56:59], while asking the session's best DOK-4 question (which behavior category — unrepentant rich or patiently enduring believer — reflects you, and what's the evidence). The self-awareness is valuable, and the question still landed well, but L8's parallel wrap-up question (\"what plans are you currently making that have quietly left God's will out of the picture?\") was delivered with more precision because it was rehearsed closer to verbatim. The fix: when a wrap-up question is written in the lesson notes, read it once silently before saying it aloud, or read it directly from the notes rather than paraphrasing live."
                 ]
               }
             ],
             "recommendationsProse": [
               {
-                "title": "Next session — Facilitation vs. Lecture",
+                "title": "Pre-Build Any Visual as a Static Slide Before the Session",
                 "paragraphs": [
-                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "This week's live, multi-cursor Zoom whiteboard attempt cost ~5 minutes before being abandoned for a screen-shared image that itself needed live rotating and cropping. Before: attempting to hand-draw a chart live on a shared Zoom whiteboard with multiple uncontrolled cursors. After: spend five minutes before the session building the same chart or timeline as a single image or slide, then go straight to screen-share. Same teaching payoff, none of the live-draw chaos, and the reclaimed time can fund the still-missing recall drill."
                 ]
               },
               {
-                "title": "Next session — Visual Aids",
+                "title": "Adapt a Written Homework Exercise for Zoom Rather Than Skipping It",
                 "paragraphs": [
-                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "This week Bryan named the Day-4 'one thing' exercise and explicitly skipped it as 'too hard to do on Zoom.' Before: naming an exercise, then substituting an unplanned activity instead. After: adapt the delivery — 'type your one thing in the chat right now,' then read two or three aloud. The content survives the medium change; nothing from the workbook gets dropped."
                 ]
               },
               {
-                "title": "Next session — Memory Reinforcement",
+                "title": "Open the Arc's Final Lesson (L10) With the Cold Cumulative Recall Drill",
                 "paragraphs": [
-                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "This is the second straight session where the formally-recommended 'without looking, recall every Big Idea' drill did not happen — and only L10 remains before the lighter wrap-up week. Before: a brief, Bryan-guided review that leans on prompting. After: open cold — 'without looking at your notes, give me every Big Idea from James, go' — and write each one on the shared screen live as it surfaces. This is the last full-content session where it can land."
                 ]
               },
               {
-                "title": "Next session — Homework References",
+                "title": "Break Any Multi-Minute Visual Explanation Into 60–90-Second, Question-Punctuated Segments",
                 "paragraphs": [
-                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "The ~6-minute prophecy-timeline narration ran almost entirely solo. Before: advancing through a multi-part chart with continuous narration. After: pause after each segment and ask a specific question about what was just shown ('where does Satan get released? What happens right after?') before advancing. Same visual, same content, but the room stays in the answering seat throughout, not just at the end."
                 ]
               },
               {
-                "title": "Next session — Leader Development",
+                "title": "Follow Up Personally on Absent Members' Live Threads Before the Next Session",
                 "paragraphs": [
-                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Attendance nearly halved this week, and two members with unresolved live threads from L8 — Mike's baptism trajectory and Chris Jones's dated work-conviction commitment — went unmentioned. Before: no in-session acknowledgment of the absences. After: a short personal text to each absent member this week, plus a one-line public update next Thursday ('talked to Mike this week, here's where he's at'). This closes the loop the same way L8's Recommendation 5 asked for on in-session confessions — applied here to members who weren't even in the room."
                 ]
               }
             ]
           },
           "sections": [
             {
-              "title": "Score composition",
-              "paragraphs": [
-                "How the four weighted clusters and any session bonuses combined into the composite score."
-              ],
+              "title": "Scorecard — 1. Attendees",
               "bullets": [
-                "Teaching Craft: 80% × weight 33 → 26.40 pts",
-                "Building Ministry: 60% × weight 31 → 18.60 pts",
-                "Engaging People: 70% × weight 18 → 12.60 pts",
-                "Being Real: 90% × weight 18 → 16.20 pts",
-                "Base (sum of cluster contributions): 73.80 / 100",
-                "Session bonuses: newcomer growth +5",
-                "Session score: 78.8 / 100"
+                "Total attendees: ~13 men (Thursday evening Zoom group) — down from ~18 last week; Mark Perry, Darrell, Nandan, Vince, Scott, Frank, Nan, Mike, Chris Gallagher, and Chris Jones did not appear this week  (Target: Consistent participation)  → ON TARGET",
+                "Newcomers / first-timers: None this week (week 9 of 10)  (Target: Organic growth over time)  → N/A"
               ]
             },
             {
-              "title": "Coaching notes by dimension",
+              "title": "Scorecard — 2. Scripture Focus",
+              "bullets": [
+                "Cross-references used: 20+ across 13 books — James 4–5; Hebrews 1; Acts 2; 2 Peter 3; Jude 1; 1 John 2; Matthew 5, 21, 23; 1 Thessalonians 2; Job 1–2, 42; Psalm 73; 2 Corinthians 4; Leviticus 19; Deuteronomy 23  (Target: 6+ per session (Lifeway))  → STRONG",
+                "Leader talk ratio (with scripture reading): ~48–52% (whole session; extensive narrated cross-ref chains plus the ~6-min timeline explanation)  (Target: ≤35%)  → NEEDS WORK",
+                "Leader talk ratio (discussion only — graded): ~40–45% (excludes scripture reading; elevated mainly by the uninterrupted prophecy-chart narration)  (Target: ≤30–35% (Lifeway 30% Rule))  → NEEDS WORK",
+                "Time to first scripture reading: ~6 min (Hunter reads James 4:13–17 to open) [00:06:05]  (Target: Within 15 min of lesson start)  → STRONG",
+                "Discussion scripture-grounded: ~85%+ of exchanges tied directly to a text  (Target: 75%+)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 3. Time Management",
+              "bullets": [
+                "Total session time: ~2 hr 10 min  (Target: 120 min)  → ON TARGET",
+                "Opening prayer + book-level Big Idea review: ~6 min (0:00–0:06) — Hunter opens; Bryan runs a fast whole-book review of James's themes  (Target: 10–20 min)  → ON TARGET",
+                "Main lesson (James 4:13–5:12 verse-by-verse + heavy cross-ref chains): ~80 min (0:06–1:26)  (Target: 60–90 min)  → STRONG",
+                "Whiteboard/timeline detour (live-draw attempt + chart share + explanation): ~11–12 min (1:39–1:51) [01:39:18–01:50:49]  (Target: High-value time, tool fit for purpose)  → NEEDS WORK",
+                "Wrap-up application + fear confessions + closing prayer: ~19 min (1:56–2:15 incl. announcements + prayer)  (Target: High-value time)  → STRONG",
+                "Tangent time: ~3 min (Joel-book ordering logistics ~1 min at open; hair-loss/baldness ribbing ~1 min [01:27]; WWE aside ~1 min [00:27])  (Target: < 5 min)  → ON TARGET",
+                "Pacing (self-managed): Bryan self-managed throughout — no external redirect — but ran ~10 min over the 120-min target  (Target: Self-managed throughout)  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Scorecard — 4. Application Questions",
+              "bullets": [
+                "Big Idea questions (DOK scored): 6 questions  (Target: 5–7 per session)  → STRONG",
+                "DOK Level 4 (apply to life): 50% (3 questions — the 60-minutes-to-live wealth hypothetical; the self-examination 'which category reflects you'; 'how can we help Hunter, Chris, and Bryan not be scared')  (Target: 35–50% for DOK 4)  → STRONG",
+                "DOK Level 3 (reason/justify): 50% (3 questions — challenges of wealth; why so much of God's Word is prophecy; defining patience from Job's example)  (Target: 35–50% for DOK 3)  → STRONG",
+                "DOK Level 1–2 scaffolding (excluded): ~20+ navigation/reading/recall prompts  (Target: Excluded from scoring)  → N/A",
+                "Confession / Personal-Response Rate: 5+ first-person responses (Chris's $5M answer; Trent's and Howard's self-examination; Hunter's, Chris's, and Bryan's own live fear confessions; the gun-store risk testimony)  (Target: ≥2 per session)  → STRONG",
+                "Leader follow-up probe frequency: 7+ probes ('Tell me more', 'Oh, come on', 'Come on', 'Give me one, Howard', 'What's the problem, specifically?')  (Target: ≥3 per session)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 5. Engagement",
+              "bullets": [
+                "Named substantive contributors: 12+ (Hunter, Nick, Marcus, Craig Rooker, Russ, Chris, Ricky, Cole, Marco, Lance, Trent, Howard)  (Target: 70–80% of attendees)  → STRONG",
+                "Substantive % of group: ~90%+ of a smaller ~13-man room — nearly every man on the call reasoned or applied, not just read  (Target: ≥70%)  → STRONG",
+                "Read-aloud assignments (reported, not scored): 20+ reading turns across a very heavy cross-reference load (Hunter, Ricky, Marco, Cole, Lance, Russ, Marcus, Nick, Craig Rooker, Chris, and others)  (Target: Reported only)  → N/A",
+                "Wait time / productive struggle: Bryan holds silence on the wrap-up questions ('Give me one, Howard'), routes partial answers onward  (Target: 3–5 sec (Rowe 1972))  → STRONG",
+                "Quiet member flag: Roster shrank sharply vs. last week — 9–10 regulars (Mark Perry, Darrell, Nandan, Vince, Scott, Frank, Nan, Mike, both L8 Chrises) did not appear; no in-session acknowledgment of the absences or outreach mentioned  (Target: All regulars contribute)  → NEEDS WORK"
+              ]
+            },
+            {
+              "title": "Scorecard — 6. Leadership",
+              "bullets": [
+                "Vulnerability moments: 2 — Bryan's own present-tense financial fear near retirement ('the value of it gets cut by a factor of 100... I'm worried about it, that doesn't make sense') [02:00:11]; the sales-integrity testimony ('I was very careful what I said... it became like a superpower') [01:38:56]  (Target: ≥1 per session with depth)  → STRONG",
+                "Vulnerability depth (rolling baseline ±1): 4/5 — a genuine, unresolved, present-tense fear disclosure; consistent with Bryan's 4/5 Thursday baseline (not a higher-cost single confession)  (Target: 4–5/5 for experienced leader)  → STRONG",
+                "Extended monologues > 90 sec: 1 — prophecy-timeline chart narration (~6 min) [01:44:32–01:50:49]  (Target: ≤2 per session (each named with fix))  → STRONG",
+                "Monologue details: See Monologues section below"
+              ]
+            },
+            {
+              "title": "Scorecard — 7. Question Quality",
+              "bullets": [
+                "% open-ended questions: ~72%  (Target: ≥60%)  → STRONG",
+                "% text-requiring questions: ~58%  (Target: ≥50%)  → STRONG",
+                "Leader follow-up probes: 7+ ('Tell me more', 'Oh, come on', 'Say that again', 'Give me one')  (Target: ≥3 per session)  → STRONG",
+                "Productive struggle rate: HIGH — Bryan repeatedly declines to supply the answer ('Give me one, Howard'; multiple held 'come on' silences), forcing a specific personal answer rather than a group-consensus one  (Target: Redirect, don't rescue (Hiebert & Grouws 2007))  → STRONG",
+                "Peer-to-peer exchanges: Present but lighter than last week — the fear-confession round is mostly sequential testimonies answering Bryan rather than a chained member-to-member dialogue  (Target: Members respond to each other)  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Scorecard — 8. Study Method & Communication",
+              "bullets": [
+                "Study flow: Book-level Big Idea review → James 4:13–5:12 verse-by-verse (wealth/patience) → 'last days' + persecution cross-ref chains → Job overview → Psalm 73 → 2 Corinthians 4 → oaths passage → prophecy timeline → wrap-up self-examination  (Target: OIA method)  → STRONG",
+                "Bumper stickers generated: 5 — 'You can't take it with you, but you sure will have to answer for it'; 'What you treasure today may testify against you tomorrow'; 'We're literally in the last blink of time... rearranging the chairs on the Titanic'; 'Don't grumble in the hallway, judgment is coming shortly'; 'Put your money where your mouth is'  (Target: 3–5 per session)  → STRONG",
+                "Visual aids (screen-share prophecy timeline + attempted live whiteboard): One prophecy-timeline chart ultimately screen-shared after a ~5-min failed live-whiteboard attempt; no on-screen Greek/Hebrew word-study tool this week  (Target: Multiple tools (Mayer))  → ON TARGET",
+                "Tone & delivery: N/A — audio only; energetic, humorous delivery evident from transcript (hair-loss ribbing, WWE reference)  (Target: N/A — audio only)  → N/A",
+                "Topic drift: Joel-book ordering logistics ~1 min (open); hair-loss/baldness ribbing ~1 min [01:27]; WWE aside ~1 min [00:27] — total ~3 min  (Target: < 5% off-topic)  → ON TARGET",
+                "Big Ideas at close: Wrap-up self-examination question + peer coping-strategy round; no formal cumulative bumper-sticker recall drill — 2nd consecutive week without it  (Target: Cumulative review at close)  → NEEDS WORK"
+              ]
+            },
+            {
+              "title": "Monologues — Detail & Fix",
               "paragraphs": [
-                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+                "Only one stretch exceeded the 90-second threshold (Stuart & Rutherford) — well under the ≤2 target. Named with its fix.",
+                "Monologue 1 — Prophecy-Timeline Chart Narration [01:44:32–01:50:49] (~6 min): After a ~5-minute failed attempt at a live, multi-cursor Zoom whiteboard drawing (\"this is going to be a bad idea\" [01:41:05]), Bryan shared a pre-existing chart and narrated the church age → tribulation → millennium → new-heaven-and-earth sequence almost entirely solo. The content is genuinely valuable and visually delivered (a real upgrade over verbal-only description), but for roughly six minutes the exchange was one-directional. Fix: break the narration into 60–90-second segments, each followed by a question (\"Where does Satan get released? What happens right after that?\") before advancing to the next part of the chart. Same visual, same content, room stays in the reasoning seat."
+              ]
+            },
+            {
+              "title": "Key Moments",
+              "moments": [
+                {
+                  "detail": "The 60-Minutes-to-Live Money Question  (🟢 Capitalized · Teaching Craft + Being Real)\n\nWhat happened: Teaching James 5:1–6 (riches that rot), Bryan built an escalating hypothetical instead of explaining the text abstractly: \"Let's say you knew for a fact... that you were going to be dead 60 minutes from now... How much money would you have to get paid to work those 60 minutes?\" A member answered concretely — \"I need, like, $5 million, because I need to make sure that my family could live off of that\" — before Bryan escalated the timeframe to a day, a week, a month, a year, forcing the room to watch the \"price\" collapse toward irrelevance as the horizon shortened: \"It's irrelevant. If you're going to die... you don't need anything.\"\n\nWhy it mattered: James 5's warning about hoarded, rotting wealth is easy to nod at and hard to feel. By forcing members to name an actual dollar figure and then watch it evaporate as the clock shortened, Bryan converted an abstract warning into a felt experience of the text's logic — the same move James 4:14's \"vapor\" language makes, but proven experientially rather than merely quoted. It set up every later application (the \"unrepentant rich vs. patiently enduring believer\" self-examination) with lived, not just intellectual, footing.\n\nWhat would make it bigger: Land it with one forward step before moving on: \"So if the last hour wouldn't be worth any amount of money, what's one thing THIS week you'd stop chasing if you really believed that?\" The hypothetical did the diagnostic work; a named, personal follow-through would have converted the insight into an assignment.",
+                  "timestamp": "[00:10:20]"
+                },
+                {
+                  "detail": "Bryan Names His Own Present-Tense Financial Fear — Not a Resolved War Story  (🟢 Capitalized · Being Real)\n\nWhat happened: Setting up the closing application, Bryan grouped himself with two members as all currently scared about money — \"How can we help Hunter and Chris and Bryan Bailey not be scared?\" — then disclosed his own live, unresolved anxiety: \"myself, at the end of the road working-wise, and not a lot of time left... there's all sorts of scenarios where painstakingly safe money... the value of it gets cut by a factor of 100... it basically has no [value], and the reality is eventually it's gonna be worth zero. And yet I'm worried about it. That doesn't make sense.\"\n\nWhy it mattered: Nearly every vulnerability disclosure in this arc so far has been a resolved past event with a redemptive ending (a firing survived, a mortality reflection processed). This is different and harder: Bryan admitting a fear he has NOT resolved, in the present tense, with no tidy conclusion attached. That is a higher-trust move than a war story — it puts the leader in the same unfinished posture he is asking Hunter and Chris to sit in, and it is the reason the room immediately offered him three separate, concrete coping practices rather than sympathy alone.\n\nWhat would make it bigger: Close the loop the way L8's Recommendation 5 asked leaders to close member confessions: name one dated, concrete action for himself out loud — \"here's my one thing this week: I'm going to [specific act] by [day].\" Modeling the exact accountability move on himself, in front of the men he's asking to do the same, would make the vulnerability doubly instructive.",
+                  "timestamp": "[02:00:11]"
+                },
+                {
+                  "detail": "The Day-4 Homework Exercise Was Named, Then Skipped — Second Week in a Row a Recommendation Went Unmet  (🟠 Missed Opportunity · Building Ministry)\n\nWhat happened: Bryan told the room plainly, \"So now I skipped the one thing exercise they gave us in day four... it's so darn hard to do this on Zoom,\" and moved directly into an unplanned attempt to hand-draw a prophecy timeline instead.\n\nWhy it mattered: With only one lesson plus a wrap-up week left in the ten-week arc, a skipped homework exercise does not get a second pass — this week's workbook content is gone once the arc moves to Joel. It also compounds a pattern: last week's report flagged the still-missing cold cumulative recall drill as the arc's most consistent gap and named L9/L10 as the ideal window to finally run it. This week substituted a different, unplanned activity instead of either the homework exercise or the recall drill — the room ran a full session without either of the two named improvement items landing.\n\nWhat would make it bigger: When a written exercise feels hard to run live on Zoom, adapt the medium rather than dropping the content: \"Type your one thing in the chat right now — I'll read three of them out loud.\" Same exercise, Zoom-native delivery, zero prep required.",
+                  "timestamp": "[01:39:18]"
+                },
+                {
+                  "detail": "~5 Minutes Lost to a Live, Multi-Cursor Zoom Whiteboard  (🟠 Missed Opportunity · Teaching Craft)\n\nWhat happened: Attempting to draw a prophecy timeline live, Bryan opened a shared Zoom whiteboard, and multiple members' cursors began drawing on it simultaneously and uncontrolled — \"Look at y'all\"; \"OK, this is a bad idea... this is going to be a bad idea. You can't do this\"; \"forget this idea\" — before Bryan abandoned the whiteboard and switched to sharing a pre-existing image instead, which itself needed live rotating and cropping to display correctly.\n\nWhy it mattered: The teaching goal (visualize the prophetic timeline) was sound and the eventual chart share delivered real value — but roughly five minutes (about 4% of the session) were spent on a tool mismatch: a multi-editor whiteboard is not built for a large Zoom call, and the failure was visible and slightly deflating in the room's energy right before the session's strongest wrap-up stretch. Time lost here is time not spent on the skipped homework exercise or the still-missing recall drill.\n\nWhat would make it bigger: Pre-build the chart or timeline as a single static image or slide before the session (five minutes of prep) and go straight to screen-share. Same visual payoff, none of the live-draw chaos, and the time saved could fund the recall drill this arc still needs.",
+                  "timestamp": "[01:39:34]–[01:44:32]"
+                },
+                {
+                  "detail": "The Cold Cumulative Recall Drill Was Skipped for a Second Straight Session  (🔵 Pivot Point (mixed) · Teaching Craft)\n\nWhat happened: The session opened with a brief, guided Big Idea review of the whole book of James (\"what appears to be the big idea of James?\" → mirror/faith-diagnostic → trials, wisdom, partiality, tongue, dead faith, friend of the world) — genuinely participatory, but prompted and guided by Bryan throughout, not a cold, unaided recall test.\n\nWhy it mattered: L8's report explicitly named this arc's single most consistent technique gap — the absence of a formal \"without looking, recall every bumper sticker\" drill — and flagged L9 or L10 as the ideal remaining window, since only two sessions plus a wrap-up week remained. L9 has now passed without it, leaving only L10 (the arc's final lesson) as the last realistic opportunity before the wrap-up week.\n\nWhat would make it bigger: Open L10 cold: \"Before we do anything — without looking at your notes, give me every Big Idea we've built across all of James. Go.\" Write each one on the shared screen live as it surfaces. This is the last full-content lesson where the drill can land before the wrap-up week's lighter agenda.",
+                  "timestamp": "[00:01:54]–[00:05:48]"
+                }
+              ],
+              "paragraphs": [
+                "Five disproportionately important moments — the pivots that shaped what this group will remember, believe, and do this week. Named explicitly so Bryan can see the pattern and replicate or repair it."
+              ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "How much money would you have to get paid to work your last 60 minutes — and how does that change at a day, a week, a month, a year? [00:10:20] — Level 4 — Apply to life — The session's signature technique — an escalating mortality hypothetical that made James 5's 'riches rot' warning felt rather than merely explained. Produced a concrete $5M answer, then collapsed toward 'it's irrelevant' as the horizon shortened.",
+                "Which behavior category — the unrepentant rich or the patiently enduring believer — most accurately reflects you, and what's the evidence? [01:56:47] — Level 4 — Apply to life — The session's sharpest self-examination question. Produced first-person answers from Trent and Howard naming where they actually land, not where they'd like to land.",
+                "How can we help Hunter, Chris, and Bryan not be scared [about money]? [02:01:52] — Level 4 — Apply to life — Bryan grouped himself with two members as all currently fearful and asked the room to coach him. Produced three distinct, reproducible peer coping practices (trust-in-provision, the gun-store testimony, the prayer journal).",
+                "What are the challenges of wealth? [00:14:05] — Level 3 — Reason/justify — Pre-text discussion question before returning to James 5:1–6. Room named false security, distraction, and pride as the core risks — set up the passage's diagnosis before it was even read closely.",
+                "Why do you think so much of God's Word — over 500 references — is devoted to prophecy? [01:52:05] — Level 3 — Reason/justify — Followed the prophecy-timeline chart. Room reasoned toward 'fulfilled prophecy proves who's inspiring this sits outside of time' — a trust-in-Scripture argument built from the text's own pattern.",
+                "How would you define patience, based on what we just read about Job? [01:14:57] — Level 3 — Reason/justify — Followed the full Job 1/2/42 reading. Room landed 'endurance under stress' as the working definition, grounded in the specific narrative just read rather than a dictionary answer."
+              ],
+              "paragraphs": [
+                "6 Big Idea questions (DOK scored). Scaffolding / reading / navigation prompts (~20+, DOK 1–2) excluded. Distribution: DOK 4 — 50% (3 questions); DOK 3 — 50% (3 questions). Confession/Personal-Response Rate: 5+ first-person responses. Leader Follow-up Probe Frequency: 7+ throughout."
+              ]
+            },
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the weighted clusters combined into the composite score."
               ],
               "bullets": [
-                "Session Structure & Flow (4/5): Delegated open/close, book-level Big Idea review, multi-reader scripture, deep teaching, and a strong wrap-up all present. Dip from a full 5 due to the ~11-min whiteboard/timeline detour and the explicitly skipped Day-4 exercise pulling time from the blueprint's later steps",
-                "Newcomer Welcome (N/A): No first-timers this week (week 9 of 10). Cluster max reduced 15→10, not penalized",
-                "Scripture Engagement (5/5): 20+ cross-references across 13 books — the widest book range of the arc to date (James, Hebrews, Acts, 2 Peter, Jude, 1 John, Matthew ×3, 1 Thessalonians, Job, Psalms, 2 Corinthians, Leviticus, Deuteronomy)",
-                "Facilitation vs. Lecture (3/5): ~40–45% discussion-only, above target; the ~6-min uninterrupted prophecy-chart narration is the main driver. Socratic technique excellent elsewhere (Psalm 73 walk-through, wealth discussion) but this dip is real, not just optics",
-                "Application Questions (5/5): 6 DOK-scored questions (within 5–7 target); 50/50 DOK 4/DOK 3 split; 5+ first-person confessions including the leader's own unresolved disclosure",
-                "Participant Engagement (4/5): 12+ substantive contributors of ~13 (~90%+) — high percentage of a much smaller room; fewer peer-to-peer chains than L8's arc-best session",
-                "Visual Aids (3/5): One prophecy-timeline chart ultimately delivered via screen-share, but a ~5-min failed live-whiteboard attempt preceded it; no on-screen Greek/Hebrew word-study tool this week (a step back from L8's word studies)",
-                "Vulnerability / Authenticity (4/5): Bryan's own live, unresolved financial-fear disclosure plus the sales-integrity testimony; high member-vulnerability floor. Consistent with the 4/5 Thursday baseline (±1 swing cap applied)",
-                "Memory Reinforcement (3/5): Brief, functional book-level review at open (~5 min), but the formal cold cumulative recall drill was skipped for a 2nd consecutive week despite being named as the arc's top priority gap",
-                "Homework References (3/5): Homework named explicitly ('the math they gave us in the homework', 'the one thing exercise... day four') but the specific Day-4 exercise was explicitly skipped rather than adapted for Zoom",
-                "Prayer (5/5): Opening (Hunter) AND closing (Cole) delegated and both captured in the recording",
-                "Leader Development (3/5): No in-session apprentice handoff or delegated facilitation window this week; arc-long pattern holds"
+                "Teaching Craft: 80.0% × weight 33 → 26.40 pts",
+                "Building Ministry: 60.0% × weight 31 → 18.60 pts",
+                "Engaging People: 70.0% × weight 18 → 12.60 pts",
+                "Being Real: 90.0% × weight 18 → 16.20 pts",
+                "BASE (pre-bonus): — × weight 100 → 73.80 pts"
               ]
             }
           ],
@@ -500,197 +567,262 @@
             "What you do is what you believe"
           ],
           "feedback": {
-            "headline": "An exceptional session — strongest in Newcomer Welcome and Scripture Engagement, with the clearest next step in Visual Aids.",
+            "headline": "The Guarantee delivered in full; BLB word study resolves the James/Paul discrepancy; Brendan commissioned for Camp Tejas — 2 Tim 2:2 chain visible.",
             "strengths": [
-              "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
-              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-              "Prayer was delegated to members, opening and closing the group in shared voice."
+              "The Guarantee: Delivered in the Most Powerful Form Possible",
+              "Blue Letter Bible Word Study Resolves the James/Paul Discrepancy",
+              "Brendan's Public Commissioning: 2 Tim 2:2 Made Visible"
             ],
             "improvements": [
-              "The session leaned audio-only; a visual anchor would aid retention.",
-              "Teaching stayed at arm’s length; little personal cost was modeled.",
-              "Prior Big Ideas weren’t reviewed, so last week’s themes faded."
+              "The Grand Canyon Monologue: Best Illustration, Breakable Delivery",
+              "Formal Ebbinghaus Drill Still Missing (9th Consecutive Session)",
+              "The Evidence Card Close: More Depth, Less Reading"
             ],
             "recommendations": [
-              "Next time, put one word-study lookup or a simple table on screen during the key term.",
-              "Next time, open one teaching point with a first-person example that cost you something.",
-              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas."
+              "Open L6 with a Formal Ebbinghaus Retrieval Drill",
+              "Ask John (or Any Newcomer) for One Card Response at Every Close",
+              "Break Every 2-Minute Illustration Before the Punchline"
             ],
             "overview": [
-              "An exceptional session — strongest in Newcomer Welcome and Scripture Engagement, with the clearest next step in Visual Aids. It scored 86.25/100 under the v3 weighted model.",
-              "The session played to its strengths in Newcomer Welcome and Scripture Engagement; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+              "The Guarantee delivered in full; BLB word study resolves the James/Paul discrepancy; Brendan commissioned for Camp Tejas — 2 Tim 2:2 chain visible.",
+              "This report carries the full written coaching for the session: 5 areas of strength, 5 areas for improvement, and 5 recommendations for next session, scored 86.25/100 on the v3 weighted model."
             ],
             "strengthsProse": [
               {
-                "title": "Newcomer Welcome anchored the session (5/5)",
+                "title": "The Guarantee: Delivered in the Most Powerful Form Possible",
                 "paragraphs": [
-                  "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
-                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
-                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: John (first-timer), Eric, Mike welcomed with full member testimonies and Guarantee; Bryan personally engaged John ('why did you decide to show up?'); +3.0 newcomer bonus applied"
+                  "The recommendation from every prior James session was to deliver The Guarantee. This session delivered it — not as a scripted pitch but as personal testimony embedded in Bryan's own story. At [00:07:48]: 'And any of you that's not doing the homework, if you with an open mind still do what the homework says every day, it's five days, so you're basically in God's word five days with an open mind, I guarantee you God will begin to speak.' And again at [01:07:08]: 'That's my guarantee. If you do the homework, if you can find a way to knuckle down and do it, and that was done to me subconsciously. It wasn't done by me knowing something, information. It was something God had transformed in my mind, right?' John — the first-timer, working security on 6th Street, never been in church — heard The Guarantee twice: once as enrollment promise, once as personal confession. That is ministry multiplication at its most efficient. The recommendation is no longer needed for the Saturday group."
                 ]
               },
               {
-                "title": "Scripture Engagement anchored the session (5/5)",
+                "title": "Blue Letter Bible Word Study Resolves the James/Paul Discrepancy",
                 "paragraphs": [
-                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 19 cross-references across 12+ books — James primary + Titus 1, Rom 3/5/6, Heb 11, Eph 2, 2 Cor 5/13, 1 Cor 6, Matt 7, Gal 5, John 3/13; 80%+ of discussion scripture-grounded"
+                  "The central interpretive challenge of James 2:14-26 is the apparent contradiction with Pauline soteriology ('justified by faith alone' vs. 'justified by works'). Bryan brings up Blue Letter Bible on screen, navigates to James 2:21, clicks on 'justified,' and finds G1344 with two definitions: (1) to render righteous, and (2) to demonstrate righteous. The moment at [01:00:00-01:00:10]: 'Okay, same work, same Greek, same Greek word G113 44, every Greek word has a number. It's the same word, but what if it's the word to demonstrate. Now re-read, re-read, keep that verse, substitute the word demonstrates.' The room gets it immediately: 'Oh, was not Abraham our father demonstrated by works when he offered up Isaac his son on the altar?' — 'Oh, that might be a little different.' This is the BLB word study used exactly the way it's designed to be used: resolving a genuine hermeneutical ambiguity through primary-language access. Any man who wanted to look this up later knows where to go. Visual Aids rises from 2/5 to 3/5 on the strength of this single tool-use."
                 ]
               },
               {
-                "title": "Prayer anchored the session (5/5)",
+                "title": "Brendan's Public Commissioning: 2 Tim 2:2 Made Visible",
                 "paragraphs": [
-                  "Prayer was delegated to members, opening and closing the group in shared voice.",
-                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
-                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Opening prayer delegated (member at 00:00); group commissioning prayer for Brendan and Glenn (3+ spontaneous member prayers at close); one of the strongest prayer moments of the James arc"
+                  "At [01:57:13], Bryan calls Glenn Gordon (men's pastor) and Brendan forward. 'This is Brendan's first, what do you wanna call it? Teacher, leader. First, like, leader, first, as a new believer, really got a desire to work with kids, and he's one of us, so we wanna pray for him and commission him out.' The group gathers around. Multiple members pray spontaneously — at least three different voices in the closing prayer circle. Bryan says: 'This is a big deal. And you take that serious. These are the kind of things that can, God can use to change people's lives.' This is the 2 Timothy 2:2 chain made visible in one room: Bryan developed these men, one of whom (Brendan) is now going to teach 25 third-grade boys the book of Daniel at Camp Tejas. The commissioning creates a visible leader development moment that the whole group witnessed — and the men who prayed over Brendan became part of his accountability chain. This moves Dim 12 from 3/5 to 4/5."
                 ]
               },
               {
-                "title": "Session Structure & Flow anchored the session (4/5)",
+                "title": "Member-Generated Bumper Stickers",
                 "paragraphs": [
-                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 10-step blueprint followed; opening prayer delegated, newcomer welcome complete with testimonies, Guarantee delivered, Big Ideas review, cross-ref arc, closing commissioning prayer; no formal Ebbinghaus drill"
+                  "Two of the session's five bumper sticks were generated by members, not Bryan. At [01:34:51], a member says unprompted: 'Apples don't make trees alive. They prove they are alive.' Bryan's response: 'Ooh, come on. That's what I'm talking about.' He then asks: 'Can you say it again?' — and the member repeats it. At [01:44:01], Keith says: 'Works without faith is bad just like faith without works is bad.' Bryan: 'Oh, come on. Write that one down. Say it again.' Both times, Bryan publicly honored the member's synthesis, asked for a repeat to let it land, and reinforced it as a teachable phrase. This is what a well-cultivated group culture produces — when men trust that their synthesis will be taken seriously, they risk offering it. Bryan's reinforcement protocol ('say it again', 'write that down', 'oh come on') is what makes the room safe for intellectual contribution."
                 ]
               },
               {
-                "title": "Facilitation vs. Lecture anchored the session (4/5)",
+                "title": "The Evidence Exercise: Bookend Applied to the First-Timer Context",
                 "paragraphs": [
-                  "Discussion outweighed lecture — the room did the thinking, not just the leader.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
-                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: ~35-40% discussion-only leader talk (excludes welcome, excludes reading); good Socratic method; some teaching monologues in cross-ref sections"
+                  "Bryan opens by handing out paper and asking members to number 1-5 and write 'five evidences — stone cold factual evidence you would use in a court of law to convict you of being a born-again Christian.' He launches this before John has received any formal teaching. By the time the evidence cards come back at the close (~[01:54:50+]), John has sat through 90 minutes of cross-references, the BLB word study, the Grand Canyon illustration, and the Christmas tree Christian concept. His five evidences at close mean something different than they would have at open. The exercise is pedagogically perfect for a first-timer: he writes at open from what he already believes (or doesn't), receives the full arc of the lesson, then reflects again at close. Whether John returned to the study is something Bryan will find out — but the man who walked out with 'I don't allow sin to fester' on his card left with a specific metric for his own faith."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Visual Aids is a growth area (3/5)",
+                "title": "The Grand Canyon Monologue: Best Illustration, Breakable Delivery",
                 "paragraphs": [
-                  "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Blue Letter Bible used on-screen for G1344 word study (resolves James/Paul discrepancy); no color-coded chart, no two-column reference board; improvement from 2/5"
+                  "The Grand Canyon illustration at [00:53:xx] is the session's best single teaching moment — 'God is on the North Rim. You're on the South Rim. Nobody's jumped across. Works can never get you to the North Rim. But when I become a believer and receive the Holy Spirit, what's always united with that faith is works.' The illustration is airtight, visual, and memorable. But it runs ~2:00 as a sustained monologue — Bryan drives from 'who's been to the Grand Canyon?' through the full payoff without a pause. One break converts it: after 'God is on the north rim and you're on the South Rim' and before 'Ain't nobody can jump,' say: 'Can anybody in the history of the world jump from the South Rim to the North Rim?' Wait three seconds. Then deliver the payoff. Same illustration; one member says 'No' or 'That's impossible'; Bryan confirms. The group participates in the conclusion rather than receiving it. Target: any monologue with a known punchline should get a Socratic break before the reveal."
                 ]
               },
               {
-                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "title": "Formal Ebbinghaus Drill Still Missing (9th Consecutive Session)",
                 "paragraphs": [
-                  "Teaching stayed at arm’s length; little personal cost was modeled.",
-                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
-                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: 3 vulnerability moments (personal guarantee story 3/5, Christmas tree theft 2/5, naming rights 3/5); one below baseline; +/-1 cap applied; no high-cost disclosure"
+                  "At [00:17:00-00:22:00], Bryan asks members 'What are the tests that James has given us from the whole book?' Members recall: tongue test, trials/endurance, temptation, partiality, hearer vs. doer, wisdom/double-mindedness, widows/orphans. This IS memory reinforcement — but it's Bryan-led recall (he asks and confirms) rather than member-driven retrieval (members generate from memory without prompting). The Ebbinghaus spacing effect requires the act of retrieval under effort, not the act of being reminded. The intervention is specific and unchanged from eight prior recommendations: at the top of L6, say 'Before we do anything else — give me every Big Idea bumper sticker from James L1 through L5. Just go. Don't look at anything.' Write each one on the BLB screen as members call them out. If they miss one, add it at the end. The nine bumper sticks now include at least two from this session: 'apples prove trees' and 'works without faith is bad.' Target: 6-7 bumper sticks recalled cold in under 4 minutes."
                 ]
               },
               {
-                "title": "Memory Reinforcement is a growth area (3/5)",
+                "title": "The Evidence Card Close: More Depth, Less Reading",
                 "paragraphs": [
-                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Informal James tests recall at open (Bryan-led); new bumper sticks generated by members; no formal Ebbinghaus retrieval drill; 9th consecutive session without it"
+                  "The evidence cards returned at close [01:54:50+] produced great moments — 'Stop cussing' (humor that signals real conviction), 'No pornography,' 'Less anger,' 'God has changed my viewpoint on sin.' Bryan reads through cards and gives brief reactions, but the session closes with the commissioning prayer rather than asking individual members to share their lists verbally. The Thursday group did this more fully (8 members each shared their own list). The Saturday version got abbreviated. At L6: after handing back the cards at close, say 'I want to hear from three of y'all. Someone who wants to share — what did you write? Did anything change from when you wrote them at the start?' Pause. Let three members share before closing. This brings the bookend full circle: the open question gets a Socratic answer. John is the most important person in the room to hear from — his list was written by a man who hadn't been to church. His closing list would have been a remarkable moment."
                 ]
               },
               {
-                "title": "Application Questions is a growth area (4/5)",
+                "title": "The July 4th Idea: Missed Spontaneous Planning Moment",
                 "paragraphs": [
-                  "Questions stayed heady; few moved the group to first-person, personal application.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: 6-7 DOK-scored Big Idea questions; strong evidence card bookend; functional atheist concept stayed intellectual; John's card not retrieved at close"
+                  "At [01:50:28-01:50:38], a member says: 'There's another big idea... knowing the existence of a God is easy. But understanding and believing what he wants from us is hard.' Bryan's response: 'I'm gonna put a pin in that... That might be a good Bible study for July 4th. What is it God wants from us? From all, any person.' The member's idea was substantive enough that Bryan flagged it as a potential session topic. But the July 4 reference passed without Bryan writing it down publicly or asking the group to name what that topic would cover. At L6 (or in a pre-session communication): 'I put a pin in something last week. Someone asked: what does God want from any person? That's our July 4 topic. I'm thinking Micah 6:8, Matthew 22:37-40, possibly Deuteronomy 10:12-13. Who wants to pull one of those passages for that week?' This (a) delivers on the commitment, (b) builds pre-session ownership, and (c) gives the member who raised the idea public credit for launching a study."
                 ]
               },
               {
-                "title": "Participant Engagement is a growth area (4/5)",
+                "title": "The Functional Atheist Question: Richest Concept, Thinnest Application",
                 "paragraphs": [
-                  "A few voices carried the discussion; quieter members went unheard.",
-                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: 15+ substantive contributors; ~75% of group; two member-generated bumper stickers; peer-to-peer exchanges; no quiet member flag"
+                  "At [00:40:46-00:43:55], Bryan introduces 'functional atheist' — 'a person who professes to know God but by their deeds denies him.' The discussion generates: no consequence awareness, living for the flesh, no fear of eternity, porn and sex with girlfriend as functional atheism. Bryan lands on: 'What you do is what you believe.' This is the session's deepest DOK-4 concept — and it was cut before it reached a personal confession. At [00:42:18]: 'Can you go to church, can you go to Bible study, and actually function like there's no God?' The group immediately answers yes. But no one named what their own functional atheism looked like. The move: after confirming 'absolutely, yes,' ask directly — 'Give me an example from your own life where you believed one thing and did another. I'll start.' Bryan's self-example on this would have set the table for three or four confessional responses. The concept became intellectual when it was designed to be diagnostic."
                 ]
               }
             ],
             "recommendationsProse": [
               {
-                "title": "Next session — Visual Aids",
+                "title": "Open L6 with a Formal Ebbinghaus Retrieval Drill",
                 "paragraphs": [
-                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Say exactly: 'Before we do anything else — give me every Big Idea bumper sticker from James L1 through L5. Just go. Don't look at anything.' Write each one on the BLB screen as members call them out. The nine bumper sticks from this arc include: 'Partial obedience is disobedience,' 'Tongue is a thermometer for your faith,' 'Saved for deeds, not by them,' 'Apples prove trees, they don't make them,' 'Works without faith is bad like faith without works,' 'What you do is what you believe,' 'Faith without works is a corpse,' and others. If they miss one, add it at the end. Target: 6-8 recalled cold in under 4 minutes. The act of blanking on one is more reinforcing than being reminded."
                 ]
               },
               {
-                "title": "Next session — Vulnerability / Authenticity",
+                "title": "Ask John (or Any Newcomer) for One Card Response at Every Close",
                 "paragraphs": [
-                  "Next time, open one teaching point with a first-person example that cost you something.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "The evidence card bookend only closes when someone who opened it without vocabulary gets to close it with new vocabulary. At L6 (if John returns), say before the commissioning prayer: 'John — you wrote that list cold this morning. Would you be willing to share one thing? And did anything shift for you?' If he declines, honor it; you asked. If he shares, the room hears the session through the ears of the man it was built to reach. Replicate this with any first-timer: their close-of-session evidence card is always the most coachable voice in the room."
                 ]
               },
               {
-                "title": "Next session — Memory Reinforcement",
+                "title": "Break Every 2-Minute Illustration Before the Punchline",
                 "paragraphs": [
-                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "The Grand Canyon illustration is excellent and has the right structure: setup (you're on the South Rim, God's on the North), problem (no one can jump), resolution (Holy Spirit bridges it via salvation). The fix: stop before the punchline and ask the room. 'Can anybody in the history of the world jump from the South Rim to the North Rim? Anybody?' Pause. Let one person say no. Then deliver the resolution. Target: any illustration with a known punchline gets a Socratic break before the reveal — the group lands the conclusion, not just receives it."
                 ]
               },
               {
-                "title": "Next session — Application Questions",
+                "title": "Name the 2 Tim 2:2 Chain Explicitly at Every Commissioning",
                 "paragraphs": [
-                  "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "The Brendan commissioning was the session's highest-stakes moment and it was fully executed. What would sharpen it further at future commissionings: after the prayer circle, turn to the group and name the chain: 'You're looking at it right now. Bryan — to this group — to Brendan — to 25 third-grade boys — to their fathers and future families. That's 2 Timothy 2:2 on a Saturday morning.' Then turn to whoever is the newest person in the room: 'That's where this goes in five years.' One sentence turns a beautiful pastoral moment into a recruitment vision."
                 ]
               },
               {
-                "title": "Next session — Participant Engagement",
+                "title": "Follow Up on the Functional Atheist Question with a Personal Confession",
                 "paragraphs": [
-                  "Next time, name one quiet regular early and invite their read on a passage.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "At L6 (or any future session where this concept appears): after 'Can you go to Bible study and function like there's no God?' and the group says yes — don't stop there. Say: 'I'll give you one from my own life.' Then name a specific area where Bryan's behavior doesn't match his stated belief (money, time, tongue, etc.). This converts an intellectual DOK-3 question into a DOK-4 confession-driver. The group follows the leader: when Bryan names his functional atheism, three others will name theirs. Target: every DOK-3 question about spiritual temperature gets a personal Bryan example before being opened to the floor."
                 ]
               }
             ]
           },
           "sections": [
             {
-              "title": "Score composition",
-              "paragraphs": [
-                "How the four weighted clusters and any session bonuses combined into the composite score."
-              ],
+              "title": "Scorecard — 1. Attendees",
               "bullets": [
-                "Teaching Craft: 76% × weight 33 → 25.08 pts",
-                "Building Ministry: 86.7% × weight 31 → 26.87 pts",
-                "Engaging People: 80% × weight 18 → 14.40 pts",
-                "Being Real: 80% × weight 18 → 14.40 pts",
-                "Base (sum of cluster contributions): 80.75 / 100",
-                "Session bonuses: newcomer growth +3, group-size +2.5",
-                "Session score: 86.25 / 100"
+                "Total attendees: ~20+ men (Saturday morning room + guests)  (Target: Consistent growth)  → STRONG",
+                "Newcomers / first-timers: 3 — John (first-timer), Eric (Chicago visitor), Mike (Ephraim's brother)  (Target: Organic growth over time)  → STRONG"
               ]
             },
             {
-              "title": "Coaching notes by dimension",
+              "title": "Scorecard — 2. Scripture Focus",
+              "bullets": [
+                "Cross-references used: 19 across 12+ books (James, Titus, Romans, Hebrews, Eph, 2 Cor, 1 Cor, Matt, Gal, John)  (Target: 6+ per session (Lifeway))  → STRONG",
+                "Leader talk ratio (with scripture reading): ~45-50% (whole session)  (Target: ≤35%)  → NEEDS WORK",
+                "Leader talk ratio (discussion only — graded): ~35-40% (excludes scripture reading; excludes newcomer welcome)  (Target: ≤30-35% (Lifeway 30% Rule))  → ON TARGET",
+                "Time to first scripture reading: ~17 min (after newcomer welcome + evidence exercise launch)  (Target: Within 15 min of lesson start)  → ON TARGET",
+                "Discussion scripture-grounded: ~80% of exchanges connected to a text  (Target: 75%+)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 3. Time Management",
+              "bullets": [
+                "Total session time: ~2 hr 7 min  (Target: 120 min)  → ON TARGET",
+                "Opening prayer + newcomer welcome + testimonies: ~10 min (0:00-0:10)  (Target: 7-25 min for newcomer welcome)  → STRONG",
+                "Evidence exercise + James context review: ~18 min (0:10-0:28)  (Target: 10-20 min)  → STRONG",
+                "Main lesson (James 2:14-26 + cross-refs): ~95 min (0:28-2:03)  (Target: 60-90 min)  → STRONG",
+                "Commissioning prayer (Brendan + Glenn): ~8 min (1:57-2:05)  (Target: Ministry act)  → STRONG",
+                "Tangent time: < 5 min (Chick-fil-A pin, July 4 pin, Russ's son joke)  (Target: < 5 min)  → STRONG",
+                "Pacing (self-managed): Bryan self-managed throughout; no external redirect  (Target: Self-managed throughout)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 4. Application Questions",
+              "bullets": [
+                "Big Idea questions (DOK scored): 6-7 questions  (Target: 5-7 per session)  → STRONG",
+                "DOK Level 4 (apply to life): ~45% (3 questions)  (Target: 35-50% for DOK 4)  → STRONG",
+                "DOK Level 3 (reason/justify): ~40% (3 questions)  (Target: 35-50% for DOK 3)  → STRONG",
+                "DOK Level 2 (compare/analyze): ~15% (1 question)  (Target: Minority)  → STRONG",
+                "DOK Level 1 scaffolding (excluded): ~10 navigation prompts  (Target: Excluded from scoring)  → N/A",
+                "Confession / Personal-Response Rate: 4+ first-person responses during evidence card share (stop cussing; no pornography; less anger; God changed my viewpoint on sin)  (Target: ≥2 per session)  → STRONG",
+                "Leader follow-up probe frequency: 6+ probes ('Say more', 'Tell me more', 'What does that mean?', 'Give me a clue', 'Say it again')  (Target: ≥3 per session)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 5. Engagement",
+              "bullets": [
+                "Named substantive contributors: 15+ (John, Eric, Mike, Tom, Mark, Danny, Mitch, Cole, Russell, Austin, Kevin, Glenn, Taylor, Brendan, Cason, Wesley, Keith, Chris, Steve, Matt, Jackson)  (Target: 70-80% of attendees)  → STRONG",
+                "Substantive % of group: ~70-80% (interpreting or applying, not just reading)  (Target: ≥70% for STRONG)  → STRONG",
+                "Read-aloud assignments (reported, not scored): ~6 members (Taylor — James 2:14-17; Steve — James 2:24-26; Kevin — 1 Cor 6:9-11; Eric — Eph 2:10; Brendan — John 13:35; Cason — 2 Cor 13:5)  (Target: Reported only)  → N/A",
+                "Wait time / productive struggle: Bryan consistently withholds answer; multiple 'Somebody say something' and name-call pivots  (Target: 3-5 sec (Rowe 1972))  → STRONG",
+                "Quiet member flag: None identified — all named regular members contributed  (Target: All regulars contribute)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 6. Leadership",
+              "bullets": [
+                "Vulnerability moments: 3 — Christmas tree college story [01:35], million-dollar naming rights confession [00:57], personal guarantee subconscious change story [00:07]  (Target: ≥1 per session with depth)  → STRONG",
+                "Vulnerability depth (rolling baseline ±1): 3/5 — personal guarantee story is medium cost; no high-cost disclosure (cf. baby/lust from Thursday); ±1 cap applied; one below baseline  (Target: 4-5/5 for experienced leader)  → ON TARGET",
+                "Extended monologues > 90 sec: 2 — Grand Canyon illustration (~2:00) [00:53], faith/works connection teaching [01:13]  (Target: ≤ 2 per session (each named with fix — see Monologues section))  → ON TARGET",
+                "Monologue details: See Monologues section below"
+              ]
+            },
+            {
+              "title": "Scorecard — 7. Question Quality",
+              "bullets": [
+                "% open-ended questions: ~70%  (Target: ≥60%)  → STRONG",
+                "% text-requiring questions: ~55%  (Target: ≥50%)  → STRONG",
+                "Leader follow-up probes: 6+ ('Tell me more', 'Come on', 'Say it again', 'More specific', 'Re-explain in different words')  (Target: ≥3 per session)  → STRONG",
+                "Productive struggle rate: HIGH — Bryan regularly routes partial answers to other members; 'It only took 12 of y'all to get to that'  (Target: Redirect, don't rescue (Hiebert & Grouws 2007))  → STRONG",
+                "Peer-to-peer exchanges: Members building on each other — Keith's 'works without faith' bumper sticker, member's 'apples' bumper sticker both generated by members mid-discussion  (Target: Members respond to each other)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 8. Study Method & Communication",
+              "bullets": [
+                "Study flow: Observation → Interpretation → Application across three pericopes of James 2:14-26  (Target: OIA method)  → STRONG",
+                "Bumper stickers generated: 5 — 'Saved for deeds, not by them', 'Accurate theology can be a corpse', 'Apples prove trees, not make them', 'Works without faith is bad like faith without works', 'What you do is what you believe'  (Target: 3-5 per session)  → STRONG",
+                "Tone & delivery: N/A — audio only; humor and warmth evident from transcript ('That's my guarantee'; commissioning prayer tone)  (Target: N/A — audio only)  → N/A",
+                "Topic drift: Three brief pins (Chick-fil-A, July 4 idea, Russ's son name) — none exceeded 30 sec  (Target: < 5% off-topic)  → STRONG",
+                "Big Ideas at close: Evidence cards collected and reviewed at close; commissioning replaced the formal close  (Target: Cumulative review at close)  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Monologues — Detail & Fix",
               "paragraphs": [
-                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+                "Two monologues exceeded the 90-second threshold (Stuart & Rutherford). Each is named with the fix.",
+                "Monologue 1 — Grand Canyon illustration [00:53:xx – 00:55:xx] (~2:00): Bryan builds the Grand Canyon analogy from setup through payoff: South Rim, North Rim, perspective, scale, 'you can't jump from South to North Rim.' The entire illustration is delivered without a teaching break. The fix: after 'God is on the North Rim,' stop and ask 'Can anybody in the history of the world jump from the South Rim to the North Rim?' Wait. Let one person say no. Then deliver: 'That's right. Ain't nobody over there. Works can never get us there.' Same content; one break; the room participates in the conclusion.",
+                "Monologue 2 — Salvation and works synthesis [01:13:xx – 01:15:xx] (~2:00): Bryan explains the link between salvation, Holy Spirit, and works: 'when I become a believer and receive the Holy Spirit, what's always united with that faith is works because God is in it producing it.' This is the session's theological capstone and deserves some monologue. The single fix: after 'when the Holy Spirit is not producing work in you, you're a corpse,' stop and ask 'So based on that — what does that mean about the person who says they're saved but there's no change in their life?' Let one member answer. Then confirm with 'Exactly. That's what James is getting at.'"
+              ]
+            },
+            {
+              "title": "Key Moments",
+              "moments": [
+                {
+                  "detail": "Brendan's Public Commissioning — The 2 Timothy 2:2 Chain Made Visible  (🟢 Capitalized · Building Ministry)\n\nWhat happened: Bryan calls Glenn Gordon and Brendan forward. He explains: \"This is Brendan's first, what do you wanna call it? Teacher, leader. First, like, leader, first, as a new believer, really got a desire to work with kids, and he's one of us, so we wanna pray for him and commission him out. This is a big deal.\" The group gathers around. Three members pray spontaneously over Brendan and Glenn. Brendan is going to Camp Tejas the following week to teach third-grade boys the book of Daniel.\n\nWhy it mattered: Bryan poured into Brendan (a new believer); Brendan said yes to leading third-graders at camp; the whole group just witnessed the chain. Every man who prayed over Brendan became part of his accountability structure. The commissioning makes the 2 Timothy 2:2 model — Paul to Timothy to faithful men to others — concrete and local: Bryan to Brendan to 25 eight-year-olds to their families. This is what Building Ministry looks like when it's working. The men who've been in this study for years saw themselves in Brendan: they were all first-timers once. John (today's first-timer) saw where this study could take him. That is recruiting, retention, and vision all in one public moment.\n\nWhat would make it bigger: After the commissioning prayer, turn to the group and say: 'You know what's about to happen to those boys? This study. Everything we're doing here is going to go into a cabin at Camp Tejas next week. That's what we're for.' Then turn to John: 'That's what this looks like five years from now, John.' One sentence connects the newcomer to the arc. Target: always name the chain out loud — Bryan to the group to Brendan to third-graders to their future families.",
+                  "timestamp": "[01:57:13]"
+                },
+                {
+                  "detail": "Blue Letter Bible: G1344 — \"Justify\" or \"Demonstrate\"?  (🟢 Capitalized · Teaching Craft)\n\nWhat happened: Bryan brings up BLB on screen, navigates to James 2:21, and clicks on 'justified': \"Okay, same work, same Greek word, G113 44, every Greek word has a number. It's the same word, but what if it's the word to demonstrate. Now re-read, re-read, substitute the word demonstrates.\" A member reads it back: 'Oh — was not Abraham our father demonstrated by works when he offered up Isaac?' Immediate recognition: 'Oh, that might be a little different.'\n\nWhy it mattered: Martin Luther called James an 'epistle of straw' because it appeared to contradict Paul. The BLB word study shows that James and Paul are using the same Greek word (G1344) with different semantic emphasis: Paul uses 'justify' as 'declared righteous' (initial justification by faith); James uses it as 'demonstrated righteous' (ongoing works as evidence). Bryan resolved in one screen-share what has divided theologians for 500 years. Every man in the room now has the tool: G1344, two meanings, two contexts, one harmonized theology. Visual Aids rises to 3/5 on the strength of this single deployment — the tool was used precisely, not decoratively.\n\nWhat would make it bigger: After the 'Oh, that might be a little different' — freeze the screen and ask: 'So who resolved the Luther problem? Was it Bryan? No. The word did. Now — if you're in a conversation with someone who says James contradicts Paul, what's your one move?' Let a member answer. Then: 'Show them G1344. They can look it up themselves in two minutes.' That turns the word study into a reproducible apologetic skill, not just a teaching moment.",
+                  "timestamp": "[01:00:00]"
+                },
+                {
+                  "detail": "The Guarantee — Delivered as Personal Testimony to John's First Visit  (🟢 Capitalized · Building Ministry)\n\nWhat happened: During the newcomer welcome, Bryan says: \"And any of you that's not doing the homework, if you with an open mind still do what the homework says every day, it's five days, so you're basically in God's word five days with an open mind, I guarantee you God will begin to speak.\" Then again at [01:07:08]: \"That's my guarantee. If you do the homework, if you can find a way to knuckle down and do it, and that was done to me subconsciously. It wasn't done by me knowing something, information. It was something God had transformed in my mind.\"\n\nWhy it mattered: John works security on 6th Street. He said he's 'never been in church' and that someone's been inviting him for three months. He woke up Saturday morning and showed up. The Guarantee is the single most important thing a man like John hears in his first visit — because it answers the implicit question: 'Is this worth showing up for every week and doing homework five days?' Bryan answered it twice, with personal testimony of his own transformation. John didn't receive a marketing pitch; he received a man's life as evidence. That distinction is what makes this study different from every other Saturday morning option John could have chosen.",
+                  "timestamp": "[00:07:48]"
+                },
+                {
+                  "detail": "John's Evidence Card — The One Voice That Would Have Closed the Bookend  (🟠 Missed Opportunity · Being Real)\n\nWhat happened: The evidence cards came back at close. Bryan read through several cards: 'Stop cussing. Rewaiting for merit. Less anger. No pornography. God has changed my viewpoint on sin.' He gave brief reactions and then moved to the commissioning prayer. Bryan did not call on John — the first-timer who wrote his evidence list cold, before any teaching, from his own life on 6th Street. What was NOT said: Bryan did not ask John what he wrote. The list John wrote at open reflected where he was before 90 minutes of James 2:14-26, the BLB word study, the Grand Canyon illustration, and 15+ cross-references.\n\nWhy it mattered: John was the most important voice in the room at close. He's a man who 'never been in church,' who wrote his evidence list without any theological vocabulary, who sat through a session that answered the question his list was built on. Whether his list changed between open and close — and how — is the most interesting data point in the room. The whole evidence-card architecture is designed to reveal that change. Bryan got great cards from the regulars; the one card that would have anchored the entire session belonged to John.\n\nWhat would make it bigger: After reading two or three cards from regulars, say: 'John — you wrote this cold, before we'd done anything. Would you be willing to share one thing you wrote? And did anything change?' If John declines, honor it. If John shares even one item, the whole room hears what a first-timer took away from James 2. That is the living proof that the session worked.",
+                  "timestamp": "[01:55:00]"
+                }
+              ],
+              "paragraphs": [
+                "Four disproportionately important moments — the pivots that shaped what this group will remember, believe, and do. These are named explicitly so Bryan can identify the pattern and replicate it."
+              ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "Write down five evidences — stone cold factual evidence you would use in a court of law to convict you of being a born-again Christian. [00:11:41 + 01:54:50] — Level 4 — Apply to life — Bookend exercise — written cold at open, returned at close. John's card was the session's highest-stakes unretrieved data point.",
+                "What does dead mean? And what does it mean that faith without works is dead? [00:29:30] — Level 2 — Compare/analyze — Set up the corpse analogy and the James 2:26 synthesis. Drove the 'corpse vs. functional atheist' distinction.",
+                "Can you separate fire and heat? [00:33:02] — Level 3 — Reason/justify — Faith-works inseparability analogy from prior session, re-used here. Member answer ('Holy Spirit') resolved the mechanism.",
+                "What allows true faith and works to always be connected — what makes them inseparable? [00:32:17] — Level 3 — Reason/justify — Bryan's highest-DOK facilitated exchange — 12 members attempted before 'Holy Spirit' answer landed.",
+                "Can you go to church, can you go to Bible study, and actually function like there's no God? [00:42:18] — Level 3-4 — Reason/justify + Apply — Functional atheist application — group said yes immediately; should have driven to personal examples.",
+                "We are God's workmanship — what does it mean that the works were prepared beforehand? [01:46:05] — Level 3 — Reason/justify — Bryan used Brendan's baptism dinner illustration; 'before y'all even showed up' made the concept concrete.",
+                "Share what you wrote on your evidence card. Did anything change from when you wrote it? [01:54:50] — Level 4 — Apply to life — Evidence card close — executed for regulars, not reached for John (the session's key unretrieved voice)."
+              ],
+              "paragraphs": [
+                "6-7 Big Idea questions (DOK scored). Scaffolding / reading prompts (~10, DOK 1) excluded. Distribution: DOK 4 — ~45% (3 questions); DOK 3 — ~40% (3 questions); DOK 2 — ~15% (1 question). Q-to-S ratio in discussion: ~50:50. Confession/Personal-Response Rate: 4+ first-person responses during evidence card share. Leader Follow-up Probe Frequency: 6+ ('say more', 'tell me more', 're-explain in different words', 'say it again', 'give me an example')."
+              ]
+            },
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the weighted clusters combined into the composite score."
               ],
               "bullets": [
-                "Session Structure & Flow (4/5): 10-step blueprint followed; opening prayer delegated, newcomer welcome complete with testimonies, Guarantee delivered, Big Ideas review, cross-ref arc, closing commissioning prayer; no formal Ebbinghaus drill",
-                "Newcomer Welcome (5/5): John (first-timer), Eric, Mike welcomed with full member testimonies and Guarantee; Bryan personally engaged John ('why did you decide to show up?'); +3.0 newcomer bonus applied",
-                "Scripture Engagement (5/5): 19 cross-references across 12+ books — James primary + Titus 1, Rom 3/5/6, Heb 11, Eph 2, 2 Cor 5/13, 1 Cor 6, Matt 7, Gal 5, John 3/13; 80%+ of discussion scripture-grounded",
-                "Facilitation vs. Lecture (4/5): ~35-40% discussion-only leader talk (excludes welcome, excludes reading); good Socratic method; some teaching monologues in cross-ref sections",
-                "Application Questions (4/5): 6-7 DOK-scored Big Idea questions; strong evidence card bookend; functional atheist concept stayed intellectual; John's card not retrieved at close",
-                "Participant Engagement (4/5): 15+ substantive contributors; ~75% of group; two member-generated bumper stickers; peer-to-peer exchanges; no quiet member flag",
-                "Visual Aids (3/5): Blue Letter Bible used on-screen for G1344 word study (resolves James/Paul discrepancy); no color-coded chart, no two-column reference board; improvement from 2/5",
-                "Vulnerability / Authenticity (3/5): 3 vulnerability moments (personal guarantee story 3/5, Christmas tree theft 2/5, naming rights 3/5); one below baseline; +/-1 cap applied; no high-cost disclosure",
-                "Memory Reinforcement (3/5): Informal James tests recall at open (Bryan-led); new bumper sticks generated by members; no formal Ebbinghaus retrieval drill; 9th consecutive session without it",
-                "Homework References (4/5): The Guarantee delivered twice — in welcome and mid-lesson as personal testimony; Precept homework implicit; 'five days a week' framing present; no explicit 'Power of Four' reference",
-                "Prayer (5/5): Opening prayer delegated (member at 00:00); group commissioning prayer for Brendan and Glenn (3+ spontaneous member prayers at close); one of the strongest prayer moments of the James arc",
-                "Leader Development (4/5): Brendan publicly commissioned for Camp Tejas — Bryan named it his 'first leader role,' called it 'a big deal'; group gathered and prayed; Glenn Gordon (men's pastor) also affirmed; fully observable in-session signal"
+                "Teaching Craft: 76.0% × weight 33 → 25.08 pts",
+                "Building Ministry: 86.7% × weight 31 → 26.87 pts",
+                "Engaging People: 80.0% × weight 18 → 14.40 pts",
+                "Being Real: 80.0% × weight 18 → 14.40 pts",
+                "BASE (pre-bonus): — × weight 100 → 80.75 pts"
               ]
             }
           ],


### PR DESCRIPTION
## Summary

The Bible-Coach pipeline now sources the portal feed from each report's real `data` object (the same content the delivered PDF renders), so reports built in the current engine format carry the full delivered depth:

- the 8 **scorecard tables** (metric · this session · target · rating),
- narrative **Top-5 Strengths / Improvements** with quotes + timestamps,
- **Monologues**, **Key Moments** (timestamped, full narrative), and DOK-scored **Application Questions**.

This is a **data-only refresh** of `packages/backend-base/src/coach/coach.data.json`.

## Why no code change

The richer content maps entirely onto fields the schema already declares — the `feedback` prose blocks (`strengthsProse`/`improvementsProse`/`recommendationsProse`/`overview`) and the generic `sections` channel (`{ title, paragraphs?, bullets?, moments? }`). No `ReportSchema` / interface change is needed.

## Verify

- All 18 reports validate against `ReportSchema` via `Value.Check` (0 invalid) — so nothing is stripped from `/coach/reports` or the admin drill-in.
- `bun tsc` — clean.
- `bun test src/coach/coach.service.test.ts` — 11 pass.
- Bryan's 2026-07-16 report now carries 12 sections (8 `Scorecard — …` tables + Monologues + Key Moments + Application Questions + Score composition) and full-length prose paragraphs (~1000 chars).

## Landing order

Additive/data-only and order-independent with the pipeline PR (andytryba/bible-study-coaching #37): until it lands the portal simply shows the previous (thinner) content, so nothing breaks in prod. This refresh is what makes the full depth reach the portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EStqy8KBpFJHPfvnW37xYn

---
_Generated by [Claude Code](https://claude.ai/code/session_01EStqy8KBpFJHPfvnW37xYn)_