### PR TITLE
Refresh coach.data.json — blank Bryan's coachName

### DIFF
--- a/packages/backend-base/src/coach/coach.data.json
+++ b/packages/backend-base/src/coach/coach.data.json
@@ -54,7 +54,7 @@
       "name": "Bryan Bailey",
       "email": "bryanbailey59@gmail.com",
       "group": "Saturday Morning Study — Austin Ridge",
-      "coachName": "Andy Tryba",
+      "coachName": "",
       "isCoach": true,
       "zoomLink": "",
       "reports": [


### PR DESCRIPTION
## Summary

Data-only refresh of `packages/backend-base/src/coach/coach.data.json`. Bryan has no coach in the roster (founder / internal benchmark; Andy is program owner, not Bryan's coach), so his `coachName` is now `""` and the portal omits the "Coached by …" line on his profile. Other leaders (coached by Bryan) are unchanged.

No code/schema change — `coachName` is already `t.String()`, and `""` is valid.

## Verify

- `bun test src/coach/coach.service.test.ts` — 11 pass.
- `node -e "…coach.data.json… bryan-bailey.coachName"` → `""`.

Pairs with the pipeline PR (andytryba/bible-study-coaching #38) and the web PR (verse-mate-web #251) that hides the line when `coachName` is empty. Additive/order-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EStqy8KBpFJHPfvnW37xYn

---
_Generated by [Claude Code](https://claude.ai/code/session_01EStqy8KBpFJHPfvnW37xYn)_