### PR TITLE
Refresh coach.data.json — legacy Bryan reports render rich + July 18 (Sat) session

### DIFF
--- a/packages/backend-base/src/coach/coach.data.json
+++ b/packages/backend-base/src/coach/coach.data.json
@@ -946,197 +946,255 @@
           ],
           "bigIdeas": [],
           "feedback": {
-            "headline": "A strong session — strongest in Scripture Engagement and Session Structure & Flow, with the clearest next step in Facilitation vs. Lecture.",
+            "headline": "The eight tables below break out the session on every tracked metric; the full point-by-point score composition is in Appendix A13.",
             "strengths": [
-              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-              "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began."
+              "Newcomer Welcome — Multiple Member Testimonies and Bryan's Own Origin Story",
+              "Bryan's Political Partiality Confession — Vulnerability-as-Authority at Session Opening",
+              "Cross-Reference Depth — 15 Texts Building a Unified Theology of Wealth and Impartiality"
             ],
             "improvements": [
-              "Leader talk crowded out discussion; the balance leaned toward lecture.",
-              "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
-              "Homework went unmentioned, reducing its pull on the group."
+              "Closing Prayer Not Delegated — Second Consecutive Saturday Without It",
+              "'Mercy Triumphs Over Judgment' — The Synthesis Never Fully Landed",
+              "Visual Aids — VerseMate Carried the Word Studies; the Cumulative 'Riches' List Still Needs a Board"
             ],
             "recommendations": [
-              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-              "Next time, ask two members to share one thing from their homework in the first 10 minutes."
+              "Give The Guarantee to Jordan, Caleb, and Matt at the Top of L5",
+              "Pre-Select the Closing Prayer Person Before the Session Starts",
+              "Write the Riches Arc on the Whiteboard as You Build It"
             ],
             "overview": [
-              "A strong session — strongest in Scripture Engagement and Session Structure & Flow, with the clearest next step in Facilitation vs. Lecture. It scored 74.27/100 under the v3 weighted model.",
-              "The session played to its strengths in Scripture Engagement and Session Structure & Flow; the recommendations below turn Facilitation vs. Lecture into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+              "The eight tables below break out the session on every tracked metric; the full point-by-point score composition is in Appendix A13.",
+              "This report carries the full written coaching for the session: 5 areas of strength, 5 areas for improvement, and 5 recommendations for next session, scored 74.27/100 on the v3 weighted model."
             ],
             "strengthsProse": [
               {
-                "title": "Scripture Engagement anchored the session (5/5)",
+                "title": "Newcomer Welcome — Multiple Member Testimonies and Bryan's Own Origin Story",
                 "paragraphs": [
-                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 15 confirmed cross-references across 8 books; Romans 2:11 ('God shows no partiality') as concise closing anchor; discussion 75-80% scripture-grounded"
+                  "The session opened with Jordan (Big Jordan, returning after years), Matt, Caleb (invited by Brendan), and the group giving multiple genuine testimonies before the lesson began. A member who has been attending since 2004 gave a testimony about the study's depth ('it's pretty special if you put your time into it'). Justin shared about moving from Pittsburgh, PA and finding a men's fellowship home ('this is not an optional thing for me... we need a group where we can come together and be real'). Jordan described the contrast with his prior 10-year study ('this is radically different... it demands that you get in the work'). Caleb gave a brief introduction. Bryan then delivered his own complete origin story — starting at 39, how the group changed the way he thought, the fertilizer-sun-water metaphor for spiritual growth.",
+                  "This 12-minute introduction block did what the newcomer welcome is designed to do: every person in the room heard from multiple existing members why they keep coming back, in their own words, before Bryan said a single teaching word. Jordan heard 'this has made me a better husband, father, grandfather, neighbor, everything' from someone who has been studying for a year. Caleb heard 'this is not optional for me' from someone who moved across the country and found his fellowship home here. Bryan's own story — 'I noticed something was changing about me. I noticed how I was thinking about things was different' — is The Guarantee at its most personal form: not a promise, but a lived report."
                 ]
               },
               {
-                "title": "Session Structure & Flow anchored the session (4/5)",
+                "title": "Bryan's Political Partiality Confession — Vulnerability-as-Authority at Session Opening",
                 "paragraphs": [
-                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Full 10-step blueprint executed; closing prayer not delegated (Bryan ran it himself, session overran); ran ~10 min long"
+                  "At [00:52], Bryan confessed a present-tense partiality pattern to the room: 'If I see a certain bumper sticker on a car, I'm gonna try to run them off the road. I get frustrated... I'm against that person. I'm judging them based on how they pull a ballot. And that's wrong.' He then immediately named the theological consequence: 'If that person pulls into this church, what have I just done? I've made it very unwelcome... I'm hostile to God's intent.' Two paragraphs after that, he added: 'I think I'll make fun of it. Because it's so bad that I just get up and leave. If they show any arrogance, I'll just blast them.' — confessing not just the attitude but the behavior.",
+                  "This disclosure arrived before any member contributed a single application insight. Bryan did not ask 'does anyone show partiality?' and wait for someone else to go first. He named his own specific partiality, specified the triggering stimulus (a bumper sticker), described his internal response (hostility), and named the theological category ('hostile to God's intent'). Every member in the room who holds a political partiality of their own — which, in a politically engaged group in Austin in 2026, is essentially everyone — heard a leader confess the same sin they are privately holding. The question is not whether they show partiality; it is whether they will own it the way Bryan just did."
                 ]
               },
               {
-                "title": "Newcomer Welcome anchored the session (4/5)",
+                "title": "Cross-Reference Depth — 15 Texts Building a Unified Theology of Wealth and Impartiality",
                 "paragraphs": [
-                  "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
-                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
-                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Jordan, Caleb, Matt welcomed; 12-min intro with 4-5 member testimonies + Bryan's full origin story; The Guarantee not formally delivered"
+                  "The session built a riches arc through five different books before arriving at the primary James 2 passage: Ecclesiastes 5:10 (money doesn't satisfy), Proverbs 11:4 (riches fail in judgment), Proverbs 23:4-5 (wealth has wings), Luke 16:13-14 (cannot serve God and wealth), Mark 4:18-19 (riches choke the Word), Luke 12:15-21 (rich man parable), 1 Timothy 6:17-19 (instructions to the rich). This gave members a seven-reference theological scaffold before a single James 2 verse was read. When James 2:5 arrived — 'Did not God choose the poor of this world to be rich in faith?' — it arrived inside a context members had just built themselves, not in a vacuum. Then the royal law discussion brought Leviticus 19:18 (origin of 'love your neighbor'), John 8:31-32 and John 12:47-48 (law of liberty), 1 Corinthians 13:13 (love is greatest), and the session closed with Romans 2:11 ('God shows no partiality') — the most concise possible summary of the entire day.",
+                  "The Romans 2:11 close is worth noting specifically. Bryan set it up: 'As simple and blunt as possible' — and then read it. The group laughed. 'That's it. God shows no partiality. I could have just read that and gotten out of here.' This is the instructional move of a master teacher: building a 2-hour case for a theological truth, then showing the group that God said the whole thing in four words. The elaboration was not unnecessary — members needed the journey. But ending with the shortest possible statement made the journey's destination visible and memorable."
                 ]
               },
               {
-                "title": "Application Questions anchored the session (4/5)",
+                "title": "'Why Is This In The Bible?' — Surfacing the Theological Stakes First",
                 "paragraphs": [
-                  "Application questions pushed members from concept to life, several at the reason/apply level.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 9-10 Big Idea questions; 40% DOK 4; 'why is this in the Bible?' opener generated excellent theological framing"
+                  "After Jordan read James 2:2-4 (the man with a gold ring vs. the poor man in dirty clothes), Bryan did not ask 'what does this passage say?' He asked: 'Why is this in the Bible? Why does God have an issue with this? This is huge.' [00:39-00:41]. Members responded at exactly the right level: 'Jesus came for all men, all sinners, all people. This is directly against his nature.' 'The final command he left his disciples was to love each other the way that he loved them.' 'By going against Jesus's nature, it's a great misstep. You're literally working against your Father.'",
+                  "This question is structurally superior to 'what is partiality?' because it requires members to locate the offense inside God's character before they can analyze the behavior. Partiality is not just impolite or unfair — it is against the nature of a God who 'made all men in his image' and who 'chose the poor of this world to be rich in faith.' Getting that answer out in the first three minutes of the James 2 discussion meant every subsequent cross-reference (the riches arc, the royal law, the law of liberty) was building on a theological foundation members had already articulated. The question generated the scaffolding before the content arrived."
                 ]
               },
               {
-                "title": "Participant Engagement anchored the session (4/5)",
+                "title": "James Jones Closing Story — Kingdom Ripple Effect of Refusing Partiality",
                 "paragraphs": [
-                  "A high share of the room contributed substantively, called on by name.",
-                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
-                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 15+ named contributors; 7+ scripture readers; member felony story as session's highest-depth disclosure"
+                  "Bryan's closing story ran from [02:03] to [02:09] and was one of the most structurally complete illustrations of the arc: (1) He wore shorts to a P&G-area church in Ohio where everyone wore suits. The pastor's mother called him 'chairman of the shorts ministry' publicly. People thought the Bailey family was poor. The experience taught him personally how it feels to be on the receiving end of class-based judgment. (2) Contrast: a gang leader named James Jones was led to faith by Ben Huffine and came to their church. He sat only with Bryan and his wife — no one else would. Bryan and his wife helped him get a job building valves, helped him buy a house, spent years with his family. (3) Years later, James Jones's wife called Bryan's wife about two foster children living next door to them in poor conditions. 'She said, y'all need to get over here, take a look. Y'all been helping people.' The Baileys adopted their daughter in 2004 because they didn't show partiality to a gang leader.",
+                  "This story is not a general exhortation to be kind. It is a documented cause-and-effect chain: Bryan and his wife refused to judge James Jones by face value → James Jones's wife trusted them enough to call them → the Baileys adopted a child. Their daughter exists in their family because they applied James 2 to a man with gold teeth who had never had a job. The session ended not with Bryan telling the group to do better. It ended with Bryan showing them what happens when you don't."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "title": "Closing Prayer Not Delegated — Second Consecutive Saturday Without It",
                 "paragraphs": [
-                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: ~33-38% leader talk (discussion only); strong Socratic calling by name; 3-4 longer teaching sections pull ratio above target"
+                  "At [02:10:11], Bryan led the closing prayer himself: 'Pray a closeness in prayer. We ran way over. It's 9-1-1. 9-1-1. Dear Lord God...' The session ran to approximately 9:11 AM (started 7am, ~130 min). The rushed close is understandable — the session ran 10 minutes over. But the closing prayer delegation is not a logistics item. It is the last teaching signal of the session: it tells the group who is trusted to close the conversation with God, and it tells the person called on that they belong here enough to speak on behalf of the group.",
+                  "The fix is not timekeeper discipline (though that helps). It is pre-selection: before the session starts, tell the person you plan to call on for closing prayer. 'I'm going to ask you to close us out today.' Now the prayer is ready regardless of whether the session runs 90 or 135 minutes. The delegation can happen even in a hurried close — 'Austin, bring us home.' Pre-selection removes the cognitive load of choosing in the moment while time pressure is high. This is the same delegation pattern that works for the opening prayer — apply it to the close."
                 ]
               },
               {
-                "title": "Memory Reinforcement is a growth area (3/5)",
+                "title": "'Mercy Triumphs Over Judgment' — The Synthesis Never Fully Landed",
                 "paragraphs": [
-                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Comprehensive James ch.1 Big Ideas review (~14 min, 6 ideas, member-participatory); bumper sticker generation at close; guided not unsupported Ebbinghaus recall"
+                  "At [01:47-01:49], Bryan asked: 'Why does mercy triumph over judgment? How could mercy triumph over judgment?' The group generated rich attempts: 'Mercy just negates the judgment itself.' 'It nullifies it.' 'It's like it supers past it — it goes beyond it.' Bryan affirmed each one but never synthesized them into a definitive statement. The conversation then moved toward the member's felony story (which illustrated the point perfectly), but the conceptual synthesis — what precisely makes mercy superior to judgment at the level of God's character — was left in fragments.",
+                  "The synthesis that was available: 'You're all pointing at the same thing — mercy doesn't just subtract the punishment, it creates a new reality. Judgment says you owe a debt. Mercy says the debt is gone and you are now someone new. That's why it triumphs — it's not less than judgment, it is categorically beyond it. Judgment works backward from what you did. Mercy works forward from who you can become.' One clear synthesis statement, spoken before the member's felony story, would have given members a theological framework to carry the story inside. Instead, the story illustrated an idea that wasn't quite yet fully named. The illustration did the work the teaching hadn't finished — but that's not the designed sequence."
                 ]
               },
               {
-                "title": "Homework References is a growth area (3/5)",
+                "title": "Visual Aids — VerseMate Carried the Word Studies; the Cumulative 'Riches' List Still Needs a Board",
                 "paragraphs": [
-                  "Homework went unmentioned, reducing its pull on the group.",
-                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Directed Caleb and Jordan to contact Lance or John for homework materials; explained 5-day format at close [02:04]; The Guarantee not formally delivered"
+                  "Credit where due: VerseMate was on screen throughout for the Greek/Hebrew word definitions (face value, partiality, the 'royal law') — exactly the on-screen word-study visual the model rewards, which is why Visual Aids scored 4/5 this session. The remaining gap is structural, not word-level: Bryan explicitly asked someone to have 'a white piece thing' out to write down the riches summary during the Ecclesiastes-through-1-Timothy sequence [00:55-01:22]. The list was the right idea — members were reading 7 references in sequence and needed a visual anchor for the cumulative summary. But the list stayed inside the room's working memory rather than on a surface everyone could see. The final synthesis Bryan delivered — 'Riches: temporary, don't satisfy, don't last, compete with God, choke spiritual life, create a false sense of security, root of sin' — is precisely the content of a whiteboard column. If it had been on a board, every member would have photographed it and carried it out.",
+                  "There are three sessions remaining in James 2 content (or it will recur in the works/faith section of James 2:14-26). The riches arc table takes 10 minutes to build outside of class and can be a standing visual the group references each week it recurs. One column: Reference. Second column: What it says about wealth. Third column: James 2 connection. The session already built this mentally — it just never made it to a surface where members could take it with them. This is the same recommendation from L4 Thursday and every session before it. Visual aids are 2/5 for the sixth consecutive session."
                 ]
               },
               {
-                "title": "Prayer is a growth area (3/5)",
+                "title": "The Guarantee Not Delivered for Jordan, Caleb, and Matt",
                 "paragraphs": [
-                  "Prayer was leader-only or rushed; the group’s voice was thin.",
-                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
-                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Opening prayer delegated to a member (at start of recording); closing prayer not delegated — Bryan led it himself due to time pressure at 9:11 AM; prayer chain not referenced"
+                  "At the close, Bryan directed Caleb (and possibly Jordan and Matt) to contact Lance or John for the Precept homework materials: 'if you're interested in that, get through Lance or John.' He also explained the format — 'it asks you questions... it's a productive struggle... that's how God teaches us.' [02:04]. That is a description of what the homework is, but it is not The Guarantee. The Guarantee is the enrollment promise: 'If you come in here, and you do the homework, five days a week... God will begin to speak to you. It's guaranteed. I guarantee, 100%.'",
+                  "The difference matters because the description gives newcomers information about a resource; The Guarantee gives them a reason to stake their week on it. Jordan has been in a prior 10-year study where he could be a 'silent participant.' He came to this group and heard it's different. What he did not hear this morning was why doing the homework will transform him specifically — the promised outcome, delivered with certainty, by the person who has seen it work 350 times. The Guarantee converts a curious returner into a committed one. It costs 30 seconds to deliver. At the start of L5, give it directly to Jordan and Caleb."
                 ]
               },
               {
-                "title": "Leader Development is a growth area (3/5)",
+                "title": "Forgiveness Without Being Asked — A Pastoral Question Left Unresolved",
                 "paragraphs": [
-                  "No in-session development of another leader was observable this week.",
-                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Background signals only (directing newcomers through Lance/John); no visible in-session apprenticeship; multiplication model referenced in newcomer welcome"
+                  "At [01:45:20], a member raised: 'There's this belief that I've heard floating around that some people say they can prove it biblically that you don't necessarily have to forgive someone else for what they've done to you unless they've asked for forgiveness.' Bryan acknowledged it ('interesting'), noted it's in some church contexts, mentioned this verse challenges it, then pivoted to 'Satanists believe in vengeance.' He followed with the poison-drinker metaphor and a strong statement: 'To withhold forgiveness is to show contempt for God.' That is a good answer. But the specific claim — 'you only have to forgive if they ask' — was never directly engaged.",
+                  "This is a pastoral question many men in the Saturday group carry without naming it — men who have been genuinely wronged by a parent, a spouse, a business partner, and have been told by someone they trust that they don't have to forgive unless asked. Bryan's answer is correct; it just answered a slightly different question. The direct answer to 'do I have to forgive if they haven't asked?': 'Yes. Here's why. Jesus forgave the men crucifying him while they were still doing it — before they asked. That's the model you have. You don't need their repentance to release them. You need yours.' The member who asked is holding this question about someone specific. They heard a partial answer. A full answer may be worth giving directly before L5."
                 ]
               }
             ],
             "recommendationsProse": [
               {
-                "title": "Next session — Facilitation vs. Lecture",
+                "title": "Give The Guarantee to Jordan, Caleb, and Matt at the Top of L5",
                 "paragraphs": [
-                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Jordan returned after years away. Caleb was invited by Brendan. Matt arrived Saturday. All three heard a strong newcomer welcome with member testimonies — but none received The Guarantee: 'If you come in here, and you do the homework, five days of homework... God will begin to speak to you. It's guaranteed. I guarantee, 100%.' Jordan heard a 10-minute explanation of why this study is different. He did not hear the specific promise that will make him open the workbook on Monday morning. The Guarantee is the enrollment mechanism that converts curious to committed. Deliver it to all three at the top of next session, before the Big Ideas review. 30 seconds, once."
                 ]
               },
               {
-                "title": "Next session — Memory Reinforcement",
+                "title": "Pre-Select the Closing Prayer Person Before the Session Starts",
                 "paragraphs": [
-                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "The closing prayer was not delegated this session because the time pressure at 9:11 AM left Bryan leading it himself. The fix is not better time management — it is pre-selection. Before the session begins, identify who will close: 'Austin, I'm going to call on you to close us out today.' Then, regardless of whether the session runs 90 or 135 minutes, you have a person ready. The cognitive load of choosing under time pressure is what causes the delegation to fail. Pre-selection eliminates that load. You can still delegate the opening in-the-moment; the closing needs a name in place before 7am."
                 ]
               },
               {
-                "title": "Next session — Homework References",
+                "title": "Write the Riches Arc on the Whiteboard as You Build It",
                 "paragraphs": [
-                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "The Ecclesiastes-through-1-Timothy arc Bryan built in this session was 7 references long, covered 5 themes, and led to a final synthesis ('riches: temporary, don't satisfy, compete with God, choke spiritual life, root of sin'). A member had a 'white piece thing' out to take notes. The entire group needed that list to be on a board where everyone could see it accumulate in real time. As each reference is read: write the reference + one-line summary. By the time you reach 1 Timothy 6:17-19, there are 7 lines on the board. The final synthesis — 'and you're honoring the person who carries all of this' — lands visually, not just verbally. This is the same recommendation from the prior three sessions. The content is already built. The board just needs to hold it."
                 ]
               },
               {
-                "title": "Next session — Prayer",
+                "title": "Synthesize 'Mercy Triumphs' Before the Story Illustrates It",
                 "paragraphs": [
-                  "Next time, ask one member to open and a different member to close in prayer.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "At [01:47], three members came very close to the same theological insight ('negates,' 'nullifies,' 'supers past it'). One sentence of synthesis before the felony story would have given members a conceptual anchor: 'You're all saying the same thing — mercy doesn't reduce judgment, it transcends it. They operate on different scales.' That sentence, spoken before the story arrives, makes the story prove the concept rather than replace it. The practice: when multiple members are circling the same answer with different vocabulary, name the convergence, state the unified form, then introduce the illustration. It takes 20 seconds and it is the difference between the group leaving with a memorable story (excellent) and leaving with a memorable concept illustrated by an unforgettable story (even better)."
                 ]
               },
               {
-                "title": "Next session — Leader Development",
+                "title": "Follow Up on the Forgiveness Question Privately Before L5",
                 "paragraphs": [
-                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "A member asked whether forgiveness is required without being asked [01:45]. Bryan gave a strong answer ('to withhold forgiveness is to show contempt for God') but didn't directly engage the specific claim that some people hold as a theological shield. The person who asked is almost certainly holding that question about a specific person. A text before L5: 'Hey — you asked a good question on Saturday about forgiveness. I've been thinking about it. The answer to the specific version of your question is [see below]. Can we grab coffee?' The direct answer they may need: 'Jesus forgave the men crucifying him while they were still doing it — before any of them asked. That's your model. You don't need their repentance to release them. You need yours.' This conversation is worth 15 minutes before it surfaces again from the pulpit and lands in them without a guide present. Bible Leader Coaching | Bryan Bailey | June 6, 2026"
                 ]
               }
             ]
           },
           "sections": [
             {
-              "title": "Score composition",
-              "paragraphs": [
-                "How the four weighted clusters and any session bonuses combined into the composite score."
-              ],
+              "title": "Scorecard — 1. Attendees",
               "bullets": [
-                "Teaching Craft: 80% × weight 33 → 26.40 pts",
-                "Building Ministry: 66.7% × weight 31 → 20.67 pts",
-                "Engaging People: 70% × weight 18 → 12.60 pts",
-                "Being Real: 70% × weight 18 → 12.60 pts",
-                "Base (sum of cluster contributions): 72.27 / 100",
-                "Session bonuses: newcomer growth +2",
-                "Session score: 74.27 / 100"
+                "Total attendees: ~15-20 men (room + online)  (Target: Consistent Saturday group attendance)  → STRONG",
+                "Newcomers / returnees: 2-3 — Jordan (Big Jordan, returning after years), Caleb (invited by Brendan), Matt  (Target: Organic newcomer growth)  → ON TARGET"
               ]
             },
             {
-              "title": "Coaching notes by dimension",
-              "paragraphs": [
-                "The per-dimension rationale behind each score on the 12-dimension scorecard."
-              ],
+              "title": "Scorecard — 2. Scripture Focus",
               "bullets": [
-                "Session Structure & Flow (4/5): Full 10-step blueprint executed; closing prayer not delegated (Bryan ran it himself, session overran); ran ~10 min long",
-                "Newcomer Welcome (4/5): Jordan, Caleb, Matt welcomed; 12-min intro with 4-5 member testimonies + Bryan's full origin story; The Guarantee not formally delivered",
-                "Scripture Engagement (5/5): 15 confirmed cross-references across 8 books; Romans 2:11 ('God shows no partiality') as concise closing anchor; discussion 75-80% scripture-grounded",
-                "Facilitation vs. Lecture (3/5): ~33-38% leader talk (discussion only); strong Socratic calling by name; 3-4 longer teaching sections pull ratio above target",
-                "Application Questions (4/5): 9-10 Big Idea questions; 40% DOK 4; 'why is this in the Bible?' opener generated excellent theological framing",
-                "Participant Engagement (4/5): 15+ named contributors; 7+ scripture readers; member felony story as session's highest-depth disclosure",
-                "Visual Aids (4/5): VerseMate on screen for the Greek/Hebrew word definitions (royal law, partiality, 'face value'); growth edge is a board for the cumulative 'riches' list, which stayed in the room's memory",
-                "Vulnerability / Authenticity (4/5): 3 moments: political partiality confession [00:52]; James Jones / adoption closing story [02:03]; shorts ministry church judgment story [02:03]",
-                "Memory Reinforcement (3/5): Comprehensive James ch.1 Big Ideas review (~14 min, 6 ideas, member-participatory); bumper sticker generation at close; guided not unsupported Ebbinghaus recall",
-                "Homework References (3/5): Directed Caleb and Jordan to contact Lance or John for homework materials; explained 5-day format at close [02:04]; The Guarantee not formally delivered",
-                "Prayer (3/5): Opening prayer delegated to a member (at start of recording); closing prayer not delegated — Bryan led it himself due to time pressure at 9:11 AM; prayer chain not referenced",
-                "Leader Development (3/5): Background signals only (directing newcomers through Lance/John); no visible in-session apprenticeship; multiplication model referenced in newcomer welcome"
+                "Cross-references: 15 (Eccl 5:10; Prov 11:4; 23:4-5; Luke 16:13-14; Mk 4:18-19; Luke 12:15-21; 1 Tim 6:17-19; Lev 19:18; John 8:31-32; 12:47-48; 1 Cor 13:13; Rom 2:11; plus James 2:1-13 primary text)  (Target: 6+ per session)  → STRONG",
+                "Leader talk ratio (with scripture reading): ~40-45%  (Target: ≤35%)  → NEEDS WORK",
+                "Leader talk ratio (discussion only): ~33-38%  (Target: ≤30%)  → ON TARGET",
+                "% discussion grounded in scripture: ~75-80%  (Target: ≥70%)  → STRONG",
+                "Time to first scripture reading: ~13-15 min (after Big Ideas review + newcomer welcome)  (Target: Within 15 min of lesson start)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 3. Time Management",
+              "bullets": [
+                "Total session time: ~130 min  (Target: 90–120 min)  → ON TARGET",
+                "Big Ideas review + context: ~12-14 min — cumulative James ch.1 review with member participation  (Target: 5–15 min)  → STRONG",
+                "Newcomer welcome / introductions: ~12 min — 4-5 member testimonies + Bryan's own origin story  (Target: 7–25 min)  → STRONG",
+                "Riches cross-reference arc: ~30 min — Eccl through 1 Tim; member reads, Bryan synthesizes  (Target: 20–35 min)  → STRONG",
+                "James 2 primary text teaching: ~50 min — favoritism, royal law, law of liberty, mercy  (Target: 45–60 min)  → STRONG",
+                "Closing application + prayer: ~12 min — bumper sticker synthesis, Bryan's closing story, prayer  (Target: 8–12 min)  → STRONG",
+                "Topic drift: ~4 min (post-session casual conversation — beard and hair comments)  (Target: < 10 min)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 4. Application Questions",
+              "bullets": [
+                "Big Idea questions (DOK scored): 9-10 questions  (Target: 5–7 per session)  → STRONG",
+                "DOK Level 4 (apply to life): 4 (~40%)  (Target: ≥25%)  → STRONG",
+                "DOK Level 3 (reason/justify): 4 (~40%)  (Target: ≥35%)  → STRONG",
+                "DOK Level 2 (compare/analyze): 1-2 (~15-20%)  (Target: ≤40%)  → STRONG",
+                "DOK Level 1 (recall — excluded): ~12 scaffolding prompts (not scored)  (Target: Excluded from DOK)  → N/A",
+                "Application spacing: Distributed throughout; bumper sticker synthesis at close with full group  (Target: Woven throughout + close)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 5. Engagement",
+              "bullets": [
+                "Named participants engaged: 15+ called by name or contributing by name  (Target: 70–80% of attendees)  → STRONG",
+                "Members who read scripture aloud: 7+ named readers (Jordan, Taylor, Kevin, Reed, Austin, Brendan, Kieran)  (Target: Multiple readers per session)  → STRONG",
+                "Closing synthesis participation: Yes — multiple members contributed bumper stickers; member felony story as final illustration  (Target: Full group participation)  → STRONG",
+                "Wait time after questions: Moderate — Bryan occasionally self-answered after brief pause  (Target: 3–5 sec (Rowe 1972))  → ON TARGET",
+                "Visual aids used: VerseMate on screen for Greek/Hebrew word definitions; no board for the cumulative 'riches' list  (Target: On-screen word tools + board)  → ON TARGET",
+                "Newcomer engagement: Jordan, Caleb, Zach contributed substantively in discussion  (Target: Newcomers contribute in first session)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 6. Leadership",
+              "bullets": [
+                "Vulnerability moments (leader): 3 — political partiality confession [00:52]; James Jones / adoption closing story [02:03]; personal story about wearing shorts to church in Ohio [02:03]  (Target: 2–3 per session, weighted by depth)  → STRONG",
+                "Teaching monologues > 90 sec: ~3-4 (wealth application section, favoritism etymology, law of liberty synthesis)  (Target: < 3 per session)  → NEEDS WORK",
+                "Closing prayer delegation: Not delegated — Bryan led the closing prayer himself as session ran over time  (Target: Delegate to a different member)  → NEEDS WORK"
+              ]
+            },
+            {
+              "title": "Scorecard — 7. Question Quality",
+              "bullets": [
+                "% open-ended Big Idea questions: ~8 of 10 (80%)  (Target: ≥70%)  → STRONG",
+                "% requiring scripture to answer: ~60%  (Target: ≥50%)  → STRONG",
+                "Follow-up probes used: Moderate — consistent 'what's the bumper sticker?', 'take a crack at it', 'give me the logic'; fewer 'what do you mean?' depth probes  (Target: Per Webb DOK standards)  → ON TARGET",
+                "Q-to-S ratio (discussion): ~42:58 (consistent with arc; theological sections pull ratio up)  (Target: 60:40 Q:S minimum)  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Scorecard — 8. Study Method & Communication",
+              "bullets": [
+                "Big Ideas review at session start: Thorough guided recall of James ch.1 — 6 big ideas reviewed with member participation; ~14 min  (Target: Ebbinghaus unsupported retrieval)  → ON TARGET",
+                "Big Ideas at close: Yes — group generated bumper stickers for James 2 ('partiality reveals a dead faith'; 'God shows no partiality'; 'God never blesses the flesh')  (Target: 5–6 per session)  → STRONG",
+                "Homework references: Referenced at close — Bryan directed Caleb and Jordan to contact Lance or John for Precept materials; explained 5-day format  (Target: Explicit Precept ref + The Guarantee)  → ON TARGET",
+                "Prayer chain referenced: Not explicitly referenced  (Target: Prayer chain infrastructure active)  → NEEDS WORK"
+              ]
+            },
+            {
+              "title": "Key Moments",
+              "moments": [
+                {
+                  "detail": "Member's Second Felony and the Judge's Mercy  (🟢 Capitalized · Being Real)\n\nWhat happened: In the discussion of mercy triumphing over judgment, a member disclosed: 'So when I was on my second, at 16 years old, I was on my second felony. And I was supposed to be sent away... to like a baby penitentiary, I guess. And because she knew the judge was my dad's DA and my father was murdered, and years later, she was now my judge, she knew the background. She knew that I just needed someone like to believe in me.' [01:48:35-01:49:03]. The judge showed mercy — didn't put him in the system. 'I never returned after that. I was good after that.' Bryan responded: 'Show mercy. Show mercy.' And then: 'That judge, because she knew something about your situation, showed mercy and didn't give you the judgment you deserved... In how did that impact you?' The member: 'It was repentance, it was a complete turn. If she would've judged, I would've had to buckle in and get my mind back into the game and survive.' Bryan: 'Mercy triumphed. That's a great example.'\n\nWhy it mattered: This member disclosed a second felony, a murdered father, and a 16-year-old who was one court decision away from the system. He carried James 2:13 ('mercy triumphs over judgment') as a verse he had been holding since childhood: 'I just remembered this verse from being a child. I remembered this verse, and I always held on to it because of that.' [01:50:37]. When a member says a verse has been personally meaningful to them since childhood — and then explains why, with a story about mercy literally determining the direction of their life — the group is in a different conversation than they were ten minutes ago. Bryan capitalized it immediately. Every member heard that this verse is not abstract theology. It is the reason someone in this room is here instead of in the system. That is what sticks.\n\nWhat would make it bigger: Bryan asked the impact question ('how did that impact you?') which is the only probe needed when a member discloses a life-altering moment. The disclosure was already complete; the probe gave the member space to name the consequence — and the consequence ('it was repentance, a complete turn') is the exact meaning of mercy: not cancellation of consequences, but transformation of trajectory. Then Bryan connected it to the text explicitly. This is the three-part sequence: hold the moment, probe for impact, connect to the passage. Bryan executed all three. To replicate in every heavy disclosure: pause, one impact question, explicit text connection.",
+                  "timestamp": "[01:48:35]"
+                },
+                {
+                  "detail": "Bryan's Political Partiality Confession  (🟢 Capitalized · Being Real)\n\nWhat happened: Bryan said: 'I've got one for darn sure. Political. If I see a certain bumper sticker on a car, I'm gonna try to run them off the road. I get frustrated... I'm against that person. I'm judging them based on how they pull a ballot. And that's wrong.' [00:52]. Then: 'If that person pulls into this church, what have I just done? I've made it very unwelcome... I'm hostile to God's intent.' And later: 'If they show any arrogance, I'll just blast them. Put them on blast, and they get up, and they know.' Bryan also shared the group's racial diversity as a counter-example: 'You know what I mean? Look at this group. This white group's so cool.' (said with humor about the group's actual diversity).\n\nWhy it mattered: In a session about showing no partiality, the leader's job is not to explain partiality — it is to model repentance from it. Bryan did not confess a past sin he has overcome. He confessed a present pattern he is still managing. The group heard their leader name a political partiality in a room that almost certainly contains men on both sides of the political line he referenced. That takes something. Members who hold their own partiality quietly — which is to say, all of them — were given permission to own it and name it by watching their leader go first.\n\nWhat would make it bigger: The specificity of the triggering stimulus ('a certain bumper sticker on a car') is what makes the confession land. Vague vulnerability ('I struggle with judgment sometimes') is safe and produces nothing. Specific vulnerability ('I see a specific bumper sticker and my first thought is hostility') is risky and produces everything. To replicate: when the text confronts a sin pattern, ask yourself which specific form of that pattern you carry right now — not historically, right now. Then name that form. The specificity is what gives everyone else in the room permission to name theirs.",
+                  "timestamp": "[00:52]"
+                },
+                {
+                  "detail": "The James Jones Adoption Closing  (🟢 Capitalized · Being Real)\n\nWhat happened: Bryan closed the session with a two-part personal story. Part 1: He wore shorts to a P&G-area church in Ohio where everyone wore suits. The pastor's mother called him 'chairman of the shorts ministry' audibly in front of others. People assumed the Bailey family was poor. Bryan: 'What I found out when we moved... people literally thought we were poor. It came out that people felt sorry for us.' [02:06:00-02:06:10]. He told his wife: 'I'm done wearing long pants to church.' Part 2: A gang leader named James Jones was led to faith by Ben Huffine and came to their church. In a predominantly one-race congregation, James Jones sat only with Bryan and his wife. Bryan helped him get a job building valves, helped him buy a house. Years later, James Jones's wife called Bryan's wife about two foster children: 'She said, y'all need to get over here, take a look.' The Baileys adopted one of them in 2004. Bryan: 'And so... don't do that. Please, okay?'\n\nWhy it mattered: The session spent 130 minutes arguing that partiality is a sin. Bryan's closing story showed what not-partiality produces in a real life over 20 years. Their daughter exists in their family because they didn't judge James Jones by face value in an Ohio church in the early 2000s. That is not a theological argument. It is a family. Every member heard the closing prayer and thought about what their refusal to show partiality might produce in the next 20 years. That is the teaching reaching its maximum effective range.\n\nWhat would make it bigger: The story has a concrete outcome that is verifiable and permanent. 'We adopted our daughter in 2004 because we didn't show partiality to a gang leader' is not a hypothetical benefit of following James 2. It is a child. When an illustration has a named result — a person, a decision, a date — it functions as evidence, not just analogy. The two-part structure (receiving partiality → refusing to give it → consequence) is also narratively complete: it shows the sin, then its opposite, then what the opposite produces. That is the full arc of repentance in one story.",
+                  "timestamp": "[02:03]"
+                },
+                {
+                  "detail": "'Why Is This In The Bible?'  (🟢 Capitalized · Teaching Craft)\n\nWhat happened: After Jordan read James 2:2-4, Bryan asked: 'Why is this in the Bible? Why does God have an issue with this? This is huge.' [00:39-00:41]. The response was immediate and theologically precise: 'Jesus came for all men, all sinners, all people. This is directly against his nature.' A member added: 'He made all men in his image... in Revelation it says all nations will eat from the tree of life.' Another: 'The final command he left his disciples was to love each other the way that he loved them... for us to refuse to love each other that way is a great misstep. You're literally working against your Father.' Bryan synthesized: 'You're literally working against his nature and him.'\n\nWhy it mattered: 'Why is this in the Bible?' is the most efficient theological framing question available. It forces members to reason about the passage's relationship to what they know about God rather than simply describe what the passage says. The answers it generated (against God's nature; violates the image of God in every person; contradicts the final command; makes you an enemy of the Father) gave Bryan a theological platform he didn't have to build himself. The group built it. He just asked the right question.\n\nWhat would make it bigger: The question is open-ended, requires no prior knowledge to attempt, and has no single correct answer — which means everyone can take a crack. But it produces high-level answers because it requires members to think about God's character rather than recite content. This is a reusable question for any passage: 'Why is this in the Bible?' works for every difficult teaching (James 3 on the tongue, James 4 on quarrels) and produces the same kind of theological grounding from the group. Add it to the standard opening question set for every new passage.",
+                  "timestamp": "[00:41]"
+                },
+                {
+                  "detail": "'Why Does Mercy Triumph?'  (🔵 Pivot Point · Teaching Craft)\n\nWhat happened: Bryan asked: 'Why does mercy triumph over judgment? How could mercy triumph over judgment — mercy doesn't even seem to be... judgment is giving people what they deserve. Mercy's not giving people what they deserve. So how does one triumph over the other?' [01:47:19-01:47:45]. Members attempted: 'Mercy just negates the judgment itself.' 'It nullifies it.' 'It doesn't negate it — it supers past it. It goes beyond it.' Bryan engaged each answer: 'Mercy nullifies it... yeah, judgment's here and you just do something that's past it. Almost. You still deserve the judgment.' Then a member's felony story arrived and illustrated the concept.\n\nWhy it mattered: Three members came extremely close to the same theological insight from three different directions ('negates,' 'nullifies,' 'supers past it'). They were sensing the same truth without the language to name it exactly. The missing synthesis: 'You're all pointing at the same thing. Mercy doesn't reduce judgment — it transcends it. Judgment operates on what you deserve. Mercy operates on who God chooses to make you. They're not on the same scale. That's why mercy wins: it's playing a different game entirely.' That statement, spoken before the felony story, would have given members a conceptual frame to carry the story inside. Instead, the story did the work the teaching hadn't quite finished. Both are valuable — but the designed sequence is synthesis first, illustration second.\n\nWhat would make it bigger: When three members attempt the same idea with different vocabulary, name the convergence. 'Negate, nullify, transcend — you're all saying the same thing.' Then state the unified form. The group has earned the synthesis; give it to them before the story illustrates it. The move costs 20 seconds and permanently anchors the vocabulary for every subsequent mercy conversation in their lives.",
+                  "timestamp": "[01:47]"
+                }
+              ],
+              "paragraphs": [
+                "These are the disproportionate moments in this session — the exchanges that shaped what this group will remember, believe, and do. Aggregated scores average these away; Key Moments names each one explicitly so Bryan can rewatch with intent."
+              ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "'Why is this in the Bible? Why does God have an issue with this?' [00:39] — DOK 3 — Reason/justify the passage's theological necessity. Multiple members answered from God's nature (all men in his image; Jesus's final command; against God's character). Session's best opening frame question. — STRONG",
+                "'What appears to be the problem [in James 2:2-4]?' [00:37] — DOK 2 — Identify and analyze from text. Members: 'unwarranted special attention based on income'; 'judges with human motives.' Correct text-based identification. — ON TARGET",
+                "'How do I treat people when there's nothing for me to gain from them? Do the people you surround yourself with look like you — same income, age, race, intelligence?' [00:51] — DOK 4 — Self-examination of relational patterns. Bryan answered his own question first (political partiality, Aggie bumper stickers). Multiple members reflected on their own homogeneous social circles. — STRONG",
+                "'Why would a poor person be a better target for God than a rich person?' [00:47] — DOK 3 — Reason/justify from theology of dependence. Members: 'they need to rely on him rather than worldly resources.' Bryan synthesized: 'The poor's advantage is where's the personal need?' Strong DOK 3 reasoning. — STRONG",
+                "'When or if — is it ever okay to pray for money?' [01:08] — DOK 4 — Personal application / self-examination. Bryan guided to the distinction: my will vs. thy will. 'God will never, ever, ever bless your flesh.' Generated significant cross-member discussion including the Job connection and the stewardship parable. — STRONG",
+                "'What are the instructions to the rich [in 1 Tim 6:17-19]? What is he saying?' [01:17] — DOK 2-3 — Extract commands from text and analyze their logic. Members: 'Don't be conceited,' 'Fix your hope on God,' 'Be rich in good works,' 'Be generous.' Bryan synthesized: 'Your riches don't mean squat — your good works are your return.' — STRONG",
+                "'What is the royal law? How do you know that?' [01:22] — DOK 2 — Identify from text; origin question. Members: 'love your neighbor as yourself.' Bryan pressed to the origin (Leviticus 19:18). Reed then read Lev 19:18 — text confirmed. Good DOK 2 foundation. — ON TARGET",
+                "'What's his logic here [James 2:8-11 — partial obedience = all broken]?' [01:25] — DOK 3 — Reason from James's argument structure. Members: 'partial obedience is disobedience.' Bryan: 'Think of it like a pane of glass — throw a baseball through the center, break a corner — it's still broken glass.' Strong DOK 3 analogical reasoning. — STRONG",
+                "'Why does mercy triumph over judgment?' [01:47] — DOK 3-4 — Reason about theological priority. Members attempted: 'negates it,' 'nullifies it,' 'supers past it.' Partially synthesized; then illustrated by member felony story. See Key Moments — Pivot Point. — ON TARGET",
+                "'What's the bumper sticker for today?' [01:53] — DOK 2-3 — Synthesis/recall of session theme. Members offered: 'partiality reveals a dead faith,' 'God shows no partiality,' 'God never blesses the flesh.' Bryan endorsed 'partiality reveals a dead faith' as the clearest summary. Effective close. — STRONG"
+              ],
+              "paragraphs": [
+                "Big Idea questions only (DOK scored): 9-10 questions. Scaffolding / reading prompts (DOK 1, excluded): ~12 navigation/recall prompts ('Read James 2:2-4', 'Give me the bumper sticker', 'What does verse 13 say?'). DOK distribution: 4 at Level 4 (~40%), 4 at Level 3 (~40%), 1-2 at Level 2 (~15-20%). Q-to-S ratio in discussion: ~42:58 (below 60:40 target; the riches cross-reference section and the law of liberty synthesis pulled leader ratio up in the session's middle third)."
               ]
             }
           ],
@@ -1260,197 +1318,247 @@
           ],
           "bigIdeas": [],
           "feedback": {
-            "headline": "A strong session — strongest in Scripture Engagement and Vulnerability / Authenticity, with the clearest next step in Visual Aids.",
+            "headline": "Bryan's highest cross-reference density in the James arc (22+ texts), his most personal vulnerability on partiality, and the moment Darrell's sponsee drove drunk and killed a man — James 2 arriving in real time.",
             "strengths": [
-              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-              "Costly personal honesty set a tone of safety, and members disclosed in turn.",
-              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place."
+              "Cross-Reference Density — 22+ Texts, Highest in the James Arc",
+              "Bryan's Partiality Confession — The Arc's Deepest Personal Vulnerability",
+              "Royal Law Application Question — DOK 4 at Session Apex"
             ],
             "improvements": [
-              "The session leaned audio-only; a visual anchor would aid retention.",
-              "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
-              "Leader talk crowded out discussion; the balance leaned toward lecture."
+              "Visual Aids — Zero Used in the Highest-Content Session of the Arc",
+              "Darrell's Sponsee Disclosure — The Heaviest Moment Left Unreceived",
+              "Newcomer Protocol — Chris and John Received Homework Instructions But Not The Guarantee"
             ],
             "recommendations": [
-              "Next time, put one word-study lookup or a simple table on screen during the key term.",
-              "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
-              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds."
+              "Deliver The Guarantee to Chris and John at the Top of L5",
+              "Open L5 with a Full 4-Minute Ebbinghaus Recall Drill",
+              "Prepare the Riches Arc and 613 Laws Visual Before L5"
             ],
             "overview": [
-              "A strong session — strongest in Scripture Engagement and Vulnerability / Authenticity, with the clearest next step in Visual Aids. It scored 76.36/100 under the v3 weighted model.",
-              "The session played to its strengths in Scripture Engagement and Vulnerability / Authenticity; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+              "Bryan's highest cross-reference density in the James arc (22+ texts), his most personal vulnerability on partiality, and the moment Darrell's sponsee drove drunk and killed a man — James 2 arriving in real time.",
+              "This report carries the full written coaching for the session: 5 areas of strength, 5 areas for improvement, and 5 recommendations for next session, scored 76.36/100 on the v3 weighted model."
             ],
             "strengthsProse": [
               {
-                "title": "Scripture Engagement anchored the session (5/5)",
+                "title": "Cross-Reference Density — 22+ Texts, Highest in the James Arc",
                 "paragraphs": [
-                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 22+ cross-references — arc high; 80-85% discussion grounded in scripture; first scripture within 15 min"
+                  "The session built a 9-text riches arc before the James 2 passage was even read: Eccl 5:10 (money doesn't satisfy), Prov 11:4 (wealth fails on judgment day), Prov 11:28 (trust in riches falls), Prov 23:4-5 (wealth has wings), Luke 16:13-14 (cannot serve God and money), Mark 4:18-19 (riches choke the Word), Luke 12:15-21 (rich man builds bigger barns), 1 Tim 6:9-10 (love of money = root of all evil), 1 Tim 6:17-19 (rich should be generous not trusting). That's nine references establishing a single unified theme before the primary text arrived. Then James 2:1-13 was read and discussed — followed by 13 additional cross-references covering the OT justice ethic (Lev 19:15, Deut 1:17, Deut 16:18-20, Ps 82:1-4), law of liberty (Jas 1:25, John 8:31-32, John 12:47-48, 2 Cor 5:10), and the purpose of the law (Matt 5:17-20, Rom 6:1-2, 6:12-13, 8:3-4, Jude 4).",
+                  "Twenty-two confirmed cross-references in one session. The L3 Thursday session had 9; the L3 Saturday had 4. The 22+ count here is not just more — it's structurally different. The pre-passage riches arc gave members a thematic grid before encountering the text, so when James 2:5 ('Did not God choose the poor of this world to be rich in faith?') arrived, it landed inside a context already saturated with wealth theology. Members weren't just reading a passage — they were placing a passage inside a framework they had just built. This is how cross-references create comprehension rather than just coverage."
                 ]
               },
               {
-                "title": "Vulnerability / Authenticity anchored the session (5/5)",
+                "title": "Bryan's Partiality Confession — The Arc's Deepest Personal Vulnerability",
                 "paragraphs": [
-                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
-                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
-                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 4 disclosures: Muslim partiality [01:07:38]; political/car partiality [01:04:08]; pornography/social media trap [01:30:02]; shorts ministry backstory [~00:50]"
+                  "Bryan named three specific partiality patterns to the group in the same teaching block: (1) people who vote a certain way ('I don't really want to spend time with those people'); (2) people who drive certain types of cars ('I immediately devalue them'); (3) certain Muslim people — verbatim: 'My viewpoint towards certain Muslim people is literally the opposite of what God thinks. Literally. That's why it's such a problem.' [01:07:38-01:07:46]. And earlier, Bryan disclosed that he has no social media accounts specifically to avoid the pornography trap: 'The reason I don't have the social media accounts is I don't want to get trapped by pornography. Those are a trap for me.' [01:30:02].",
+                  "Unlike prior vulnerability moments — which were historical (adopted son's incarceration, wife's health, Ohio church) — these disclosures were present-tense and self-incriminating. Bryan was not telling a story about what he overcame. He was naming something he still struggles with, in the room, in real time, to the exact people the teaching was addressing. This is the vulnerability structure that creates application authority: the leader does not say 'James 2 applies to me too.' He shows the specific ways it applies, named and undefended. Every member who held a similar partiality heard permission to own it. The application round confirmed it — at least four members shared specific partiality confessions in direct response."
                 ]
               },
               {
-                "title": "Session Structure & Flow anchored the session (4/5)",
+                "title": "Royal Law Application Question — DOK 4 at Session Apex",
                 "paragraphs": [
-                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Full 10-step blueprint executed; Big Ideas review in Q&A/guided-themes format (not unsupported Ebbinghaus recall)"
+                  "'If the royal law — love your neighbor as yourself — governs your life, do you have a specific neighbor you are currently failing to love like you love yourself?' [~01:01:28-01:01:43]. This is the session's single highest-leverage question. It does not ask members to define the royal law (DOK 2) or argue why partiality is wrong (DOK 3). It asks them to name a person — specific, present, actionable. The question bypasses reflection and lands directly in self-examination. Bryan then modeled the answer: 'I actually have some ideas — on myself.' And he went there. The domino effect was immediate: a member shared reconciling with an estranged family member; Bryan shared his Muslim partiality; another member named political partiality toward neighbors.",
+                  "A DOK 4 question that produces the leader's own confession before any member answers is structurally rare. The sequence — question, leader answer, member cascade — is the application protocol executing at its designed maximum. To replicate: in any session where the text produces a specific behavioral command (royal law, pure religion, doers not hearers), ask the question from the first person: 'Do you have a specific ___?' Not 'what would it look like if someone showed partiality?' but 'where are you showing it?' The specificity of the question dictates the specificity of the answer."
                 ]
               },
               {
-                "title": "Application Questions anchored the session (4/5)",
+                "title": "Law of Liberty Illustration — 'Hand My Phone to Anyone'",
                 "paragraphs": [
-                  "Application questions pushed members from concept to life, several at the reason/apply level.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 9 Big Idea questions; 44% DOK 4 (above 25% benchmark); royal law question at arc's highest single-question yield"
+                  "When Nick questioned the apparent paradox in 'law of liberty,' Bryan answered with a concrete self-test that every member could run in the room: 'The law of liberty is — you follow what God says and you can hand your phone to anybody and you don't care. I don't care. Scroll to wherever you want.' [01:54:19-01:54:30]. He then extended it: 'I don't wanna worry about that. I don't wanna hurt my sweet wife or my kids. So there's liberty, there's freedom in just doing what God says. If I deal with my money properly, I don't have to be ashamed about anybody finding out.' [01:55:04-01:55:28].",
+                  "Darrell immediately confirmed it from personal experience: 'I look at how I have lived, and I wouldn't hand over my cell phone or my personal computer to anybody... but now that I live pursuing a relationship with God... that I truly do abide as best that I can... it's truly liberating.' [01:56:46-01:57:31]. A concept that generates a personal confirmation from another member, in real time, is an illustration that already worked before Bryan finished explaining it. The 'hand your phone to anyone' test is memorable, portable, and immediately checkable — which is precisely why it's effective."
                 ]
               },
               {
-                "title": "Participant Engagement anchored the session (4/5)",
+                "title": "Application Round — 8+ Members, Full Disclosure Cascade",
                 "paragraphs": [
-                  "A high share of the room contributed substantively, called on by name.",
-                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
-                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 14+ named contributors; 8+ scripture readers; 8-member application close"
+                  "The closing application round ran approximately 12 minutes with 8+ distinct contributors, each sharing at DOK 4 depth. Chris (newcomer, 100% commission sales role): 'I should not seek comfort from money. I need to fully surrender to God. Money will leave me empty. Money brings false security.' [01:49:43-01:50:04] — four distinct behavioral commitments from a first-visit newcomer. Taylor (finance and accounting): connected the session directly to his career — 'I need to spend a lot more time worrying about an eternal retirement and less of an earthly retirement.' [01:50:26-01:50:32]. Mark: 'The whole so speak and so act... judgment will be merciless to the one who has not shown mercy. Like that saying — when you're pointing your finger at somebody, there's three pointing back at you.' [01:52:45-01:53:18]. Darrell disclosed his sponsee's vehicular manslaughter — raw, unscripted, and directly tied to the partiality and mercy themes. Nandan confessed political partiality that fractured 8 friendships.",
+                  "Eight distinct voices, each with a specific personal application, in twelve minutes. This is what the study design exists to produce. The session created the conditions — rigorous cross-reference scaffolding, Bryan's own partiality confessions, the DOK 4 royal law question — and the group responded at the level the environment invited."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Visual Aids is a growth area (2/5)",
+                "title": "Visual Aids — Zero Used in the Highest-Content Session of the Arc",
                 "paragraphs": [
-                  "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: None used — no whiteboard, no BLB word studies, no diagrams in the arc's highest-density content session"
+                  "This session contained the most teachable visual content of the James arc: a 9-text riches arc mapping a single theme across Wisdom literature, Gospels, and Epistles; the civil/ceremonial/moral law categorization (613 laws, three types); the Bema judgment / Great White Throne fork; the law-of-liberty cause-effect chain (James 1:25 → John 8:31 → Rom 6 → law = freedom). None of it had a visual anchor. The riches arc alone — 9 texts, 5 themes, one unified warning — is a perfect single-column table: Text | Core Theme | Application. Members could photograph it and carry it into their week.",
+                  "The 613 laws explanation [01:24-01:28] is the clearest example: Bryan named three categories (civil, ceremonial, moral), distinguished them with examples, and explained which Jesus fulfilled. Without a visual, members heard it once and held it in working memory for the rest of the session. With a three-column table (Category | Examples | Status Under Christ), the framework becomes permanent. This is not a refinement — it's the highest-leverage mechanical change available in the program. Visual aids are 2/5 for the fourth consecutive session. Building the riches arc table and the law categories table takes 10 minutes of prep and adds 20% retention per session that uses them."
                 ]
               },
               {
-                "title": "Newcomer Welcome is a growth area (3/5)",
+                "title": "Darrell's Sponsee Disclosure — The Heaviest Moment Left Unreceived",
                 "paragraphs": [
-                  "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
-                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Chris and John welcomed; homework instructions given at close; The Guarantee and formal member testimony protocol not executed"
+                  "At [01:59:22], Darrell shared that a sponsee he had invested in deeply — a man he thought he had 'really made an impact on' — got drunk and killed someone in a vehicular manslaughter incident the previous weekend. 'Long story short, he got drunk and killed a guy last weekend, intoxicated, vehicular manslaughter. And now I also feel convicted because... I've been on the road and I feel like I need to go visit him and just let him know that, hey man, I'm gonna be praying for you. And every night I have prayed for the family of the man that Eddie killed that night.' [01:59:22-01:59:55].",
+                  "Bryan's response was to move immediately to Nandan for the 'last word.' The lightest disclosure in the round received the same treatment as the heaviest. Darrell was describing grief, guilt, and a pastoral obligation — all three in a single statement — and the room moved on in under 5 seconds. The minimum response: 'Darrell — stay right there for a second. What's holding you back from going to see him?' That one follow-up would have honored the disclosure and potentially opened the deepest pastoral conversation of the session. Instead, the disclosure landed and disappeared. In a group where vulnerability is the highest-scoring cluster, protecting the weight of a moment like this is what tells every other member it's safe to share."
                 ]
               },
               {
-                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "title": "Newcomer Protocol — Chris and John Received Homework Instructions But Not The Guarantee",
                 "paragraphs": [
-                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: ~32-35% leader talk (discussion only); three theological bridge monologues pulled ratio up in middle third"
+                  "Two newcomers were present — Chris (invited by Lance) and John (invited by Lance). At the close of the session, Bryan explicitly gave both Chris and John homework instructions: 'We actually have five days of homework... it asks you questions that make you read maybe a paragraph of the Bible over and over... it's a method to let God's word work in your mind.' [02:03:23-02:04:49]. That is the back end of the newcomer protocol.",
+                  "The front end — member testimonies, Bryan's own testimony, and The Guarantee — does not appear to have been executed at the session's standard. The Guarantee is Bryan's highest-leverage enrollment sentence: 'If you come in here, and you do the homework, five days of homework... God will begin to speak to you. It's guaranteed. I guarantee, 100%.' Chris already shared the richest newcomer application of the entire session at close — he came engaged. The Guarantee converts an engaged first-visit newcomer into a second-visit committed member. It should be delivered every time, to every newcomer, at the start of the session. Not as a closing logistics note — as a front-door promise."
                 ]
               },
               {
-                "title": "Memory Reinforcement is a growth area (3/5)",
+                "title": "Big Ideas Review — Guided Q&A vs. Unsupported Recall",
                 "paragraphs": [
-                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Guided-themes Big Ideas review (not unsupported Ebbinghaus retrieval); no formal bumper-sticker generation at close"
+                  "The session opened with a Big Ideas review using a 'tag in the story' guided-themes format. This is guided recall, not unsupported recall. The Ebbinghaus retrieval protocol requires members to produce Big Ideas from memory without any prompts — no author cues, no verse references, no themed scaffolding. Guided recall strengthens recognition memory; unsupported recall strengthens generative memory, which is what produces spontaneous application outside the group. After four James sessions, this group has 30+ stored Big Ideas and 22 new cross-references from this session alone.",
+                  "For L5: open with a 4-minute cold recall drill. 'Before we touch anything new — give me every bumper sticker you remember from James so far. Memory only. No notes. No prompts. Go.' Write each on the board or screen. The drill will likely surface 15-20 ideas. Do not prompt by chapter or theme — unsupported retrieval is the mechanism. The act of recalling 22 references from L4 alone, even imperfectly, triples retention vs. re-reading (Roediger & Karpicke 2006). The recall is not a quiz — it is the primary learning event of the session's opening."
                 ]
               },
               {
-                "title": "Prayer is a growth area (3.5/5)",
+                "title": "Theological Bridge Monologues — 3-5 Minute Blocks Without Question Breaks",
                 "paragraphs": [
-                  "Prayer was leader-only or rushed; the group’s voice was thin.",
-                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
-                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Closing prayer delegated to Marco [02:01-02:03] — on-topic (learning + application); opening prayer not captured in transcript; no prayer chain reference"
+                  "The 613 laws explanation [01:24-01:28], the Bema judgment / Great White Throne teaching [01:14-01:18], and the Romans 6-8 synthesis [01:28-01:32] each ran as 3-5 minute uninterrupted monologues. These are Bryan's highest-depth theological bridging moments — and they're also the points where the Q-to-S ratio drops below 30:70. The content is valuable; the delivery structure locks members out of the conversation for extended windows. In a session with a 45:55 ratio (below the 60:40 target), these three blocks account for the majority of the gap.",
+                  "The fix is not content cuts — it's punctuation. After explaining the law categories: 'Which of these three do you think most Christians accidentally treat as still binding — civil, ceremonial, or moral?' [30-second question, 3-second hold]. After the Bema judgment explanation: 'What's one thing you're doing right now that you think will survive the blowtorch?' [30-second question, 4-second hold]. These two questions break the monologues, test whether the explanations landed, and return the Q-to-S ratio to target — without changing a single word of content. Three pre-marked 'H' questions in the theological bridge sections of your prep notes would solve this across every session."
                 ]
               }
             ],
             "recommendationsProse": [
               {
-                "title": "Next session — Visual Aids",
+                "title": "Deliver The Guarantee to Chris and John at the Top of L5",
                 "paragraphs": [
-                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Chris arrived as a newcomer, did his own in-room application of the riches content (commission income, false security), and gave the most precise behavioral application of the entire session. He came engaged — and Bryan gave him homework instructions at the close. What Chris did not receive is The Guarantee: 'If you come in here, and you do the homework, five days of homework... God will begin to speak to you. It's guaranteed. I guarantee, 100%.' That sentence is not a closing logistics note — it is the enrollment promise that converts a curious newcomer into a committed member. At the top of L5, before anything else, give Chris and John The Guarantee directly. The investment is 60 seconds; the yield is a member who shows up with homework done because someone promised him it would matter."
                 ]
               },
               {
-                "title": "Next session — Newcomer Welcome",
+                "title": "Open L5 with a Full 4-Minute Ebbinghaus Recall Drill",
                 "paragraphs": [
-                  "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "'Before we touch anything new — give me every Big Idea from James that you remember. Memory only. No notes. No prompts. Go.' This group just processed 22 cross-references in a single session. They have stored more material in L4 than in any prior session in the arc. A cold recall drill will likely surface 12-18 ideas — bumper stickers, cross-references, application confessions. Write each on the board or screen as they surface. The unsupported retrieval is the learning event, not the subsequent teaching. Ebbinghaus spacing: retrieval after 72+ hours (Thursday → Thursday) is the exact interval where the memory trace needs active retrieval to survive. Do not guided-cue ('what were the riches passages?') — the drill only works if it is cold."
                 ]
               },
               {
-                "title": "Next session — Facilitation vs. Lecture",
+                "title": "Prepare the Riches Arc and 613 Laws Visual Before L5",
                 "paragraphs": [
-                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Two visuals from this session deserve to be on a whiteboard or printout in every future James session where the content recurs: (1) the Riches Arc — a 9-row table (Text | Theme | Implication) covering Eccl 5:10 through 1 Tim 6:17-19; (2) the Law Categories table — three rows (Civil | Ceremonial | Moral) with examples and Jesus' fulfillment status in each column. Both tables take 10 minutes to build and add 20% retention per session that uses them (Mayer's Redundancy Principle). The riches arc table, specifically, can become a reference card members carry through the entire James arc — a portable scaffold for every future passage on wealth, faith, and works."
                 ]
               },
               {
-                "title": "Next session — Memory Reinforcement",
+                "title": "Text Darrell Before the Next Session",
                 "paragraphs": [
-                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Darrell shared that his sponsee killed someone last weekend — vehicular manslaughter — and that he feels convicted to visit him in custody. The disclosure was not followed up in the session. Before L5, a direct text closes the pastoral loop: 'Darrell — I've been thinking about what you shared Thursday. Have you gone to see him yet?' Two things happen: (1) Darrell learns that his disclosure was heard and remembered, which tells him the group holds the weight of what he shared; (2) you learn where he is pastorally — whether the visit happened, whether he needs support, whether there's something to bring back to the group next week. The 30 seconds in the session that weren't given to Darrell can still be given now."
                 ]
               },
               {
-                "title": "Next session — Prayer",
+                "title": "Mark Three 'Full Hold Questions' in the Theological Bridge Sections",
                 "paragraphs": [
-                  "Next time, ask one member to open and a different member to close in prayer.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "The 613 laws block, the Bema judgment block, and the Romans 6-8 synthesis each ran as 3-5 minute monologues in this session. For L5, mark three questions in your prep notes with 'H' (hold) — one inside each of the session's two or three deepest theological bridge sections. When you reach the marked question: ask, then count silently to 8 before speaking. In L3 Thursday, a 4-second pause before Bryan answered 'What is the crown of life?' was the pattern that needed extending. The hold is there — the pre-marking ensures the 8-second threshold is reached. One fully held question per bridge section lowers the monologue window, returns the Q-to-S ratio toward target, and tests whether the explanation landed before moving forward. Bible Leader Coaching | Bryan Bailey | June 4, 2026"
                 ]
               }
             ]
           },
           "sections": [
             {
-              "title": "Score composition",
-              "paragraphs": [
-                "How the four weighted clusters and any session bonuses combined into the composite score."
-              ],
+              "title": "Scorecard — 1. Attendees",
               "bullets": [
-                "Teaching Craft: 72% × weight 33 → 23.76 pts",
-                "Building Ministry: 70% × weight 31 → 21.70 pts",
-                "Engaging People: 70% × weight 18 → 12.60 pts",
-                "Being Real: 85% × weight 18 → 15.30 pts",
-                "Base (sum of cluster contributions): 73.36 / 100",
-                "Session bonuses: newcomer growth +2, group-size +1",
-                "Session score: 76.36 / 100"
+                "Total attendees: ~17-20 men  (Target: Consistent weeknight group attendance)  → STRONG",
+                "Newcomers: 2 — Chris (invited by Lance), John (invited by Lance)  (Target: Organic newcomer growth)  → ON TARGET"
               ]
             },
             {
-              "title": "Coaching notes by dimension",
-              "paragraphs": [
-                "The per-dimension rationale behind each score on the 12-dimension scorecard."
-              ],
+              "title": "Scorecard — 2. Scripture Focus",
               "bullets": [
-                "Session Structure & Flow (4/5): Full 10-step blueprint executed; Big Ideas review in Q&A/guided-themes format (not unsupported Ebbinghaus recall)",
-                "Newcomer Welcome (3/5): Chris and John welcomed; homework instructions given at close; The Guarantee and formal member testimony protocol not executed",
-                "Scripture Engagement (5/5): 22+ cross-references — arc high; 80-85% discussion grounded in scripture; first scripture within 15 min",
-                "Facilitation vs. Lecture (3/5): ~32-35% leader talk (discussion only); three theological bridge monologues pulled ratio up in middle third",
-                "Application Questions (4/5): 9 Big Idea questions; 44% DOK 4 (above 25% benchmark); royal law question at arc's highest single-question yield",
-                "Participant Engagement (4/5): 14+ named contributors; 8+ scripture readers; 8-member application close",
-                "Visual Aids (2/5): None used — no whiteboard, no BLB word studies, no diagrams in the arc's highest-density content session",
-                "Vulnerability / Authenticity (5/5): 4 disclosures: Muslim partiality [01:07:38]; political/car partiality [01:04:08]; pornography/social media trap [01:30:02]; shorts ministry backstory [~00:50]",
-                "Memory Reinforcement (3/5): Guided-themes Big Ideas review (not unsupported Ebbinghaus retrieval); no formal bumper-sticker generation at close",
-                "Homework References (4/5): Explicit homework instructions to both newcomers at close [02:03:23]; referenced during session; The Guarantee not formally delivered",
-                "Prayer (3.5/5): Closing prayer delegated to Marco [02:01-02:03] — on-topic (learning + application); opening prayer not captured in transcript; no prayer chain reference",
-                "Leader Development (3.5/5): Lance bringing 2 newcomers signals multiplication; Bryan directing newcomers through Lance and John shows distributed pastoral network; no in-training leader like Russell in Thursday group"
+                "Cross-references: 22+ (Eccl, Prov ×3, Luke ×2, Mark, 1 Tim ×2, Lev, Deut ×2, Ps, Jas 1, John ×2, 2 Cor, Matt, Rom ×3, Jude)  (Target: 6+ per session)  → STRONG",
+                "Leader talk ratio (with scripture reading): ~40–45%  (Target: ≤35%)  → NEEDS WORK",
+                "Leader talk ratio (discussion only): ~32–35%  (Target: ≤30%)  → ON TARGET",
+                "% discussion grounded in scripture: ~80–85%  (Target: ≥70%)  → STRONG",
+                "Time to first scripture reading: ~12-15 min (after Big Ideas review + newcomer welcome)  (Target: Within 15 min of lesson start)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 3. Time Management",
+              "bullets": [
+                "Total session time: ~127 min  (Target: 90–120 min)  → ON TARGET",
+                "Big Ideas review / context overview: ~6 min — themes with 'tag in the story' format  (Target: 5–15 min)  → STRONG",
+                "Newcomer welcome: ~5-7 min  (Target: 7–25 min)  → ON TARGET",
+                "Riches cross-reference arc (pre-James 2 text): ~35 min  (Target: 20–35 min)  → STRONG",
+                "James 2:1-13 + royal law / law of liberty teaching: ~55 min  (Target: 45–60 min)  → STRONG",
+                "Application round (close): ~12 min  (Target: 8–12 min)  → STRONG",
+                "Closing prayer + newcomer follow-up: ~5 min  (Target: 3–8 min)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 4. Application Questions",
+              "bullets": [
+                "Big Idea questions (DOK scored): 9 questions  (Target: 5–7 per session)  → STRONG",
+                "DOK Level 4 (apply to life): 4 (~44%)  (Target: ≥25%)  → STRONG",
+                "DOK Level 3 (reason/justify): 4 (~44%)  (Target: ≥35%)  → STRONG",
+                "DOK Level 2 (compare/analyze): 1 (~11%)  (Target: ≤40%)  → STRONG",
+                "DOK Level 1 (recall — excluded): ~12 scaffolding prompts (not scored)  (Target: Excluded from DOK)  → N/A",
+                "Application spacing: Distributed throughout; 8+ contributors at close  (Target: Woven throughout + close)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 5. Engagement",
+              "bullets": [
+                "Named participants engaged: 14+ called by name to contribute  (Target: 70–80% of attendees)  → STRONG",
+                "Members who read scripture aloud: 8+ different readers (Nick, Marcus, Mark, Lance, Nandan, Chris Scow, Jackson, others)  (Target: Multiple readers per session)  → STRONG",
+                "Application round at close: Yes — 8+ contributors: Chris, Taylor, Mark, Nick, Bryan, Darrell, Nandan, member on family reconciliation  (Target: Full group participation)  → STRONG",
+                "Wait time after questions: Moderate — Bryan occasionally self-answered after brief pauses  (Target: 3–5 sec (Rowe 1972))  → ON TARGET",
+                "Visual aids used: None — no whiteboard, no BLB, no diagrams  (Target: Charts, maps, BLB)  → NEEDS WORK",
+                "Newcomer engagement: Chris participated in application round with the session's most precise behavioral application; John introduced at close  (Target: Newcomers contribute in first session)  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Scorecard — 6. Leadership",
+              "bullets": [
+                "Vulnerability moments (leader): 4 — Muslim partiality confession [01:07:38]; political/car-type partiality admission [01:04:08]; social media/pornography trap disclosure [01:30:00]; shorts ministry backstory [~00:50]  (Target: 2–3 per session, weighted by depth)  → STRONG",
+                "Teaching monologues > 90 sec: ~4 (613 laws explanation, Bema judgment / Great White Throne, Romans 6-8 arc, law of liberty synthesis)  (Target: < 3 per session)  → NEEDS WORK",
+                "Pastoral response to member disclosures: Darrell's sponsee vehicular manslaughter [01:59:22] received no follow-up — moved immediately to Nandan; other disclosures well-held  (Target: Sit with disclosure before reframing)  → NEEDS WORK"
+              ]
+            },
+            {
+              "title": "Scorecard — 7. Question Quality",
+              "bullets": [
+                "% open-ended Big Idea questions: ~8 of 9 (89%)  (Target: ≥70%)  → STRONG",
+                "% requiring scripture to answer: ~67%  (Target: ≥50%)  → STRONG",
+                "Follow-up probes used: Moderate — 'give me an example', 'come on', directed calls-by-name; fewer 'what do you mean?' depth probes  (Target: Per Webb DOK standards)  → ON TARGET",
+                "Q-to-S ratio (discussion): ~45:55 (theological bridge sections pull leader ratio up)  (Target: 60:40 Q:S minimum)  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Scorecard — 8. Study Method & Communication",
+              "bullets": [
+                "Big Ideas review at session start: Guided Q&A with 'tag in the story' themes — not formal unsupported recall  (Target: Ebbinghaus unsupported retrieval)  → NEEDS WORK",
+                "Big Ideas at close: Partial — closing application round generated behavioral takeaways; formal bumper-sticker synthesis not executed  (Target: 5–6 per session)  → ON TARGET",
+                "Homework references: Yes — Bryan gave Chris and John explicit 5-day homework instructions at close [02:03:23-02:04:49]; referenced during session  (Target: Explicit Precept ref + The Guarantee)  → ON TARGET",
+                "Prayer chain referenced: Not explicitly referenced  (Target: Prayer chain infrastructure active)  → NEEDS WORK",
+                "Topic drift: ~3-4 min (beard jokes post-session [02:05-02:07])  (Target: < 10 min total)  → STRONG"
+              ]
+            },
+            {
+              "title": "Key Moments",
+              "moments": [
+                {
+                  "detail": "DOK 4 at Maximum Depth  (🟢 Capitalized · Being Real + Engaging People)\n\nWhat happened: Bryan asked: 'If the royal law — love your neighbor as yourself — governs your life, do you have a specific neighbor you are currently failing to love like you love yourself?' [01:01:28-01:01:43]. Before any member answered, Bryan said: 'I actually have some ideas — on myself.' [01:02:06-01:02:09]. He then confessed his partiality toward people who vote a certain way, drive certain cars, and — most directly — certain Muslim people: 'My viewpoint towards certain Muslim people is literally the opposite of what God thinks. Literally.' [01:07:38-01:07:46]. The question produced a full member cascade: a member disclosed reconciling with an estranged family member through a health crisis; another confessed political partiality that fractured 4 friendships.\n\nWhy it mattered: When a leader asks a DOK 4 question and then answers it himself — specifically, with present-tense self-indictment — the room understands that the question is not rhetorical. Bryan did not say 'James 2 challenges all of us.' He named the type of person he devalues on sight and acknowledged it is 'literally the opposite of what God thinks.' That is the difference between teaching about partiality and demonstrating repentance from it. The cascade of member disclosures that followed was not accidental — it was the direct output of the leader going first and going specific.\n\nWhat would make it bigger: The question used the second person singular and required specificity ('a specific neighbor'). Generic questions produce generic answers. 'Do we all show partiality sometimes?' produces nods. 'Do you have a specific neighbor you are currently failing to love like you love yourself?' produces Nandan's 4-couple story and Bryan's Muslim partiality confession. To replicate: any time the text produces a behavioral command, ask it from the first person, with a specific noun ('a neighbor,' 'a person,' 'a situation') and no escape route. Then answer it yourself.",
+                  "timestamp": "[01:01:28]"
+                },
+                {
+                  "detail": "Illustration at Maximum Portability  (🟢 Capitalized · Teaching Craft)\n\nWhat happened: Nick challenged the 'law of liberty' concept — 'I get hung up on just the word law' — and Bryan responded with a concrete, personally verifiable test: 'The law of liberty is — you follow what God says and you can hand your phone to anybody and you don't care. I don't care. Scroll to wherever you want. Don't send anything that's not on my behalf... but there's liberty. There's freedom in following God's ways.' [01:54:19-01:54:55]. He extended it to money, laptop, marriage. Darrell confirmed it from personal experience immediately after.\n\nWhy it mattered: A concept that generates self-assessment in the room, while the leader is still speaking, is an illustration at maximum effectiveness. Darrell's confirmation — 'I wouldn't hand over my cell phone or my personal computer to anybody... but now... it's truly liberating' — was the illustration proving itself through a member's own experience, in real time. The concept was not just explained — it was verified by testimony before Bryan finished teaching it.\n\nWhat would make it bigger: The illustration is a test, not a metaphor. 'The law of liberty is like a bird in a cage' requires interpretation. 'The law of liberty means you can hand your phone to anyone' requires no interpretation — just an honest answer. Personal, practical tests are always more effective than structural metaphors. For any abstract theological concept, ask: what would it look like if this were true in my life right now? Then state the test. Bryan did this naturally here; identifying the move consciously makes it replicable.",
+                  "timestamp": "[01:54:19]"
+                },
+                {
+                  "detail": "Partiality vs. Bad Company Distinction  (🔵 Pivot Point · Teaching Craft)\n\nWhat happened: Taylor (finance and accounting) shared: 'I need to spend a lot more time worrying about an eternal retirement and less of an earthly retirement.' [01:50:26-01:50:32]. A group member immediately hedged it for him — 'Taylor might be in a unique position... researching stocks is kind of part of his job.' Bryan clarified: 'You're supposed to do your job the best of your ability. As if you're doing it for the Lord.' [01:52:02-01:52:05]. Taylor clarified he meant personal retirement savings, not job duties. Bryan moved on.\n\nWhy it mattered: Darrell described grief (a mentee killed someone), guilt (feeling partly responsible), and an unresolved pastoral obligation (needs to visit him in custody). This is one of the heaviest disclosures in the arc. The disclosure had nothing to do with the session's content in an obvious way — it required the leader to stop the rhythm of the application round, hold the moment, and give Darrell's statement the weight it deserved. Members watching learned something from how Bryan handled it — and what they learned is that the heaviest disclosures receive the same response as the lightest ones.\n\nWhat would make it bigger: Bryan caught the conflation before it embedded. When a member voices a misunderstanding that could derail the teaching, the correction needs to be specific and fast — not gentle or delayed. 'No — those are two different things' followed by the distinction is the right structure. Bryan executed it precisely. The group heard both truths, not a compromise of one.",
+                  "timestamp": "[01:06:20]"
+                }
+              ],
+              "paragraphs": [
+                "These are the disproportionate moments in this session — the exchanges that shaped what this group will remember, believe, and do. Aggregated scores average these away; Key Moments names each one explicitly so Bryan can rewatch with intent."
+              ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "'What is the royal law, according to this passage?' [00:58:54] — DOK 2 — Identify and locate from text. Member answers: 'Love your neighbor as yourself' / 'the golden rule.' Correct identification, minimal reasoning required. — ON TARGET",
+                "'Could you make the argument that partiality is not a little sin?' [01:00:34] — DOK 3 — Reason/justify from text. Bryan guided the group to see partial obedience = disobedience via the broken window pane analogy. Member: 'Disobedience.' Strong DOK 3 reasoning. — STRONG",
+                "'If the royal law governs your life, do you have a specific neighbor you are currently failing to love like you love yourself?' [01:01:28] — DOK 4 — Direct personal application; requires naming a specific person or pattern. Bryan answered first (Muslim partiality). Member cascade followed. Session's highest-yield question. — STRONG",
+                "'What does liberty mean to you? Law and liberty — aren't they an oxymoron?' [01:19:36] — DOK 3 — Concept analysis, productive friction. Nick: 'Freedom with liberty.' Bryan probed the paradox, then resolved it through John 8 and Romans. Good DOK 3 conceptual engagement. — STRONG",
+                "'What's the big idea with Jesus — what's he saying in Matthew 5:17-20?' [01:08:08] — DOK 3 — Synthesize/infer from Jesus' first public sermon. Members: 'It still stands,' 'Contrary to popular opinion.' Bryan: 'He was going to live a perfect life and fulfill all the requirements of the law.' Strong inference. — STRONG",
+                "'What does that tell us about the purpose of the law? Or what does it tell us about sin?' [01:29:29] — DOK 3 — Theological inference from Romans 6-8. Members: 'The law can't save you,' 'We can't keep it.' Bryan: 'The law can't save you — but Jesus did what the law couldn't.' Solid DOK 3 synthesis. — STRONG",
+                "'What's the litmus test you're now evaluating yourself on?' [01:43:40] — DOK 4 — Self-application/synthesis of the full passage. Multiple members identified 'do I show favoritism?' as their personal test. Bryan linked to the session's core: 'Am I treating people differently because of ___?' — STRONG",
+                "'Do most of the people you spend your time with fit your profile — race, money, age, intelligence?' [01:47:08] — DOK 4 — Self-examination of relational patterns. Bryan: 'That might be a flag to look at.' Members quietly reflected. This is the Socratic version of the royal law question — outward-facing vs. inward-facing examination of the same sin. — STRONG",
+                "'Complete this phrase: Genuine faith produces ___.' [01:45:13] — DOK 3 — Completion/recall of theological concept. Member answers: maturity, proof, obedience. Bryan: 'genuine faith produces fruit, produces obedience, produces good works. It's inevitable.' Anchor for the whole James 2 argument. — STRONG"
+              ],
+              "paragraphs": [
+                "Big Idea questions only (DOK scored): 9 questions. Scaffolding / reading prompts (DOK 1, excluded): ~12 navigation/recall prompts ('Read James 2:1 for us', 'What does verse 13 say?', etc.). DOK distribution: 4 at Level 4 (~44%), 4 at Level 3 (~44%), 1 at Level 2 (~11%). Q-to-S ratio in discussion: ~45:55 (below 60:40 target; theological bridge monologues in middle third account for the gap)."
               ]
             }
           ],
@@ -1574,197 +1682,248 @@
           ],
           "bigIdeas": [],
           "feedback": {
-            "headline": "A strong session — strongest in Newcomer Welcome and Session Structure & Flow, with the clearest next step in Scripture Engagement.",
+            "headline": "Five newcomers, Brennan's baptism announced, and Bryan used his own coaching experience to illustrate James 1:19 — perhaps the most self-aware application moment in the James arc.",
             "strengths": [
-              "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
-              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-              "Application questions pushed members from concept to life, several at the reason/apply level."
+              "Newcomer Welcome — Best of the James Arc",
+              "Criminal Thinking / Sin Progression Bridge — Maximum Teaching Depth",
+              "Vulnerability — Coaching Program Disclosure as Live Teaching"
             ],
             "improvements": [
-              "Discussion drifted from the text; a few more passages would ground the teaching.",
-              "Leader talk crowded out discussion; the balance leaned toward lecture.",
-              "The session leaned audio-only; a visual anchor would aid retention."
+              "Cross-Reference Count — 4 vs. the 6+ Benchmark",
+              "Big Ideas Review — Q&A vs. Formal Unsupported Recall",
+              "Leader Talk Ratio — Newcomer Week Structural Pull"
             ],
             "recommendations": [
-              "Next time, pre-mark 3 cross-references to pull in during the densest teaching block.",
-              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-              "Next time, put one word-study lookup or a simple table on screen during the key term."
+              "Open James L4 with a Full Ebbinghaus Recall Drill",
+              "Prepare 3 'Full Hold Questions' in Advance",
+              "Build a Crown Passages Reference Card for Saturday Members"
             ],
             "overview": [
-              "A strong session — strongest in Newcomer Welcome and Session Structure & Flow, with the clearest next step in Scripture Engagement. It scored 84.31/100 under the v3 weighted model.",
-              "The session played to its strengths in Newcomer Welcome and Session Structure & Flow; the recommendations below turn Scripture Engagement into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+              "Five newcomers, Brennan's baptism announced, and Bryan used his own coaching experience to illustrate James 1:19 — perhaps the most self-aware application moment in the James arc.",
+              "This report carries the full written coaching for the session: 5 areas of strength, 5 areas for improvement, and 5 recommendations for next session, scored 84.31/100 on the v3 weighted model."
             ],
             "strengthsProse": [
               {
-                "title": "Newcomer Welcome anchored the session (5/5)",
+                "title": "Newcomer Welcome — Best of the James Arc",
                 "paragraphs": [
-                  "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
-                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
-                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 5 newcomers; 3 member testimonies (Keith, Brendan, Russ); Bryan testimony + The Guarantee delivered"
+                  "Five newcomers attended (Brant, Jared #1, Jared #2, James, Jacob), and the welcome protocol was executed at its highest level of this arc. Keith gave a 90-second testimony ('I thought I knew it all, and I really didn't at all'); Brendan shared a six-month transformation ('I'm a complete 180 from what I used to be'); Russ tied the stakes directly to current culture ('This world is too loud and it's getting louder'). Then Bryan gave his own testimony — believer at childhood, secondhand information until age 39, found Precept, and gave The Guarantee: 'If you come in here, and you do the homework, five days of homework... God will begin to speak to you. It's guaranteed. I guarantee, 100%.' [00:09:07–09:29]. This is the full protocol in sequence: existing members testify → Bryan testifies → Guarantee delivered → newcomers introduce themselves. Building Ministry Dimension 2: 5/5."
                 ]
               },
               {
-                "title": "Session Structure & Flow anchored the session (4/5)",
+                "title": "Criminal Thinking / Sin Progression Bridge — Maximum Teaching Depth",
                 "paragraphs": [
-                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Full 10-step blueprint executed; Big Ideas review Q&A style rather than formal retrieval"
+                  "Bryan connected James 1:14-15 (temptation → lust → sin → death) to two modern frameworks simultaneously: (1) the bird-lands-on-your-head analogy ('you can't stop a bird from landing on your head, but you can keep it from nesting') and (2) criminal thinking rehabilitation, drawn from his adopted son's incarceration. Verbatim: 'I adopted a nine-year-old boy that didn't make it. But anyway, I visited him at all the correctional facilities... they would try to teach these people about criminal thinking... you don't just rape a person. What happened right before you committed the rape?' [01:04:59–01:06:03]. Then he drew the progression: tempted → lust → sin → death. Three layers of illustration — biblical, folk wisdom, clinical — converging on a single text. This is Teaching Craft at its highest: the ancient framework is validated by modern behavioral science and personal testimony simultaneously."
                 ]
               },
               {
-                "title": "Application Questions anchored the session (4/5)",
+                "title": "Vulnerability — Coaching Program Disclosure as Live Teaching",
                 "paragraphs": [
-                  "Application questions pushed members from concept to life, several at the reason/apply level.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 8-10 Big Idea questions; DOK 3-4 majority; Weston application at highest DOK 4 quality"
+                  "At [01:32:25], Bryan disclosed the VerseMate coaching program to the group and used it directly as an illustration of James 1:19 ('quick to hear, slow to speak, slow to anger'): 'The big reason I record these sessions is Andy's built a program model for me from 14 other Bible study methods... It's painful... week one of the things I have it looking for is am I capitalizing properly on a crucial moment during the meeting... I blew a crucial moment. I could have built on what he said instead of the way I moved on. I was like shut it down.' [01:34:39–01:35:26]. This is the most theologically precise application of the day's text by any voice in the room — including the leader. He did not say 'I should practice James 1:19.' He showed the moment when he failed to, named what it cost, and stated the lesson. This is Vulnerability as Authority at its highest."
                 ]
               },
               {
-                "title": "Participant Engagement anchored the session (4/5)",
+                "title": "Sin-Progression Diagram — Visual Teaching at the Right Moment",
                 "paragraphs": [
-                  "A high share of the room contributed substantively, called on by name.",
-                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
-                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 15+ named contributors; 8+ scripture readers; 6-member Big Ideas close"
+                  "Bryan built the sin-progression diagram interactively: 'Why don't we put the words tempted, enticed, lust, sin, deception. Sin. And what's the outcome of sin? Death.' [01:02:54–01:03:15]. He then asked Russ to draw it — making the whiteboard moment collaborative, not performative. The criminal thinking parallel ('it's almost like a line') gave the diagram a second dimension: the diagram is not just theology, it's a behavioral model. 'So you're tempted, the saying starts with the saying, you're tempted... the bird lands on your head.' Members could see the stages, name them, and plot where their own temptation patterns enter the chain. This is Mayer's multimedia principle applied: the verbal explanation alone would have been less memorable than the verbal + visual combination."
                 ]
               },
               {
-                "title": "Vulnerability / Authenticity anchored the session (4/5)",
+                "title": "Big Ideas Close — Group Generates 6 Canonical Bumper Stickers",
                 "paragraphs": [
-                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
-                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
-                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 4 disclosures: VerseMate coaching [01:32:25]; Facebook [01:01:36]; adopted son [01:04:59]; wife's health [00:25:16]"
+                  "The close produced six distinct Big Ideas from the group without Bryan prompting the answers: 'There is a worthless religion' [02:01:43], 'grateful for trial' [02:01:52], 'God doesn't tempt me' [02:01:40], 'enemy within' [02:01:45], 'you're doing what you believe' [02:03:14], 'joy is a decision, not a reaction' [02:03:51]. Six fully-formed bumper stickers generated by members — not by the leader. This is the retrieval protocol working at DOK 4: the group is not recalling facts, they are generating memorable formulations of theological convictions. The member who said 'leaders must fall out of a decision, not a reaction' had not heard that phrase from Bryan — he generated it himself. That is compression, not recall."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Scripture Engagement is a growth area (3/5)",
+                "title": "Cross-Reference Count — 4 vs. the 6+ Benchmark",
                 "paragraphs": [
-                  "Discussion drifted from the text; a few more passages would ground the teaching.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: 4 cross-references vs. 6+ benchmark; newcomer welcome consumed cross-referencing time"
+                  "Four confirmed cross-references (1 Cor 9:24-27, 1 Cor 3:12-15, Rev 3:11, Rev 2:10) fell below the 6+ benchmark. The Thursday group (May 28) covered the same material with 9 cross-references including BLB word studies. The Saturday group's newcomer welcome (18 minutes) naturally consumed time that Thursday's lesson-only format (no newcomers) kept available for cross-referencing. This is a structural tradeoff — the Newcomer Welcome is more important than cross-reference count — but the gap is worth noting.",
+                  "For the Saturday group specifically, the crown study (James 1:12 + five crown passages) offers a built-in opportunity to hit 6+ cross-references without changing the session structure. The five crown texts (1 Cor 9, 2 Tim 4, 1 Pet 5:4, 1 Thes 2:19, Rev 2:10, Rev 3:11) are pre-mapped and would add 5 references with minimal additional time. Consider building a laminated 'crown passages card' that members can hold during the session — that turns a teacher's monologue into a member-driven cross-reference exercise."
                 ]
               },
               {
-                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "title": "Big Ideas Review — Q&A vs. Formal Unsupported Recall",
                 "paragraphs": [
-                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: ~38-42% leader talk (discussion only); consistent growth lever across all sessions"
+                  "The session opened with Bryan asking 'Who can tell me about the author of James, the background of this book?' [00:18:47] — a guided Q&A, not a formal bumper-sticker recall. The Ebbinghaus retrieval protocol requires members to produce Big Ideas from memory without any prompts: 'From memory only — give me the bumper stickers from the last two sessions. No looking at notes. Go.' The difference is not trivial: guided Q&A prompts retrieval from hints; unsupported recall strengthens the memory trace itself.",
+                  "Saturday members have been with this material since May 16 (James L1) — three sessions plus homework. A four-minute cold-recall drill would likely surface 8-10 Big Ideas from members without any prompts. That recall would prime them to connect the L3 material to everything they've already stored. Target for L4: open with 'Before we touch anything new — give me every bumper sticker you remember from James so far. Memory only. I'll write them on the board.' See what surfaces."
                 ]
               },
               {
-                "title": "Visual Aids is a growth area (3/5)",
+                "title": "Leader Talk Ratio — Newcomer Week Structural Pull",
                 "paragraphs": [
-                  "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Sin progression diagram (collaborative); no BLB word studies; no maps"
+                  "Estimated leader talk with scripture reading: ~45–50%. Discussion only: ~38–42%. Both are above the Lifeway 30% Rule target (≤30–35%). The newcomer welcome protocol contributes significantly — Bryan's personal testimony and The Guarantee constitute ~6 minutes of uninterrupted leader talk at [00:05:50–00:09:51]. This is the right decision. The Guarantee is Bryan's highest-leverage enrollment tool and should not be shortened. However, the teaching blocks in the first 30 minutes of the lesson (crown study, sin-progression setup) also run at 60% leader talk before discussion opens up.",
+                  "The fix is not structural but strategic: pick 3 questions in the first 30 minutes of the lesson and mark them in advance as 'full hold questions' — no answer for 6 seconds regardless of silence. In this session, 'What's the crown of life?' [00:33:24] drew a 4-second pause before Bryan answered it himself. The pause was there; the hold broke early. One question per lesson that goes to the 8-second silence threshold would noticeably lower the ratio."
                 ]
               },
               {
-                "title": "Memory Reinforcement is a growth area (3/5)",
+                "title": "Visual Aids — Diagram Built, BLB Not Used",
                 "paragraphs": [
-                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Q&A review not formal Ebbinghaus unsupported retrieval; consistent growth lever"
+                  "The sin-progression diagram (tempted → lust → sin → death) was excellent — interactive, collaborative, and pedagogically sound. But BLB word studies were absent, and no maps or slides accompanied the text. The crown study — 5 passages across 4 books — is the exact kind of content that a visual reference table serves best: Crown Type | Reference | Who Receives It | Condition. A 90-second table-build at the whiteboard during the crown study would have (a) organized dense information, (b) given members something to photograph, and (c) made the cross-reference structure visible rather than just auditory.",
+                  "The Saturday group has fewer notebook-prepared members than the Thursday group (based on audience composition). This makes visual anchors more important, not less. Consider: at the opening of the crown study, draw a 3-column table (Crown | Reference | Who Gets It) and have members fill it in as the texts are read. The diagram and the table together would bring Visual Aids from 3/5 to 4/5."
                 ]
               },
               {
-                "title": "Homework References is a growth area (4/5)",
+                "title": "'I Want to Be Full' — James's Moment Deserved More Space",
                 "paragraphs": [
-                  "Homework went unmentioned, reducing its pull on the group.",
-                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: The Guarantee delivered explicitly [00:09:07]; homework exhorted at close [02:06:00]"
+                  "Late-arriving newcomer James said [00:12:24]: 'My biggest thing is I just want to go and help people. I can't do that. I don't know myself. I'm like putting this on before I get somebody else to pass it on. I just want to be full.' Bryan's response: 'The best witness Drake you've been making is be the witness. More is caught than taught. You still need to have the words. If God is speaking to you, then you've got a chance to speak on this path. Otherwise, you're just saying stuff.' This was theologically correct and warm — but fast. James's 'I just want to be full' is one of the most significant statements any newcomer made in this session. It describes sanctification by instinct: you cannot give what you don't have.",
+                  "A single follow-up question — 'What does full look like for you?' or 'What are you most hungry for?' — would have let James go one layer deeper and given the group a window into his actual spiritual condition. In a session that covered 'do not be deceived' and 'be doers of the word,' a newcomer expressing a hunger for authentic faith formation is the session's thesis in personal form. It was not missed — it was slightly under-held."
                 ]
               }
             ],
             "recommendationsProse": [
               {
-                "title": "Next session — Scripture Engagement",
+                "title": "Open James L4 with a Full Ebbinghaus Recall Drill",
                 "paragraphs": [
-                  "Next time, pre-mark 3 cross-references to pull in during the densest teaching block.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Start the next session with: 'Before we touch anything new — give me every bumper sticker you remember from James so far. Memory only. No notes. Go.' Write each one on the board or screen. Set a timer for 4 minutes. Do not prompt with author, date, or verse — unsupported retrieval is what builds durable memory (Ebbinghaus spacing effect). The Saturday group has now been through 3 sessions of dense material. A cold-recall drill will surface 8-12 Big Ideas and prime the room for L4 engagement at a higher level than guided Q&A will produce."
                 ]
               },
               {
-                "title": "Next session — Facilitation vs. Lecture",
+                "title": "Prepare 3 'Full Hold Questions' in Advance",
                 "paragraphs": [
-                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Mark three questions in your notes before the session begins with a 'H' (hold). When you reach these questions: ask, then count silently to 8 before speaking. In this session, 'What is the crown of life?' went to 4 seconds then Bryan answered it. 'Happy is the man who endures — where did we see that word before?' drew a longer hold and produced member answers. The hold works — the pattern is there. The pre-marking simply ensures it doesn't get lost in the energy of facilitation. Three full holds in a session would meaningfully lower the leader talk ratio in the first half."
                 ]
               },
               {
-                "title": "Next session — Visual Aids",
+                "title": "Build a Crown Passages Reference Card for Saturday Members",
                 "paragraphs": [
-                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "The crown study (James 1:12 + five parallel texts) is a natural visual opportunity: Crown of Life | James 1:12 | For those who endure. Crown of Righteousness | 2 Tim 4:8 | For those who love His appearing. Incorruptible Crown | 1 Cor 9:25 | For those who run with discipline. Crown of Glory | 1 Pet 5:4 | For faithful shepherds. Star Crown | 1 Thes 2:19 | For those who produce disciples. A laminated 3x5 card that stays in their James workbook gives Saturday members a reference they can use through the whole arc. The Saturday group has fewer notebook-prepared members — a physical anchor helps."
                 ]
               },
               {
-                "title": "Next session — Memory Reinforcement",
+                "title": "Follow Up James's 'I Want to Be Full' Statement After Class",
                 "paragraphs": [
-                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "James arrived late, shared a hunger for spiritual fullness, and then the session moved forward. His statement — 'I just want to be full' — is the kind of disclosure that usually means someone is in active spiritual searching, not passive curiosity. A 5-minute conversation after class or a direct text ('I appreciate what you shared today — what are you most hungry for?') converts a newcomer who made a disclosure into a newcomer who feels seen. Members who feel seen in the first session come back."
                 ]
               },
               {
-                "title": "Next session — Homework References",
+                "title": "Name the Arc's Teaching Architecture for Newcomers",
                 "paragraphs": [
-                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Five newcomers arrived this session. None of them have the James arc's cumulative context — they don't know L1's Big Ideas, L2's cross-references, or the three-sessions-deep patterns Bryan has been building. A 60-second orientation at the start of each session (before the Big Ideas recall drill) would bring newcomers current: 'We're three weeks into James. The book's big idea is this. The biggest things we've discovered so far are these three bumper stickers.' That orientation lets newcomers participate in the recall drill rather than watching experienced members perform it. It also models the arc's intentional structure — which is itself a lesson in how to study the Bible. Bible Leader Coaching | Bryan Bailey | May 30, 2026"
                 ]
               }
             ]
           },
           "sections": [
             {
-              "title": "Score composition",
-              "paragraphs": [
-                "How the four weighted clusters and any session bonuses combined into the composite score."
-              ],
+              "title": "Scorecard — 1. Attendees",
               "bullets": [
-                "Teaching Craft: 68% × weight 33 → 22.44 pts",
-                "Building Ministry: 86.7% × weight 31 → 26.87 pts",
-                "Engaging People: 70% × weight 18 → 12.60 pts",
-                "Being Real: 80% × weight 18 → 14.40 pts",
-                "Base (sum of cluster contributions): 76.31 / 100",
-                "Session bonuses: newcomer growth +5, group-size +3",
-                "Session score: 84.31 / 100"
+                "Total attendees: ~25 men  (Target: Consistent Saturday group attendance)  → STRONG",
+                "Newcomers: 5 — Brant, Jared #1, Jared #2, James, Jacob  (Target: Organic newcomer growth)  → STRONG"
               ]
             },
             {
-              "title": "Coaching notes by dimension",
-              "paragraphs": [
-                "The per-dimension rationale behind each score on the 12-dimension scorecard."
-              ],
+              "title": "Scorecard — 2. Scripture Focus",
               "bullets": [
-                "Session Structure & Flow (4/5): Full 10-step blueprint executed; Big Ideas review Q&A style rather than formal retrieval",
-                "Newcomer Welcome (5/5): 5 newcomers; 3 member testimonies (Keith, Brendan, Russ); Bryan testimony + The Guarantee delivered",
-                "Scripture Engagement (3/5): 4 cross-references vs. 6+ benchmark; newcomer welcome consumed cross-referencing time",
-                "Facilitation vs. Lecture (3/5): ~38-42% leader talk (discussion only); consistent growth lever across all sessions",
-                "Application Questions (4/5): 8-10 Big Idea questions; DOK 3-4 majority; Weston application at highest DOK 4 quality",
-                "Participant Engagement (4/5): 15+ named contributors; 8+ scripture readers; 6-member Big Ideas close",
-                "Visual Aids (3/5): Sin progression diagram (collaborative); no BLB word studies; no maps",
-                "Vulnerability / Authenticity (4/5): 4 disclosures: VerseMate coaching [01:32:25]; Facebook [01:01:36]; adopted son [01:04:59]; wife's health [00:25:16]",
-                "Memory Reinforcement (3/5): Q&A review not formal Ebbinghaus unsupported retrieval; consistent growth lever",
-                "Homework References (4/5): The Guarantee delivered explicitly [00:09:07]; homework exhorted at close [02:06:00]",
-                "Prayer (4/5): Opening delegated; closing delegated; prayer chain + session email list promoted at close",
-                "Leader Development (4/5): Russell in training; Colt brought newcomer after 2 weeks; Brennan baptism; multiple multiplication signals"
+                "Leader talk ratio (with scripture reading): ~45–50%  (Target: ≤35% (Lifeway 30% Rule))  → NEEDS WORK",
+                "Leader talk ratio (discussion only): ~38–42%  (Target: ≤30% (Lifeway, Flanders))  → NEEDS WORK",
+                "Cross-references: 4 (1 Cor 9:24-27, 1 Cor 3:12-15, Rev 3:11, Rev 2:10)  (Target: 6+ per session)  → NEEDS WORK",
+                "% discussion grounded in scripture: ~65%  (Target: ≥70%)  → ON TARGET",
+                "Time to first scripture reading: ~28 min (after newcomer welcome + Bryan intro)  (Target: Within 15 min of lesson start)  → NEEDS WORK"
+              ]
+            },
+            {
+              "title": "Scorecard — 3. Time Management",
+              "bullets": [
+                "Total session time: ~131 min  (Target: 90–120 min)  → ON TARGET",
+                "Newcomer welcome (testimonies + intros): ~18 min  (Target: 7–25 min)  → STRONG",
+                "Big Ideas review / context overview: ~10 min — Q&A on author, recipients, theme  (Target: 5–15 min)  → STRONG",
+                "Core teaching / discussion (Jas 1:12-27): ~90 min  (Target: 60–90 min)  → STRONG",
+                "Application close + Big Ideas at end: ~8 min  (Target: 5–10 min)  → STRONG",
+                "Closing prayer + logistics + prayer chain: ~5 min  (Target: 3–8 min)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 4. Application Questions",
+              "bullets": [
+                "Big Idea questions (DOK scored): 8–10 questions  (Target: 5–7 per session)  → STRONG",
+                "DOK Level 4 (apply to life): 3–4 (35–40%)  (Target: ≥25%)  → STRONG",
+                "DOK Level 3 (reason/justify): 4 (40%)  (Target: ≥35%)  → STRONG",
+                "DOK Level 2 (compare/analyze): 2 (20%)  (Target: ≤40%)  → STRONG",
+                "DOK Level 1 (recall — excluded): ~15 scaffolding prompts (not scored)  (Target: Excluded from DOK)  → N/A",
+                "Application spacing: Distributed throughout; Big Ideas surfaced at close  (Target: Woven throughout + close)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 5. Engagement",
+              "bullets": [
+                "Named participants engaged: 15+ called by name to contribute  (Target: 70–80% of attendees)  → STRONG",
+                "Members who read scripture aloud: 5+ different readers  (Target: Multiple readers per session)  → STRONG",
+                "Application round at close: Yes — group contributed 5-6 Big Ideas collectively  (Target: Full group participation)  → STRONG",
+                "Wait time after questions: Moderate — occasional self-answers before group engaged  (Target: 3–5 sec (Rowe 1972))  → ON TARGET",
+                "Visual aids used: Sin progression diagram (whiteboard/on-screen); no BLB word studies  (Target: Charts, maps, BLB)  → NEEDS WORK",
+                "Newcomer engagement: All 5 newcomers introduced; 3 participated in lesson discussion  (Target: Newcomers contribute in first session)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 6. Leadership",
+              "bullets": [
+                "Vulnerability moments (leader): 4 — VerseMate coaching program + missed moment [01:32:25]; Facebook encounter [01:01:36]; adopted son incarceration [01:04:59]; wife Lisa's health struggles [00:25:16]  (Target: 2–3 per session, weighted by depth)  → STRONG",
+                "Teaching monologues > 90 sec: ~3–4 (newcomer testimony, sin-progression chain, criminal thinking story, true religion conclusion)  (Target: < 3 per session)  → NEEDS WORK",
+                "Pastoral response to member disclosures: Weston's mom DUI application fully held [01:40:43]; James's 'I want to be full' slightly brief [00:12:24]  (Target: Sit with disclosure before reframing)  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Scorecard — 7. Question Quality",
+              "bullets": [
+                "% open-ended Big Idea questions: ~8 of 10 (80%)  (Target: ≥70%)  → STRONG",
+                "% requiring scripture to answer: ~60%  (Target: ≥50%)  → STRONG",
+                "Follow-up probes used: Frequent — 'what does that mean practically?', 'give me an example', 'who's got the next idea?'  (Target: Per Webb DOK standards)  → STRONG",
+                "Q-to-S ratio (discussion): ~45:55 (below 60:40 target; newcomer welcome + crown study pull leader ratio up)  (Target: 60:40 Q:S minimum)  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Scorecard — 8. Study Method & Communication",
+              "bullets": [
+                "Big Ideas review at session start: Q&A on author/background/theme — not formal bumper-sticker recall from memory  (Target: Ebbinghaus unsupported retrieval)  → NEEDS WORK",
+                "Big Ideas at close: Yes — 5-6 ideas from group: 'worthless religion', 'grateful for trial', 'God doesn't tempt me', 'enemy within', 'you're doing what you believe'  (Target: 5–6 per session)  → STRONG",
+                "Homework references: Explicit Guarantee given to newcomers [00:09:07]; homework referenced at close [02:06:00]  (Target: Explicit Precept ref + The Guarantee)  → STRONG",
+                "Prayer chain referenced: Yes — both prayer change and session email list explained at close [02:08:23]  (Target: Prayer chain infrastructure active)  → STRONG",
+                "Topic drift: ~4 min (coaching program discussion [01:32–01:35] — productive teaching moment; gym humor digression)  (Target: < 10 min total)  → STRONG"
+              ]
+            },
+            {
+              "title": "Key Moments",
+              "moments": [
+                {
+                  "detail": "Vulnerability as Teaching  (🟢 Capitalized · Being Real)\n\nWhat happened: Bryan disclosed the VerseMate coaching program to the group, then used it as a live illustration of James 1:19. He named a specific mistake he made with a member — the member shared something, Bryan moved on too quickly, and the member did not speak again for 20 minutes. Verbatim trigger: 'The big reason I record these sessions is Andy's built a program model for me from 14 other Bible study methods... I blew a crucial moment. I could have built on what he said instead of the way I moved on... It pointed it out and said you had a crucial moment. It said he said this and then you said that and then he didn't speak for 20 minutes.' [01:32:29–01:35:26]\n\nWhy it mattered: The VerseMate coaching disclosure is the most theologically precise application of James 1:19 in the entire session — and it came from the leader's own life, not from a hypothetical. Bryan demonstrated precisely the posture James commands: he received correction without anger, he shared the specific failure with the group, and he did not defend himself. In a session on 'quick to hear, slow to anger,' this moment made the principle inescapable. No member who heard it will forget it. This is also the highest-risk vulnerability of the session — Bryan named a public ministry program and a specific pastoral failure in front of 25 men. That level of transparency is what gives a leader's instruction its authority.\n\nWhat would make it bigger: Bryan did not say 'James 1:19 applies to me too.' He showed the moment when it cost him something. Specificity is the difference between a teaching illustration and a testimony. To replicate: identify one moment from a prior session where you moved on too quickly, name it to the group, and describe what it cost. That takes 90 seconds and earns 90 minutes of credibility.",
+                  "timestamp": "[01:32:25]"
+                },
+                {
+                  "detail": "Member Vulnerability + Full Application  (🟢 Capitalized · Being Real)\n\nWhat happened: Weston shared live: 'My mom right now is currently facing jail time for DUI charge, setting on Brooklyn. She kind of had a court date in a few months, and right now I'm very, you know, a lot of emotion about that. Very angry at her for putting herself in this position. So, for me, this would look like, all right, God, I'm emotional, I'm angry about this. I'm gonna put that aside, surrender my emotion.' [01:40:43–01:41:04]\n\nWhy it mattered: This is the DOK 4 moment the entire passage builds to. James 1:21 commands 'putting aside all filthiness and wickedness, receive with humility the word implanted.' Bryan had asked 'what would putting aside all filthiness and wickedness look like for yourself?' [01:39:46] — and Weston answered with a live crisis. A member sharing an active legal crisis involving a family member AND applying the text correctly AND naming the emotion he needs to put aside is the application round's highest-water mark. This is what the study is for.\n\nWhat would make it bigger: The five vulnerability moments prior to this exchange — Bryan's coaching disclosure, his Facebook story, his adopted son story, his wife's health — lowered the cost of disclosure for members. Weston did not share in spite of the room's norms; he shared because of them. The leader's own vulnerability set the ceiling. To sustain: the vulnerability cascade works because Bryan goes first and goes specific. Generic leader vulnerability ('I struggle with this too') produces generic member responses. Specific leader vulnerability ('I moved on and he went silent for 20 minutes') produces specific member responses.",
+                  "timestamp": "[01:40:43]"
+                },
+                {
+                  "detail": "Ancient-Modern Bridge  (🟢 Capitalized · Teaching Craft)\n\nWhat happened: Bryan connected James 1:14-15 (lust → sin → death) to criminal thinking rehabilitation, using his adopted son's incarceration. Verbatim: 'I'm fortunate I have a son incarcerated for an extended period of time, from 13 to 19... they would try to teach these people about criminal thinking... you don't just rape a person. What happened right before you committed the rape?' [01:04:59–01:06:35]. Then drew the diagram. Then connected it to the bird analogy: 'you can't stop a bird from landing on your head... if he's living with your girlfriend, well, okay, that bird's going to keep coming.'\n\nWhy it mattered: James 1:14-15 describes a universal human process. Bryan gave it three simultaneous anchors: (1) the biblical text itself, (2) folk wisdom (bird analogy), (3) clinical behavioral science (criminal thinking). Three different knowledge systems converging on one truth is what makes teaching unforgettable. The adopted son's incarceration is not a casual illustration — it is personal testimony drawn from family tragedy. When a leader uses his own suffering as a teaching bridge, the group hears it differently than an anecdote about someone else. Stakes are visible. The teaching earns its authority.\n\nWhat would make it bigger: The three-layer structure (text + folk analogy + clinical framework) is replicable. For any key theological process (trial produces endurance, faith without works, etc.), ask: what is the folk wisdom version? What does modern research say? What personal experience validates it? Then sequence: text first, bridge second, personal anchor third. The diagram makes the sequence visible and photographable.",
+                  "timestamp": "[01:01:00]"
+                },
+                {
+                  "detail": "Theological Correction at Depth  (🟢 Capitalized · Teaching Craft)\n\nWhat happened: A member summarized: 'I need to start doing what I believe.' Bryan's immediate response: 'You just misunderstood the last two hours. You're doing what you believe. You need to change what you believe.' [02:03:01–02:03:14]. He continued: 'We think the Western misconception is we can have ideas in our head and they could be different from what I do and I need to match them up. There's no such thing. You're doing what you believe.'\n\nWhy it mattered: The Western discipleship model ('I believe X but I need to act on X') is exactly the misreading James 1:22 addresses. A member voiced it aloud, giving Bryan the opportunity to name and correct the most common error in the room's application of this text. 'You're doing what you believe' is the bumper sticker that encodes the correction. Four other men in the room who hold the same misreading heard it corrected without being singled out. This is why the public teaching environment is more effective than private counseling for theological formation — one correction reaches 25.\n\nWhat would make it bigger: Bryan did not soften the correction ('well, sort of') or delay it. He went directly to the reframe. The member's statement was a gift — it named the exact misunderstanding Bryan had been countering for the whole session. When a member voices the misunderstanding you've been correcting, name it precisely: 'That's the exact thing this passage is pushing back against.' Then restate the text. The group learns from the correction; the member does not feel attacked.",
+                  "timestamp": "[02:03:39]"
+                },
+                {
+                  "detail": "Newcomer Welcome  (🔵 Pivot Point · Building Ministry)\n\nWhat happened: Newcomer James arrived late and shared: 'My biggest thing is I just want to go and help people. I can't do that. I don't know myself. I'm like putting this on before I get somebody else to pass it on. I just want to be full.' [00:12:39–00:13:13]. Bryan's response: 'The best witness you've been making is be the witness. More is caught than taught. You still need to have the words. If God is speaking to you, then you've got a chance to speak on this path.' [00:13:27–00:13:44]\n\nWhy it mattered: 'I just want to be full' is one of the richest newcomer disclosures in this arc. James is describing, by instinct, what theologians call the Patristic distinction between infused grace and active virtue — you cannot give what you have not received. His hunger is theological, not just relational. Bryan heard it and responded correctly, but the response did not linger long enough to let James go deeper. A single follow-up — 'What does full mean for you? What are you most hungry for?' — might have opened a disclosure that defined James's return to the group.\n\nWhat would make it bigger: After 'I just want to be full,' pause for 3 seconds, then ask: 'What does full feel like for you? Where have you seen it in someone else?' That 20-second follow-up gives James room to name what he's actually looking for — which may be the opening conversation that brings him back. For newcomers who disclose a spiritual hunger on the first visit, a direct follow-up question converts a statement into a connection. The invitation has been made; the follow-up completes it.",
+                  "timestamp": "[00:12:24]"
+                }
+              ],
+              "paragraphs": [
+                "These are the disproportionate moments in this session — the exchanges that shaped what this group will remember, believe, and do. Aggregated scores average these away; Key Moments names each one explicitly so Bryan can rewatch with intent."
+              ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "'What appears to be the big idea of this book?' [00:20:52] — DOK 2 — Compare/synthesize across chapters to identify theme. Member answers: saving faith has visible behavior (Chris); trials reveal faith (Tristan). Both valid. — ON TARGET",
+                "'Happy is the man who endures — where did we see that word before?' [00:30:00] — DOK 2 — Text comparison across James 1:2-4 and 1:12. Endurance as connective thread. Members traced the repetition. — STRONG",
+                "'What does it mean to get your crown taken away?' [00:43:04] — DOK 3 — Reason/justify from Revelation 3:11. Members reasoned about renouncing faith vs. losing salvation. Bryan clarified the distinction. — STRONG",
+                "'What do you do when you recognize your bird is nesting?' [01:03:53] — DOK 4 — Apply the bird analogy to personal behavioral patterns. Member: 'if you let that bird keep coming... that bird's going to keep coming.' Strong DOK 4 application. — STRONG",
+                "'Can anybody help me out with this — does it connect to yourself?' [01:35:01] (temptation cascade) — DOK 4 — Apply sin-progression chain to personal life. Opened Weston/Brad/Russ application. Highest DOK 4 yield in the session. — STRONG",
+                "'What would be an example of putting aside all filthiness and wickedness — for yourself or somebody in here?' [01:39:46] — DOK 4 — Personalized application of James 1:21. Weston's mom DUI response was a direct, live DOK 4 answer. — STRONG",
+                "'Why would visiting widows and orphans be on the list of pure religion — why do you think that's on the list?' [01:52:55] — DOK 3 — Reason from God's character/Old Testament priorities. Bryan: 'The God that made us — his heart is for the widow and orphan.' Excellent group reasoning. — STRONG",
+                "'What is the world? What's that code?' [02:00:25] — DOK 2 — Define the biblical concept of 'the world' as a systemic alternative to God's design. Members: 'man-made reference'; 'the system'. Bryan: 'the dog-eat-dog world.' — ON TARGET"
+              ],
+              "paragraphs": [
+                "Big Idea questions only (DOK scored, included in scorecard): 8–10 questions. Scaffolding / reading prompts (DOK 1, excluded from scoring): ~15 navigation/recall prompts ('What does verse 12 say?', 'Read 1 Corinthians 9 for us', etc.). Total Q-to-S ratio in discussion: ~45:55 (below 60:40 target; newcomer welcome block and crown study pull leader ratio up in first 30 minutes)."
               ]
             }
           ],
@@ -1888,197 +2047,238 @@
           ],
           "bigIdeas": [],
           "feedback": {
-            "headline": "A strong session — strongest in Scripture Engagement and Session Structure & Flow, with the clearest next step in Facilitation vs. Lecture.",
+            "headline": "A dense and convicting session — James 1:12–27 surfaced remarkable member vulnerability and produced the James arc's most substantive application round to date.",
             "strengths": [
-              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-              "Application questions pushed members from concept to life, several at the reason/apply level."
+              "Cross-Reference Mastery — 9 Parallel Texts in One Session",
+              "Vulnerability-Chain Reaction — A Cascade the Leader Triggered",
+              "Application Round Depth — Every Member Named a Specific Takeaway"
             ],
             "improvements": [
-              "Leader talk crowded out discussion; the balance leaned toward lecture.",
-              "The session leaned audio-only; a visual anchor would aid retention.",
-              "Prior Big Ideas weren’t reviewed, so last week’s themes faded."
+              "Leader Talk Ratio — Teaching Blocks Pull the First Half Above Benchmark",
+              "Big Ideas Review — Informal Q&A vs. Cumulative Memory Recall",
+              "Cole's Conversion Testimony — Pastoral Moment Needed More Room"
             ],
             "recommendations": [
-              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-              "Next time, put one word-study lookup or a simple table on screen during the key term.",
-              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas."
+              "Open with James L1–L3 Big Ideas Review from Memory (4 min)",
+              "Hold Cole's Thread Open",
+              "Mark 3 Questions in Your Notes for Full Wait-Time (5 sec each)"
             ],
             "overview": [
-              "A strong session — strongest in Scripture Engagement and Session Structure & Flow, with the clearest next step in Facilitation vs. Lecture. It scored 75.28/100 under the v3 weighted model.",
-              "The session played to its strengths in Scripture Engagement and Session Structure & Flow; the recommendations below turn Facilitation vs. Lecture into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+              "A dense and convicting session — James 1:12–27 surfaced remarkable member vulnerability and produced the James arc's most substantive application round to date.",
+              "This report carries the full written coaching for the session: 5 areas of strength, 5 areas for improvement, and 5 recommendations for next session, scored 75.28/100 on the v3 weighted model."
             ],
             "strengthsProse": [
               {
-                "title": "Scripture Engagement anchored the session (5/5)",
+                "title": "Cross-Reference Mastery — 9 Parallel Texts in One Session",
                 "paragraphs": [
-                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 9 cross-references; 2 BLB Greek word studies; exceeds 6+ benchmark"
+                  "Nine cross-references spanning both Testaments — 1 Corinthians 9:24–27, 2 Timothy 4:6–8, 1 Peter 5:1–4, 1 Thessalonians 2:19–20, Revelation 2:10, Revelation 3:11, 1 John 2:15–17, 1 John 3:1–3, and 1 John 3:17–18 — exceeded the 6+ session benchmark by 50%. The crown study alone drew four parallel texts in 12 minutes, giving members a panoramic view of a single concept across Paul, Peter, James, and John. The 1 John 3:17–18 connection ('let us not love with word or tongue, but in deed and truth') to the doers-not-hearers passage was particularly seamless. This is Teaching Craft at its highest: not proof-texting, but weaving a coherent canonical argument.",
+                  "Two BLB word studies added philological depth: the Greek for 'carried away' (animal-trap lure imagery) and 'abide' (to stay near, remain beside). Both unlocked meaning that a surface reading misses."
                 ]
               },
               {
-                "title": "Session Structure & Flow anchored the session (4/5)",
+                "title": "Vulnerability-Chain Reaction — A Cascade the Leader Triggered",
                 "paragraphs": [
-                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Strong blueprint adherence; Big Ideas review informal but present; both prayers captured"
+                  "Bryan's invitation at [00:35:01] — 'Do you recognize that in yourself? Can anybody testify?' — opened a chain reaction of member vulnerability that defined the session's emotional core. Darrell's rehab testimony ('your first thought is wrong — always trust your second or third thought') [00:35:40] unlocked Lance's detailed account of a three-month pornography-recovery class [00:36:49], which unlocked Bryan's own disclosure about deleting all social media apps [00:39:20], which opened Nick's reflection on turning to God rather than a coping outlet [00:40:37]. Four consecutive, increasingly personal shares in 8 minutes — each one made safe by the prior one.",
+                  "This is the best vulnerability sequence in the James arc to date. The key move: Bryan shared his own application ('no YouTube shorts, no Instagram, no Twitter') immediately after Darrell and Lance shared theirs. A leader who shares his own application after inviting others earns the room's trust in a way that no technique can substitute for."
                 ]
               },
               {
-                "title": "Application Questions anchored the session (4/5)",
+                "title": "Application Round Depth — Every Member Named a Specific Takeaway",
                 "paragraphs": [
-                  "Application questions pushed members from concept to life, several at the reason/apply level.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 11 Big Idea questions; DOK 2–4; 36% DOK 4; distributed throughout + full go-around"
+                  "The closing application round [01:40:00–02:04:00] covered approximately 15 members by name, and nearly every one named a specific, personal application rather than a theological observation. Marcus: 'the filth that has come out of my mouth... is holding me back from my true potential by leaps and bounds.' Brad: 'I need to take these promises and lean into them... seems to be a heavy time.' Cole: 'I'm way lower than I thought I was — I have a lot of work to do.' Trent: 'instead of running to somebody to talk about something, I need to run to the Father more.' Vashon: the Haiti Pulp Fiction moment, connecting the orphan-and-widow passage to lived experience.",
+                  "Twenty-six minutes for a go-around in which every member is specific and personal is exceptional. This is the Ebbinghaus curve working in reverse — not retrieval of prior knowledge, but sealing new conviction in long-term memory through personal application articulation."
                 ]
               },
               {
-                "title": "Participant Engagement anchored the session (4/5)",
+                "title": "Leader Multiplication Visibility — Three Signals in One Session",
                 "paragraphs": [
-                  "A high share of the room contributed substantively, called on by name.",
-                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
-                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 15+ named contributors; 8 scripture readers; ~15 go-around participants"
+                  "Three explicit leader-multiplication moments surfaced in one session: (1) Hunter's upcoming baptism [02:05:51] — Bryan announced it to the group and tied it to the next season of ministry; (2) Brendan praised publicly by name [01:48:28] — 'you ask him a question and he can wait... that young man's got great leadership skill'; (3) Pocan's son confirmed as the newest Precept leader [01:47:54] — 'he's leading a couples class.' That is three members of Bryan's ecosystem — a disciple being baptized, an apprentice leader publicly affirmed, a multiplication product running his own class. This is 2 Timothy 2:2 in action: Paul → Timothy → faithful men → others."
                 ]
               },
               {
-                "title": "Vulnerability / Authenticity anchored the session (4/5)",
+                "title": "Conceptual Architecture — Trials vs. Temptation Built with Precision",
                 "paragraphs": [
-                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
-                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
-                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 4 Bryan disclosures; cascade of member vulnerability; Cole's conversion testimony; Marcus tongue confession"
+                  "The trials/temptation distinction (James 1:2–16) was scaffolded carefully before the key insight landed: 'Trials have purpose to mature you and are from God. Temptation is from your inner lust, and it's to kill you. He's trying to make a distinction — don't think a trial is like a temptation.' [00:46:02]. The criminal thinking illustration [00:32:02] — drawn from Bryan's adopted son's incarceration — was the most pedagogically powerful moment in the session. It translated an abstract theological progression (lust → sin → death) into a concrete rehabilitation protocol that inmates actually use. That bridge from ancient text to modern clinical practice gave the group a secular corroboration of James's theology that no proof-text could provide."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "title": "Leader Talk Ratio — Teaching Blocks Pull the First Half Above Benchmark",
                 "paragraphs": [
-                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: ~41% leader talk; first-half teaching blocks pull above 30% benchmark; second half recovers"
+                  "Estimated leader talk with scripture reading: ~40%. Discussion only: ~42%. The Lifeway 30% Rule targets ≤30–35% during discussion time. The gap is primarily in the first 45 minutes: the Big Ideas review, the crown study, and the temptation/sin-process explanation all run at 55–60% leader talk. The second half recovers dramatically — the application round is 80–85% members.",
+                  "The fix is not to shorten the teaching but to insert more wait-time at natural pauses. 'What's the next piece of logic?' [00:38:55] was answered before the group fully engaged. 'What connects the message on trials with this message?' [00:44:26] drew a 30-second silence, then Bryan answered his own question: 'It's almost like trials have purpose to mature you... He's trying to make a distinction.' That is the moment where a 5-second hold would have produced a member answer at DOK 4 rather than a leader answer.",
+                  "Target for James L4: choose 3 questions in the first half where you hold silence for a full 5 seconds before speaking. Mark them in your notes in advance."
                 ]
               },
               {
-                "title": "Visual Aids is a growth area (3/5)",
+                "title": "Big Ideas Review — Informal Q&A vs. Cumulative Memory Recall",
                 "paragraphs": [
-                  "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: BLB for 2 word studies; no slides, whiteboard, or maps"
+                  "The session opened well [00:01:00] — Bryan walked the group through author, recipients, and book theme using named members (Cole as the 'returning' framing device was excellent). But this was a guided Q&A, not a cumulative bumper-sticker recall. The Ebbinghaus retrieval protocol requires members to produce the Big Ideas from memory without prompts — 'Give me the Big Ideas from the last two weeks. Memory only. Go.' That unsupported retrieval is what moves information from fragile short-term to durable long-term memory.",
+                  "James L3 carries 15+ Big Ideas from three sessions of dense content. A 4-minute cold-recall drill — before any new teaching — would have surfaced 5–8 of them from members without prompting and made the group's comprehension of the new content visibly higher. The member who said [00:06:42] 'I'm breaking myself of the habit of saying things that aren't in the book' — that is the Ebbinghaus mechanism working. He's encoding through repeated articulation. A formal recall drill amplifies that for everyone."
                 ]
               },
               {
-                "title": "Memory Reinforcement is a growth area (3/5)",
+                "title": "Cole's Conversion Testimony — Pastoral Moment Needed More Room",
                 "paragraphs": [
-                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Informal review at start (not formal recall drill); 6 bumper stickers surfaced; no formal closing drill"
+                  "Cole disclosed [01:47:17]: 'We had the twins almost two years ago. My wife and I both lost our job. We lost the house. I had a perception of where my faith was at before tonight. And I'm way lower than I thought I was. I went into the last trial in Atheist, and I'm here.' This is a faith-conversion testimony embedded in an application round — one of the most significant disclosures in the James arc. Bryan's immediate response: 'If you didn't learn on this first trial, God will give you another one. So I would take everything you just said and go as fast as I could to application.' [01:48:47]",
+                  "The coaching was correct and direct. But the disclosure needed to breathe first. An 8-second pause after 'I went into the last trial in Atheist, and I'm here' — followed by 'Tell us more' or 'What changed?' — would have given Cole the room to say what he may have needed to say, and given the group a moment to honor what they just witnessed. The theological pivot ('God will give you another trial') landed too quickly to let the room feel the weight of someone announcing a faith journey. Cole added 'I went into the last trial in Atheist, and I'm here. Come on.' Bryan's 'Come on' and 'I'm glad you're with us' came after the coaching. The sequence was reversed."
                 ]
               },
               {
-                "title": "Homework References is a growth area (3/5)",
+                "title": "Visual Aids — Conceptual Diagrams Would Anchor Dense Theology",
                 "paragraphs": [
-                  "Homework went unmentioned, reducing its pull on the group.",
-                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: No explicit Guarantee; one casual next-week reference; one member disclosed weak homework week"
+                  "The sin-progression diagram (lust → carried away → sin → death) is one of the most teachable frameworks in all of James. It maps cleanly to a whiteboard or slide — three columns, one arrow each. The criminal thinking parallel (initial inclination → escalation → crime) makes it even more visual. This session had BLB for two word studies, but no diagrams, no slides, no maps. Score: 3/5 (Visual Aids).",
+                  "James 1:13–16 is not a narrative — it is a logic chain. Logic chains memorize better with a visible structure. A one-slide diagram of the sin-progression, referencing James 1:14–15, would give members something to photograph and return to during the week. The crown study (James 1:12 + five parallel texts) would also benefit from a simple table: Crown Type | Reference | Recipient."
                 ]
               },
               {
-                "title": "Prayer is a growth area (4/5)",
+                "title": "Homework References — 'The Guarantee' Missing, Next Week Casual",
                 "paragraphs": [
-                  "Prayer was leader-only or rushed; the group’s voice was thin.",
-                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
-                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Opening prayer delegated (captured at recording start); closing prayer delegated to member (on-topic, referenced James themes); prayer chain (Craig Rooker follow-up)"
+                  "The Guarantee — 'Do the homework, show up, and I guarantee God will speak to you' — is Bryan's highest-leverage enrollment tool for the Precept workbook. It appeared in zero sessions this arc. The homework is what separates this study from a discussion group, and The Guarantee is what makes the homework compelling. One member disclosed [01:00:42] 'I didn't do a great job in the homework this week' — that is the exact moment for The Guarantee.",
+                  "At close, Bryan said: 'I haven't looked at next week's homework but I'm guessing it's in chapter two' [02:04:57]. That framing — the leader guessing at next week's content — undercuts the homework's authority. The close is the highest-leverage enrollment moment of the session. Recommended close instead: 'Next week we're in James 2 — personal favoritism. The homework you do this week is what makes the difference between having opinions about it and actually being changed by it. Do the homework. I guarantee God will speak to you through it.' 20 seconds. Maximum authority."
                 ]
               }
             ],
             "recommendationsProse": [
               {
-                "title": "Next session — Facilitation vs. Lecture",
+                "title": "Open with James L1–L3 Big Ideas Review from Memory (4 min)",
                 "paragraphs": [
-                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Before any new content: 'Give me the Big Ideas from the last three weeks. Memory only — no notes. Go.' Hold silence for 8 seconds. Call on a member who hasn't led recall yet. Let the group surface 5–7 unprompted. Then: 'Okay. Tonight we're adding to these.' That four-minute drill is the highest-ROI move in the session — it moves prior Big Ideas from fragile recall to durable memory while demonstrating the cumulative value of the study to everyone in the room. Recommended Big Ideas to test for recall: (1) Trials are from God and for our benefit — endure them. (2) Sin has to be conceived before it's committed. (3) The heart of every sin is doubting God's goodness. (4) Every good thing has one return address. (5) Well done, not well heard. (6) Pure religion: bridle your tongue, visit the orphan and widow."
                 ]
               },
               {
-                "title": "Next session — Visual Aids",
+                "title": "Hold Cole's Thread Open",
                 "paragraphs": [
-                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Before James L4 begins: 'Cole — last week you said something I've been thinking about all week. You said you went into your last trial as an atheist, and you're here. Will you tell us more about that?' One minute. Let the room hear the full story. Then: 'Men, did you hear that?' That one question at the start of L4 honors what Cole offered and raises the group's vulnerability ceiling before the new content even begins."
                 ]
               },
               {
-                "title": "Next session — Memory Reinforcement",
+                "title": "Mark 3 Questions in Your Notes for Full Wait-Time (5 sec each)",
                 "paragraphs": [
-                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "James 2 on favoritism has several high-stakes application questions where the group will have strong, personal answers if given enough silence. Before the session, mark three specific questions in your outline. When you hit them, ask the question, set the phone down, look at the camera, and count to five in your head before speaking. If the room is still silent at five, say 'Take another moment.' The research on wait-time (Rowe, Stahl) is unambiguous: group response rate and quality both increase sharply when silence exceeds 3 seconds. Your instinct is to rescue — resist it for those three marked questions."
                 ]
               },
               {
-                "title": "Next session — Homework References",
+                "title": "Bring One Visual for James 2",
                 "paragraphs": [
-                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "James 2:1–13 (favoritism) maps perfectly to a single two-column slide or whiteboard diagram: 'How the world sees people' vs. 'How God sees people.' Rich man / poor man, prominent seat / footstool, with James 2:9 ('you have committed sin') as the dividing line. One visual costs 5 minutes to prepare and gives members something to photograph. The lesson will stick longer when it has a spatial anchor in memory."
                 ]
               },
               {
-                "title": "Next session — Prayer",
+                "title": "Deploy The Guarantee at Close",
                 "paragraphs": [
-                  "Next time, ask one member to open and a different member to close in prayer.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "At the close of James L4: 'Next week we're deeper into James 2 — favoritism and the royal law. The homework you do this week is what determines whether you have opinions about it on Thursday or whether it actually changes how you treat people. Do the homework. Show up. I guarantee God will speak to you through it.' Twenty seconds. Maximum enrollment authority. The Guarantee has not appeared in the James arc — James 2's 'royal law of love' is the ideal passage to re-deploy it. Bible Leader Coaching | Bryan Bailey | May 28, 2026"
                 ]
               }
             ]
           },
           "sections": [
             {
-              "title": "Score composition",
-              "paragraphs": [
-                "How the four weighted clusters and any session bonuses combined into the composite score."
-              ],
+              "title": "Scorecard — 1. Attendees",
               "bullets": [
-                "Teaching Craft: 76% × weight 33 → 25.08 pts",
-                "Building Ministry: 70% × weight 31 → 21.70 pts",
-                "Engaging People: 70% × weight 18 → 12.60 pts",
-                "Being Real: 80% × weight 18 → 14.40 pts",
-                "Base (sum of cluster contributions): 73.78 / 100",
-                "Session bonuses: group-size +1.5",
-                "Session score: 75.28 / 100"
+                "Total attendees: ~18 men  (Target: Consistent with Thursday group baseline)  → ON TARGET",
+                "Newcomers: 0  (Target: 7–25 min welcome protocol)  → N/A"
               ]
             },
             {
-              "title": "Coaching notes by dimension",
-              "paragraphs": [
-                "The per-dimension rationale behind each score on the 12-dimension scorecard."
-              ],
+              "title": "Scorecard — 2. Scripture Focus",
               "bullets": [
-                "Session Structure & Flow (4/5): Strong blueprint adherence; Big Ideas review informal but present; both prayers captured",
-                "Newcomer Welcome (N/A): No newcomers — Building Ministry max reduced proportionally",
-                "Scripture Engagement (5/5): 9 cross-references; 2 BLB Greek word studies; exceeds 6+ benchmark",
-                "Facilitation vs. Lecture (3/5): ~41% leader talk; first-half teaching blocks pull above 30% benchmark; second half recovers",
-                "Application Questions (4/5): 11 Big Idea questions; DOK 2–4; 36% DOK 4; distributed throughout + full go-around",
-                "Participant Engagement (4/5): 15+ named contributors; 8 scripture readers; ~15 go-around participants",
-                "Visual Aids (3/5): BLB for 2 word studies; no slides, whiteboard, or maps",
-                "Vulnerability / Authenticity (4/5): 4 Bryan disclosures; cascade of member vulnerability; Cole's conversion testimony; Marcus tongue confession",
-                "Memory Reinforcement (3/5): Informal review at start (not formal recall drill); 6 bumper stickers surfaced; no formal closing drill",
-                "Homework References (3/5): No explicit Guarantee; one casual next-week reference; one member disclosed weak homework week",
-                "Prayer (4/5): Opening prayer delegated (captured at recording start); closing prayer delegated to member (on-topic, referenced James themes); prayer chain (Craig Rooker follow-up)",
-                "Leader Development (4/5): Hunter's baptism June 6; Brendan praised publicly; Pocan's son running couples class — three multiplication signals in one session"
+                "Leader talk ratio (with scripture reading): ~40%  (Target: ≤35% (Lifeway 30% Rule))  → NEEDS WORK",
+                "Leader talk ratio (discussion only): ~42%  (Target: ≤30% (Lifeway, Flanders))  → NEEDS WORK",
+                "Cross-references: 9 (1 Cor 9, 2 Tim 4, 1 Pet 5, 1 Thes 2, Rev 2, Rev 3, 1 Jn 2, 1 Jn 3:1–3, 1 Jn 3:17–18)  (Target: 6+ per session)  → STRONG",
+                "Blue Letter Bible usage: 2 word studies (Greek: 'carried away,' 'abide')  (Target: At least 1 per key term)  → STRONG",
+                "% discussion grounded in scripture: ~70%  (Target: ≥70%)  → ON TARGET",
+                "Time to first scripture reading: ~12 min (after Big Ideas review)  (Target: Within 15 min of lesson start)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 3. Time Management",
+              "bullets": [
+                "Total session time: ~127 min  (Target: 90–120 min)  → ON TARGET",
+                "Big Ideas review at start: ~12 min — informal Q&A recall (author, background, trials theme)  (Target: 5–10 min cumulative recall)  → ON TARGET",
+                "Crown study / cross-ref block: ~11 min  (Target: Per session flow)  → ON TARGET",
+                "Core teaching (Jas 1:13–27): ~65 min  (Target: 60–80 min)  → STRONG",
+                "Application round (full go-around): ~26 min  (Target: 15–25 min)  → STRONG",
+                "Closing / admin / prayer: ~8 min  (Target: 5–10 min)  → STRONG",
+                "Tangent time: ~5 min (AI coaching discussion, humor digression)  (Target: < 10 min)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 4. Application Questions",
+              "bullets": [
+                "Big Idea questions (DOK scored): 11 questions  (Target: 5–7 per session)  → STRONG",
+                "DOK Level 4 (apply to life): 4 of 11 (36%)  (Target: ≥25%)  → STRONG",
+                "DOK Level 3 (reason/justify): 5 of 11 (45%)  (Target: ≥35%)  → STRONG",
+                "DOK Level 2 (compare/analyze): 2 of 11 (18%)  (Target: ≤40%)  → STRONG",
+                "DOK Level 1 (recall — excluded): ~20 scaffolding prompts (not scored)  (Target: Excluded from DOK)  → N/A",
+                "Application spacing: Distributed throughout; full go-around at close  (Target: Woven throughout + close)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — 5. Engagement",
+              "bullets": [
+                "Named participants engaged: 15+ members called by name to contribute  (Target: 70–80% of attendees)  → STRONG",
+                "Members who read scripture aloud: ~8 different readers (Tristan, Pocan, Brad, Mark, Darrell, Ernest, Lance, Chris)  (Target: Multiple readers per session)  → STRONG",
+                "Members who asked questions / added insight: ~12 distinct contributors in discussion  (Target: ≥60% of attendees)  → STRONG",
+                "Application round participation: ~15 members shared named takeaways  (Target: Full group participation)  → STRONG",
+                "Wait time after questions: Moderate — some questions answered quickly before group could respond  (Target: 3–5 sec (Rowe 1972))  → ON TARGET",
+                "Quiet member engagement: Taylor (muted, encouraged); Vashon (muted but shared at close)  (Target: Seek out quiet members)  → ON TARGET",
+                "Visual aids used: Blue Letter Bible (word studies); no slides or whiteboard  (Target: Charts, maps, BLB)  → NEEDS WORK"
+              ]
+            },
+            {
+              "title": "Scorecard — 6. Leadership",
+              "bullets": [
+                "Vulnerability moments (leader): 4 disclosures: adopted son's incarceration [00:31:31]; no social media on devices [00:39:20]; personal anger acknowledgment [00:59:27]; orphans/adoption reflection [01:32:20]  (Target: 2–3 per session, weighted by depth)  → STRONG",
+                "Member vulnerability moments: 3+ significant: Darrell's rehab disclosure ('first thought is wrong') [00:35:40]; Cole's twins/job loss/atheism-to-faith testimony [01:47:17]; Marcus's tongue confession [01:44:38]  (Target: Peer vulnerability present)  → STRONG",
+                "Teaching monologues > 90 sec: ~4 monologues (criminal thinking story, sin-conception process, doers illustration, adoption reflection)  (Target: < 3 per session)  → NEEDS WORK",
+                "Pastoral response to member disclosures: Responsive to most; Brad's trial disclosure and Marcus's tongue confession got brief replies; Cole's conversion testimony received direct coaching before pastoral care  (Target: Sit with disclosure before reframing)  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Scorecard — 7. Question Quality",
+              "bullets": [
+                "% open-ended Big Idea questions: 10 of 11 (91%)  (Target: ≥70%)  → STRONG",
+                "% requiring scripture to answer: ~60%  (Target: ≥50%)  → STRONG",
+                "Follow-up probes used: Yes — frequent: 'say more,' 'what does that look like,' 'give me a bumper sticker'  (Target: Per Webb DOK standards)  → STRONG",
+                "Q-to-S ratio (discussion): ~50:50 (Q slightly below 60:40 target — teaching blocks pull leader up)  (Target: 60:40 Q:S minimum)  → ON TARGET",
+                "Productive struggle honored: Moderate — some answers supplied before full group engagement  (Target: Redirect, don't rescue)  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Scorecard — 8. Study Method & Communication",
+              "bullets": [
+                "Big Ideas review at session start: Yes — informal Q&A on author, theme, trials (12 min); not a formal bumper-sticker recall drill  (Target: Cumulative recall from memory)  → ON TARGET",
+                "Big Ideas surfaced at close: Yes — 'consider it joy,' 'sin conceived before committed,' 'every good thing has one return address,' 'well done not well heard,' 'pure religion is visiting orphans and widows'  (Target: 5–6 per session)  → STRONG",
+                "Homework references: Indirect — one member admitted weak homework; BLB word study implied; next week's homework referenced casually at close  (Target: Explicit Precept reference + The Guarantee)  → NEEDS WORK",
+                "Topic drift: ~5 min on AI coaching (productive teaching moment — used to reinforce quick-to-hear); ~2 min humor digression  (Target: < 10 min total)  → STRONG",
+                "Bumper stickers generated: 5 canonical: 'Sin has to be conceived before committed,' 'The heart of every sin is doubting God's goodness,' 'Every good thing has one return address,' 'Well done not well heard,' 'Pure religion: bridle tongue, visit orphans'  (Target: 4–6 per session)  → STRONG",
+                "Closing summary / call to action: Bryan: 'Don't deceive yourself — let it become something you do. When you feel called to act, do it right away.' [02:03:47]  (Target: Concrete close with call to action)  → STRONG"
+              ]
+            },
+            {
+              "title": "Key Moments",
+              "moments": [
+                {
+                  "detail": "Vulnerability  (🟢 Capitalized · Being Real)\n\nWhat happened: Bryan asked, 'Do you recognize that in yourself? Can anybody testify?' after teaching the sin-conception chain. Darrell responded immediately with his rehab testimony: 'Your first thought is wrong — always trust your second or third thought.' This opened Lance's pornography-class account, which opened Bryan's own social media deletion disclosure. Verbatim trigger: 'Can anybody help me out with this? Does it connect to yourself?' [00:35:01]\n\nWhy it mattered: The sin-conception passage (Jas 1:14–15) is intellectually satisfying but clinically remote unless someone demonstrates what it looks like in practice. Darrell's rehab testimony — drawn from addiction-recovery therapy — provided empirical corroboration of James's 2,000-year-old framework. Four members then contributed, each making the framework personal. When a leader's theological teaching produces a spontaneous cascade of application testimony, the group is no longer studying about sin — they are reckoning with their own.\n\nWhat would make it bigger: The invitation was specific ('Can anybody testify?') rather than generic ('Any thoughts?'). Specificity creates permission. Bryan's personal disclosure immediately after the group shared lowered the status differential. To replicate: after teaching a principle, name the type of evidence you want ('Can anyone give me an example from your own experience where this played out?') and then share your own before moving on.",
+                  "timestamp": "[00:35:01]"
+                },
+                {
+                  "detail": "Pastoral Response  (🟠 Missed Opportunity · Being Real)\n\nWhat happened: During the application round, Cole shared: 'We had the twins almost two years ago. My wife and I both lost our job right there before and right thereafter. We lost the house we were living in. I had a perception of where my faith was at before tonight. And I'm way lower than I thought I was... I went into the last trial in Atheist, and I'm here.' [01:49:17]\n\nWhy it mattered: Cole disclosed a faith conversion embedded in a trial trilogy: lost job, lost house, lost theological certainty (entered as an atheist). His closing line — 'I went into the last trial in Atheist, and I'm here' — is a before-and-after faith statement, not a general application observation. The room needed to honor that before moving. This is the kind of testimony that sets the group's vulnerability ceiling for months. When it goes unmarked, or is immediately redirected to coaching, the group infers that conversion stories are not worth the full weight of the room's attention.\n\nWhat would make it bigger: After 'I went into the last trial in Atheist, and I'm here': pause 6 seconds. Then: 'Cole — say that again, slowly.' Let him repeat it. Then to the room: 'Men, did you hear that?' Then to Cole: 'Tell us what changed. What was the thing that moved you from atheist to here?' Then — and only then — pivot to the coaching ('God will use the next trial to deepen it'). The sequence: honor → invite → explore → then coach. Reversing it (coach → honor) compresses a conversion testimony into a teaching point.",
+                  "timestamp": "[01:47:17]"
+                },
+                {
+                  "detail": "Application Bridge  (🟢 Capitalized · Teaching Craft)\n\nWhat happened: Vashon shared three trips to Haiti, the 'veil is thin' experience, and Erlin the clinician who opens the gate for neighborhood children after work. Verbatim: 'I've never felt closer to God... I think it's because there's so much compassion for widows and orphans there.' [02:00:29]\n\nWhy it mattered: James 1:27 risks sounding abstract in an affluent Thursday evening Zoom group. Vashon's Haiti testimony transformed it into something the room had seen, smelled, and felt. Erlin opening the compound gate for neighborhood children is the incarnation of pure religion. Bryan's response — 'I totally buy this passage just experientially' — authenticated Vashon's story as theological evidence, not mere anecdote. This is the session's emotional high point and the moment members will carry into the week.",
+                  "timestamp": "[01:59:43]"
+                },
+                {
+                  "detail": "Pastoral Hold  (🔵 Pivot Point · Being Real)\n\nWhat happened: Marcus shared: 'Folks that know me well, I can withhold physical discipline more than just about anyone I've met, which has helped me hold back from a lot of physical sin. But my goodness, the filth that has come out of my mouth and the ways I've hurt people has always been with my mouth, and it's holding me back from my true potential by leaps and bounds.' [01:44:38]\n\nWhy it mattered: Marcus named a specific pattern of sin with specific consequence ('ways I've hurt people') and tied it to a self-limiting belief ('holding me back from my true potential'). This is a level-3 vulnerability moment — not just a theological observation but a public acknowledgment of a recurring failure. The application round is the highest-stakes moment for pastoral impact, and a three-second acknowledgment before moving on is the bare minimum. The group needed to hear Bryan say something like: 'Marcus — that's honest. And you just described exactly what James 1:26 is getting at. When you're ready, keep talking to me about that.'\n\nWhat would make it bigger: After Marcus finishes: pause 4 seconds. 'Marcus — what does it look like when it shows up?' Let him get specific. Then: 'Has anyone else seen that pattern — where the part of you that's disciplined in one area is exactly what's unchecked in another?' A 60-second hold would have connected Marcus's disclosure to a pattern that 4–5 others in the room almost certainly share. Then move to Pocan.",
+                  "timestamp": "[01:44:38]"
+                }
+              ],
+              "paragraphs": [
+                "These are the disproportionate moments in this session — the exchanges that shaped what this group will remember, believe, and do. Aggregated scores average these away; Key Moments names each one explicitly so Bryan can rewatch with intent."
               ]
             }
           ],
@@ -2202,197 +2402,252 @@
           ],
           "bigIdeas": [],
           "feedback": {
-            "headline": "A strong session — strongest in Newcomer Welcome and Application Questions, with the clearest next step in Session Structure & Flow.",
+            "headline": "Four newcomers fully engaged through strong member testimonies and The Guarantee; Bryan’s stillborn baby disclosure validated the Romans 5 hope promise from lived experience. Cross-reference count below Bryan’s benchmark (1 vs. 6+ target) after the discussion ran long.",
             "strengths": [
-              "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
-              "Application questions pushed members from concept to life, several at the reason/apply level.",
-              "A high share of the room contributed substantively, called on by name."
+              "Newcomer Welcome Executed at Blueprint Level — Four New Men Anchored",
+              "The Guarantee Delivered With Full Conviction and Personal Testimony",
+              "Bryan’s Stillborn Baby Disclosure — Highest-Cost Vulnerability of the Session"
             ],
             "improvements": [
-              "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
-              "Discussion drifted from the text; a few more passages would ground the teaching.",
-              "Leader talk crowded out discussion; the balance leaned toward lecture."
+              "Cross-Reference Count Well Below Benchmark — Only Romans 5 Used (vs. 9 Last Session)",
+              "Eddie’s Vulnerability Disclosure — Theological Pivot Without Pastoral Acknowledgment",
+              "Opening Prayer Not Captured — Session Blueprint Step 2 Unclear"
             ],
             "recommendations": [
-              "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
-              "Next time, pre-mark 3 cross-references to pull in during the densest teaching block.",
-              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds."
+              "Open with L1+L2 Big Ideas Review from Memory (3 min)",
+              "Pre-assign 3 Cross-References Before the Session",
+              "Ask Justin Harvey to Speak Into the Lesson"
             ],
             "overview": [
-              "A strong session — strongest in Newcomer Welcome and Application Questions, with the clearest next step in Session Structure & Flow. It scored 77.05/100 under the v3 weighted model.",
-              "The session played to its strengths in Newcomer Welcome and Application Questions; the recommendations below turn Session Structure & Flow into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+              "Four newcomers fully engaged through strong member testimonies and The Guarantee; Bryan’s stillborn baby disclosure validated the Romans 5 hope promise from lived experience. Cross-reference count below Bryan’s benchmark (1 vs. 6+ target) after the discussion ran long.",
+              "This report carries the full written coaching for the session: 5 areas of strength, 5 areas for improvement, and 5 recommendations for next session, scored 77.05/100 on the v3 weighted model."
             ],
             "strengthsProse": [
               {
-                "title": "Newcomer Welcome anchored the session (4/5)",
+                "title": "Newcomer Welcome Executed at Blueprint Level — Four New Men Anchored",
                 "paragraphs": [
-                  "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
-                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
-                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 4 newcomers, all engaged. Strong existing-member testimonies (Brendan, Andy Truebert, Austin). The Guarantee delivered. Personal challenge to Mauricio. Missed: Eddie’s hurt not acknowledged before theological pivot."
+                  "Four men walked into a multi-year group cold. Bryan ran the blueprint: existing members gave testimonies first (Andy Truebert, Austin, Brendan) before newcomers spoke — showing guests what authentic engagement looks like before asking it of them. Brendan’s testimony was the emotional centerpiece: “my whole life has completely changed... before I got in the study, I was as sinful as I got.” All four newcomers gave substantive self-introductions, and Bryan gave each a personal follow-up challenge (Mauricio: “this weekend go home and tell your wife what you learned”).",
+                  "“My whole life has completely changed and turned around for the absolute best. When it came to before I got in the study, I was as sinful as I got. And now I can have the courage and knowledge and wisdom to deny temptation and to endure temptation.” [00:04:05]",
+                  "Three of the four newcomers came to this study for explicitly personal reasons — recovery, a struggling marriage, double divorce. Brendan’s testimony is the direct answer to all three. For Justin, Mauricio, and Eddie, it is proof that the system works on people with real damage, not just curious seekers."
                 ]
               },
               {
-                "title": "Application Questions anchored the session (4/5)",
+                "title": "The Guarantee Delivered With Full Conviction and Personal Testimony",
                 "paragraphs": [
-                  "Application questions pushed members from concept to life, several at the reason/apply level.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 9 Big Idea questions, all DOK 2–4. DOK distribution: 33% Level 4, 45% Level 3, 22% Level 2. Questions distributed throughout; strong synthesis round at close. No DOK 1 questions scored. Matches Bryan’s best recent sessions on question quality."
+                  "Bryan gave the core homework pitch — “The Guarantee” — early and with conviction: “If you do this homework and make that your practice and then you come every week, I guarantee eventually you will see God beginning to speak to you.” He then grounded it in his own story (“I did this homework for a long time before I began to see that change”) and expanded to the scale of the ministry (“22 groups now”). For four newcomers hearing this pitch for the first time, the combination of the promise + personal testimony + scale is the most credible version of the argument.",
+                  "“If you do the homework, make that your practice, come every week — I guarantee eventually you will see God beginning to speak to you. And when God speaks to you, you change.” [00:08:00]",
+                  "Bryan also translated The Guarantee directly to Mauricio’s stated goal: “you put your nose in God’s word and say speak to me — there’s no way you will completely avoid what you were talking about.” That is personalized application of a general principle, the highest-skill version of a pitch."
                 ]
               },
               {
-                "title": "Participant Engagement anchored the session (4/5)",
+                "title": "Bryan’s Stillborn Baby Disclosure — Highest-Cost Vulnerability of the Session",
                 "paragraphs": [
-                  "A high share of the room contributed substantively, called on by name.",
-                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
-                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 20+ named voices; 10+ with substantive contributions; >40% of named participants contributed. Quiet members called on directly. All 4 newcomers gave substantive introductions. Estimated participation rate ~75–80%."
+                  "At the close of the lesson, after building the entire logic chain of trials → endurance → proven character → hope (Rom 5:3–5), Bryan disclosed losing his first child: “Spirit baby dies in our home, our first child... my wife and I cried until you literally could have put an onion in my face and no tears would come out.” He then described walking outside and feeling “an overwhelming sense of peace — that was hope.”",
+                  "“I remember walking outside of my house first time ever and I felt an overwhelming sense of peace — that was hope. Because my character was proven. And that’s partly how I know this book is true.” [02:00:50]",
+                  "This is the highest-cost personal disclosure in Bryan’s recent arc. Eddie is double divorced with “a lot of hurt in here.” Justin runs a treatment center for people at their lowest. Mauricio just got married and is figuring out what faith looks like in real life. Bryan’s willingness to go to the bottom of his own pain — and emerge with proof that the passage is true — is the exact authority move the room needed at the exact moment it was made."
                 ]
               },
               {
-                "title": "Vulnerability / Authenticity anchored the session (4/5)",
+                "title": "Blue Letter Bible Word Study Demonstrated Live — Seven Greek Roots Unpacked",
                 "paragraphs": [
-                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
-                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
-                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Stillborn first child disclosure is the highest-cost vulnerability in Bryan’s recent arc. Trials breakdown disclosure and heart attack reference add supporting depth. Weighted by depth: stillborn carries the score. Missed: Eddie’s vulnerability could have been reciprocated earlier."
+                  "Bryan taught the room how to use Blue Letter Bible by walking through it on screen for seven consecutive Greek words: consider (hēgeomai — to count, bank on), joy (chara — calm delight, gladness), trial (peirasmos — testing/proving), faith (pistis — assurance, trust), knowing (ginoskō — perceive, understand), endurance (hupomons — remaining under), humiliation (tapeinōsis — littleness in God’s eyes). Each word study corrected a natural English misreading before it could take root.",
+                  "“If you really don’t think about what is being said, you would totally miss it. You could say, hey, maybe think about it, this might be a lot of fun. Right? And you would be reading it totally wrong.” [00:41:58]",
+                  "For newcomers Justin and Eddie, this is also a skill transfer: they now know how to study this book on their own. The word studies weren’t just content delivery — they were a how-to demonstration for home use during the week."
                 ]
               },
               {
-                "title": "Homework References anchored the session (4/5)",
+                "title": "Strong Big Ideas Synthesis at Close — Group Named Five Canonical Takeaways",
                 "paragraphs": [
-                  "Homework was referenced and rewarded, differentiating the members who prepared.",
-                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
-                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: The Guarantee delivered with full conviction and personal story. Multiple references to the 5-day homework rhythm. BLB instruction is direct homework skill-transfer. Closing prompt: “you’ve got five days to study a few verses.” Slightly below May 22 (5/5) due to less explicit homework tracking this session."
+                  "Bryan closed by asking the group to name the big ideas, and members generated all five: trials have purpose and are God’s curriculum; tested faith produces maturity; God wants to give you his viewpoint on your trial — just ask; double-mindedness makes you unstable in all ways; rich or poor, the need is the same (God’s wisdom). Bryan then framed the third Big Idea: “God wants to give you his viewpoint just as… that’s quite a promise.” This is the canonical close working as designed — members retrieving and owning the learning before they leave.",
+                  "“Trials have purpose — there’s a grand design. Trials are not interruptions, there’s a curriculum. God is taking you somewhere.” [01:54:49]"
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Session Structure & Flow is a growth area (3/5)",
+                "title": "Cross-Reference Count Well Below Benchmark — Only Romans 5 Used (vs. 9 Last Session)",
                 "paragraphs": [
-                  "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Blueprint followed (newcomer welcome → overview → scripture → application → Big Ideas → closing prayer). Opening prayer not captured. No formal cumulative Big Ideas review from L1. Ran over by ~8 min."
+                  "Bryan covered Jas 1:1–11 with one cross-reference passage (Rom 5:3–5) and seven Greek word studies via Blue Letter Bible. The prior session (May 22) used nine cross-references for the same passage. Bryan acknowledged the gap at the close: “I skipped all the cross-references because of the way the discussion went.” The word studies were excellent, but they consumed the session time that would have funded the parallel texts.",
+                  "Research benchmark: 6+ cross-references per session (Precept methodology, Bryan’s own standard). A session that stays in one passage with no parallel texts misses the Three-Source Parallel Reading technique that makes Bryan’s study distinctive. For a book like James that has direct parallels in 1 Peter 1:6–9, 1 Peter 4:12–13, Proverbs, and Romans 8:28, the network exists and is highly teachable.",
+                  "For Lesson 3 (Jas 1:12–18): pre-assign 3 cross-references before the session. Write them in the homework. Give one to a specific member (“Russell, you’re on Romans 5:3–5 — bring it and tell us why it belongs”). If discussion runs long, defer a Socratic question rather than a cross-reference. The parallel texts are the structural DNA of the study."
                 ]
               },
               {
-                "title": "Scripture Engagement is a growth area (3/5)",
+                "title": "Eddie’s Vulnerability Disclosure — Theological Pivot Without Pastoral Acknowledgment",
                 "paragraphs": [
-                  "Discussion drifted from the text; a few more passages would ground the teaching.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: 1 cross-reference passage (Rom 5:3–5) plus 7 Greek word studies via BLB. Cross-ref count (2 passages) is well below the 6+ benchmark. Bryan acknowledged skipping prepared cross-refs. Word study depth is excellent but doesn’t substitute for parallel-text density."
+                  "Eddie introduced himself by sharing double divorce and the emotional weight it carries: “I’m divorced. I’m actually double divorced. So there’s a lot of hurt in here and also a father.” Bryan’s response pivoted immediately to theology: “I’ll tell you something about truth. There ain’t no such thing as deep truth. There’s just truth and falsehood. You’re in the right spot.” The theological content is correct. The pastoral beat was skipped.",
+                  "Eddie came as a first-time visitor who is a seeker. He disclosed a wound — “a lot of hurt in here” — in front of a room full of strangers on his very first day. That kind of public vulnerability deserves acknowledgment before redirection. Without it, the theological pivot can land as a deflection rather than a welcome.",
+                  "Before/After: Instead of going directly to “there ain’t no such thing as deep truth” — try: “Ed, welcome. And I want you to know — what you just described is exactly why this book exists. James was writing to people on the run with real pain. You’re in exactly the right room.” Then pivot to theology. Eight seconds of pastoral acknowledgment, then the point. Eddie would have felt seen, not managed."
                 ]
               },
               {
-                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "title": "Opening Prayer Not Captured — Session Blueprint Step 2 Unclear",
                 "paragraphs": [
-                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Leader talk ratio ~45% with reading, ~38% discussion-only. Above the Lifeway 30% target. BLB teaching block (~5 min) and Guarantee pitch (~4 min) are the primary drivers. Strong back-and-forth throughout; 20+ distinct voices compensate partially."
+                  "The recording begins mid-newcomer introduction. No opening prayer is audible. It is possible the prayer occurred before the recording started; if so, this is a documentation gap rather than a session gap. If the prayer was skipped in favor of jumping directly into newcomer welcome, that is a structural drift: the opening prayer (delegated to a member) signals to the group and newcomers that this study is consecrated time, not a seminar.",
+                  "The closing prayer (delegated to Russell) was excellent — on-topic, scripture-connected, and well-executed. If the opening prayer also happened but wasn’t captured, Dim 11 (Prayer) should be scored higher. Starting the recording at the very beginning of the opening prayer ensures both halves are visible in the coaching record.",
+                  "Next session: start recording before the opening prayer, not after. The prayer itself is a coaching data point — who Bryan delegates to, how members respond, whether it’s connected to the lesson theme. Two prayers per session is a signature element of Bryan’s blueprint and worth capturing."
                 ]
               },
               {
-                "title": "Visual Aids is a growth area (3/5)",
+                "title": "Group Split Needed But No Leader Identified — Multiplication Gap",
                 "paragraphs": [
-                  "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: BLB on screen with Strong’s Concordance — excellent and extensively used. No color-coded charts, maps, or structural diagrams this session. BLB was the single visual aid tool."
+                  "Bryan stated directly during newcomer welcome: “We need to split this group right down the middle. But I don’t have a leader. So this group will continue to grow until we find a leader.” With 25+ men in the room and four newcomers arriving today alone, the group is past the natural split threshold. The lack of a visible apprentice is the highest-leverage improvement lever in the v3 model (Leader Development, Building Ministry cluster).",
+                  "The Multiplication and Legacy pattern is visible in this session: Brendan’s transformation testimony, Mauricio’s goal to lead his wife, Justin’s 24-year recovery background with James. Any of these men could be an apprentice. But they’re not being identified, challenged, or given a visible teaching role in the session.",
+                  "The most efficient move: identify one man this week and give him a 3-minute window in the next session. Not a prayer chain role — a facilitation moment. “Russell, bring us Romans 8:28 and tell us why it belongs with James 1:2.” Let the room watch him do it. That’s the 2 Timothy 2:2 mechanism in action."
                 ]
               },
               {
-                "title": "Memory Reinforcement is a growth area (3/5)",
+                "title": "No Big Ideas Review from Lesson 1 — Spaced Retrieval Window Missed",
                 "paragraphs": [
-                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: No L1 Big Ideas review from memory at session start. Strong canonical close (5 Big Ideas surfaced with full group input). Bumper stickers: “joy is a verdict,” “holiness not happiness,” “tested faith produces maturity,” “partial obedience is disobedience” (referenced). 4 bumper stickers, slightly below the 5–7 target."
+                  "The session opened directly with newcomer introductions. No audible L1 Big Ideas review from memory is present. The Ebbinghaus spaced retrieval mechanism — which Bryan built this study around — requires prior Big Ideas to be surfaced before new content begins. For a Lesson 2 on the same material, this is the highest-leverage retention moment of the week.",
+                  "Four newcomers were also in the room. Watching 15 returning members recite Big Ideas from memory — without notes — is the single most powerful argument for doing the homework. It makes visible what the study produces in people over time. That visual costs 3 minutes and cannot be replicated any other way.",
+                  "For Lesson 3 open: before anything else — “Give me the big ideas from last week. Memory only. Go.” Hold the silence. Let the room surface them. For Justin and Eddie, that moment will either confirm or deny whether this study is worth 5 days of their life every week."
                 ]
               }
             ],
             "recommendationsProse": [
               {
-                "title": "Next session — Session Structure & Flow",
+                "title": "Open with L1+L2 Big Ideas Review from Memory (3 min)",
                 "paragraphs": [
-                  "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Before anything else: “Give me the Big Ideas from the last two weeks. Memory only. Go.” Hold the silence. Let the room surface them without notes. For Justin and Eddie on only their second visit, this will show them what the study produces in returning members over time. Then: “Okay. Now let’s add to that.” That is how a cumulative study feels different from a sermon series."
                 ]
               },
               {
-                "title": "Next session — Scripture Engagement",
+                "title": "Pre-assign 3 Cross-References Before the Session",
                 "paragraphs": [
-                  "Next time, pre-mark 3 cross-references to pull in during the densest teaching block.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "James 1:12–18 has direct parallels in 1 Peter 1:6–9 (trials + hope), Romans 7:7–11 (temptation / law), and Genesis 3 (the pattern of temptation from James 1:14–15). Assign them to members in the prayer chain message: “Russell — you’re on 1 Peter 1:6–9. Will — Romans 7:7–11. Bring them and be ready to say why they belong.” This restores the parallel-text density that is the structural signature of Bryan’s study."
                 ]
               },
               {
-                "title": "Next session — Facilitation vs. Lecture",
+                "title": "Ask Justin Harvey to Speak Into the Lesson",
                 "paragraphs": [
-                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Justin has 24 years of applied James knowledge. He came back today. Set the expectation now: “Justin, every week I’m going to ask you what you’ve seen in the field that relates to what we’re studying.” During James 1:13–18 (temptation originating in desire), ask: “Justin, what does temptation look like when someone is trying to get sober?” He has the answer and the room will listen."
                 ]
               },
               {
-                "title": "Next session — Visual Aids",
+                "title": "Give One Member a Visible Facilitation Window",
                 "paragraphs": [
-                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "The group needs to split and Bryan is looking for the next leader. One way to identify a candidate: give multiple men a 3-minute facilitation window over the next 4 sessions. Start with Russell or Cole. “Russell, you’re going to bring us 1 Peter 1:6–9 and tell us why it belongs. You’ve got 3 minutes. Go.” Watch how he handles it. The man who can bring a cross-reference and hold the room for 3 minutes is your next group leader."
                 ]
               },
               {
-                "title": "Next session — Memory Reinforcement",
+                "title": "Acknowledge Eddie Personally Before or After the Session",
                 "paragraphs": [
-                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Eddie disclosed double divorce and named hurt openly on his first day. He stayed for the full 2+ hours. A direct acknowledgment after the session — “Ed, I’m glad you’re here. What you shared took guts. Come back next week” — costs 20 seconds and dramatically increases his probability of return. If he comes back to a second session, the ministry statistics say he is likely to become a regular. Bible Leader Coaching | Bryan Bailey | May 23, 2026"
                 ]
               }
             ]
           },
           "sections": [
             {
-              "title": "Score composition",
-              "paragraphs": [
-                "How the four weighted clusters and any session bonuses combined into the composite score."
-              ],
+              "title": "Scorecard — Table 1",
               "bullets": [
-                "Teaching Craft: 64% × weight 33 → 21.12 pts",
-                "Building Ministry: 73.3% × weight 31 → 22.73 pts",
-                "Engaging People: 70% × weight 18 → 12.60 pts",
-                "Being Real: 70% × weight 18 → 12.60 pts",
-                "Base (sum of cluster contributions): 69.05 / 100",
-                "Session bonuses: newcomer growth +5, group-size +3",
-                "Session score: 77.05 / 100"
+                "Number of Attendees: ~25 men (estimated, in-person)  (Target: —)  → —",
+                "New Attendees: 4 (Justin Harvey, Arash, Mauricio, Eddie)  (Target: —)  → —"
               ]
             },
             {
-              "title": "Coaching notes by dimension",
-              "paragraphs": [
-                "The per-dimension rationale behind each score on the 12-dimension scorecard."
-              ],
+              "title": "Scorecard — Table 2",
               "bullets": [
-                "Session Structure & Flow (3/5): Blueprint followed (newcomer welcome → overview → scripture → application → Big Ideas → closing prayer). Opening prayer not captured. No formal cumulative Big Ideas review from L1. Ran over by ~8 min.",
-                "Newcomer Welcome (4/5): 4 newcomers, all engaged. Strong existing-member testimonies (Brendan, Andy Truebert, Austin). The Guarantee delivered. Personal challenge to Mauricio. Missed: Eddie’s hurt not acknowledged before theological pivot.",
-                "Scripture Engagement (3/5): 1 cross-reference passage (Rom 5:3–5) plus 7 Greek word studies via BLB. Cross-ref count (2 passages) is well below the 6+ benchmark. Bryan acknowledged skipping prepared cross-refs. Word study depth is excellent but doesn’t substitute for parallel-text density.",
-                "Facilitation vs. Lecture (3/5): Leader talk ratio ~45% with reading, ~38% discussion-only. Above the Lifeway 30% target. BLB teaching block (~5 min) and Guarantee pitch (~4 min) are the primary drivers. Strong back-and-forth throughout; 20+ distinct voices compensate partially.",
-                "Application Questions (4/5): 9 Big Idea questions, all DOK 2–4. DOK distribution: 33% Level 4, 45% Level 3, 22% Level 2. Questions distributed throughout; strong synthesis round at close. No DOK 1 questions scored. Matches Bryan’s best recent sessions on question quality.",
-                "Participant Engagement (4/5): 20+ named voices; 10+ with substantive contributions; >40% of named participants contributed. Quiet members called on directly. All 4 newcomers gave substantive introductions. Estimated participation rate ~75–80%.",
-                "Visual Aids (3/5): BLB on screen with Strong’s Concordance — excellent and extensively used. No color-coded charts, maps, or structural diagrams this session. BLB was the single visual aid tool.",
-                "Vulnerability / Authenticity (4/5): Stillborn first child disclosure is the highest-cost vulnerability in Bryan’s recent arc. Trials breakdown disclosure and heart attack reference add supporting depth. Weighted by depth: stillborn carries the score. Missed: Eddie’s vulnerability could have been reciprocated earlier.",
-                "Memory Reinforcement (3/5): No L1 Big Ideas review from memory at session start. Strong canonical close (5 Big Ideas surfaced with full group input). Bumper stickers: “joy is a verdict,” “holiness not happiness,” “tested faith produces maturity,” “partial obedience is disobedience” (referenced). 4 bumper stickers, slightly below the 5–7 target.",
-                "Homework References (4/5): The Guarantee delivered with full conviction and personal story. Multiple references to the 5-day homework rhythm. BLB instruction is direct homework skill-transfer. Closing prompt: “you’ve got five days to study a few verses.” Slightly below May 22 (5/5) due to less explicit homework tracking this session.",
-                "Prayer (3/5): Closing prayer: delegated to Russell, on-topic, scripture-connected, well-executed (“help us to be perfected by the trials that we go through and help us to have your viewpoint”). Opening prayer: not captured in recording. Prayer chain referenced multiple times in context. Score reflects only the closing prayer being visible.",
-                "Leader Development (3/5): Group is past split threshold. Bryan stated “we don’t have a leader” directly. 22 groups total, Austin Stone partnership, Brendan’s baptism — multiplication is visible in the program. But no in-session apprenticeship moment; no member given a facilitation window; no named apprentice. 2 Tim 2:2 mechanism not active in this session."
+                "Leader Talk Ratio (w/ scripture reading): ~45%  (Target: ≤35% (Lifeway))  → NEEDS WORK",
+                "Leader Talk Ratio (discussion only): ~38%  (Target: ≤30% (Lifeway))  → NEEDS WORK",
+                "% of statements grounded in a Bible verse: ~72%  (Target: ≥75%)  → ON TARGET",
+                "Cross-references cited: 2 (Jas 1:1–11 primary; Rom 5:3–5)  (Target: ≥6 (benchmark))  → NEEDS WORK",
+                "Blue Letter Bible / word study used: Yes — shared screen; Greek roots for consider (hēgeomai), joy (chara), trial, faith, endurance, knowing, humiliation  (Target: Session-appropriate)  → STRONG",
+                "Time to first scripture (after newcomer intros): ~24 min (long newcomer intro section)  (Target: ≤20 min)  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 3",
+              "bullets": [
+                "Total Session Duration: ~2h 8m (ran over)  (Target: ~2h ±10 min)  → ON TARGET",
+                "Newcomer welcome + member testimonies: ~17 min  (Target: 10–25 min)  → STRONG",
+                "Historical context + last-week recap: ~7 min  (Target: 5–10 min)  → STRONG",
+                "Main lesson (Jas 1:1–11, word studies, cross-ref): ~90 min  (Target: 60–90 min)  → STRONG",
+                "Big Ideas review / takeaways at close: ~11 min  (Target: 5–10 min)  → STRONG",
+                "Closing prayer: ~1 min  (Target: 2–4 min)  → ON TARGET",
+                "Tangent time: ~4 min (Joel Osteen Twitter story, Bryan’s son at Alabama)  (Target: ≤5 min)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 4",
+              "bullets": [
+                "Big Idea question count: 9  (Target: 5–7 (Precept benchmark))  → STRONG",
+                "DOK Level 4 (apply to life): ~33% (3 of 9)  (Target: ≥30%)  → STRONG",
+                "DOK Level 3 (reason/justify): ~45% (4 of 9)  (Target: ≥40% majority)  → STRONG",
+                "DOK Level 2 (compare/analyze): ~22% (2 of 9)  (Target: ≤20%)  → ON TARGET",
+                "DOK Level 1 (recall): 0%  (Target: Minimal)  → STRONG",
+                "Application spacing: Distributed throughout; strong Big Ideas closure round at end  (Target: Woven throughout)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 5",
+              "bullets": [
+                "Named speakers / distinct voices: 20+ including 4 newcomers  (Target: ≥70% of attendees)  → STRONG",
+                "Participants who read scripture aloud: Preston (Rom 5:3–5) + multiple during lesson  (Target: Multiple readers per session)  → STRONG",
+                "Participants asking questions: Mitch, Will, Justin, Cole, Weston, Russ, Austin, Zach, Emilio, others — 8+ distinct  (Target: ~30% of attendees)  → STRONG",
+                "Quiet members engaged by name: Yes — Bryce, Ron, Mauricio, Jackson, Weston, Andres called by name  (Target: Consistent)  → STRONG",
+                "Wait time after questions: 2–4 sec typical; Bryan held silence before answering  (Target: 3–5 sec (Rowe 1972))  → ON TARGET",
+                "Visual aid (BLB shared screen): Yes — Strong’s Concordance, 7 Greek words demonstrated live  (Target: Session-appropriate)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 6",
+              "bullets": [
+                "Vulnerability moments (Bryan): 3 — stillborn first child (highest cost); trials nearly broke him completely; heart attack at 62 referenced  (Target: Weighted by depth)  → STRONG",
+                "Monologue count (>90 sec during discussion): 4 (Guarantee pitch, BLB teaching, rabbinical West/East, stillborn story)  (Target: ≤2 sustained per session)  → NEEDS WORK",
+                "Longest monologue: ~5 min (BLB walk-through, 00:35–40)  (Target: <90 sec benchmark)  → NEEDS WORK",
+                "Humor / engagement moments: 4 (push-up joke, Mitch arriving late, Joel Osteen Twitter, Bryan’s son at Alabama)  (Target: Consistent)  → STRONG",
+                "Opening prayer: Not captured (started mid-newcomer intros)  (Target: Required by blueprint)  → NEEDS WORK"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 7",
+              "bullets": [
+                "% open-ended questions: ~85%  (Target: ≥75%)  → STRONG",
+                "% requiring text engagement: ~67%  (Target: ≥60%)  → STRONG",
+                "Follow-up probes after answers: Consistent — “Say more,” “What’s the difference?” “Ooh, expand on that”  (Target: Frequent)  → STRONG",
+                "Productive struggle allowed: Yes — held questions open; waited before adding to member answers  (Target: Redirect, don’t rescue)  → STRONG",
+                "Questions redirected vs. answered directly: Bryan redirected ~65% of time; answered directly ~35%  (Target: ≥65% redirect)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 8",
+              "bullets": [
+                "Question-to-statement ratio (discussion time): ~50:50 Q:S  (Target: ≥60:40)  → NEEDS WORK",
+                "Bumper stickers / memorable language: 4: “Joy is a verdict, not a feeling”; “God is more interested in your holiness than happiness”; “tested faith produces maturity”; “partial obedience is disobedience” referenced  (Target: 5–7 per session)  → ON TARGET",
+                "Topic drift: ~4 min (Joel Osteen Twitter, Bryan’s son at Alabama)  (Target: ≤5 min)  → STRONG",
+                "Summaries after key exchanges: Consistent — Bryan recapped word meaning conclusions, cross-ref logic  (Target: After every major exchange)  → STRONG",
+                "Big Ideas review at session start: Not observed — no L1 review from memory audible before lesson  (Target: Required by blueprint)  → NEEDS WORK",
+                "Big Ideas surfaced at close: Yes — 5 canonical takeaways identified with full group input (10 min)  (Target: 5–6 per session)  → STRONG"
+              ]
+            },
+            {
+              "title": "Key Moments",
+              "moments": [
+                {
+                  "detail": "Building Ministry  (🟢 Capitalized · Building Ministry)\n\nWhy it mattered: Four newcomers were in the room waiting to introduce themselves. Justin Harvey runs a treatment center and has studied James for 20 years in the recovery context. Mauricio came because he wants to lead his wife. Eddie has a lot of hurt from double divorce. Arash has no church community yet. Brendan’s testimony hits every one of those needs: he names sin by name, describes the transformation mechanism (daily homework in God’s word), and speaks with obvious conviction. This is not Bryan selling the program — it is peer testimony, which research consistently shows is more credible than leader advocacy. Bryan capitalized it by validating Brendan immediately and without qualification.\n\nWhat would make it bigger: “Brendan, what specifically was it about the homework that changed you — give Justin and Eddie one thing to watch for.” Directing Brendan to address the newcomers by name would have doubled the landing. The testimony was already excellent; a 10-second bridge to the newcomers would have made it a direct handoff.",
+                  "timestamp": "[00:03:49]"
+                },
+                {
+                  "detail": "Being Real  (🟢 Capitalized · Being Real)\n\nWhy it mattered: This is the highest-cost personal disclosure in Bryan’s recent arc. Eddie is in the room with double divorce. Justin works daily with people at the bottom. Mauricio is building a marriage foundation. The claim “tested faith produces hope” is an abstract theological proposition until Bryan puts his dead first child behind it and says “that’s how I know this book is true.” At that moment, the proposition becomes biography. You cannot argue with biography. Bryan did not soften the cost or rush past it — he named the wailing, named the peace, and named the source. That is vulnerability as authority at its highest.\n\nWhat would make it bigger: The share was complete as given. One option for amplification: after closing the story, ask “Justin — in 24 years of walking people through trials in recovery, what have you seen? Does proven character actually produce hope?” Justin has 24 years of field evidence. Passing the mic to him for 30 seconds would have created a peer testimony on the same theme from a different life domain, and validated Justin’s expertise in front of the room on his first day.",
+                  "timestamp": "[01:59:15]"
+                },
+                {
+                  "detail": "Being Real  (🟠 Missed Opportunity · Being Real)\n\nWhy it mattered: Eddie is a first-time visitor who named a wound explicitly — “a lot of hurt in here” — in front of 25 strangers on his first morning. That kind of public disclosure is a high-risk act. It signals that Eddie is looking for more than information; he’s looking to be known. Bryan’s response tells him he’s in the right place, which is true — but it skips the personal acknowledgment that would have made Eddie feel seen rather than processed. With Brendan’s transformation testimony still hanging in the air, and four newcomers introducing themselves in sequence, the pastoral window was open. A missed hold here can quietly discourage deeper sharing throughout the session.",
+                  "timestamp": "[00:15:07]"
+                },
+                {
+                  "detail": "Building Ministry  (🔵 Pivot Point · Building Ministry)\n\nWhy it mattered: Justin Harvey walked into this group with 24 years of applying James 1 to people’s lives in crisis. He has field data on “what does tested faith actually look like in someone hitting bottom?” that no one else in the room has. He started a treatment center 10 years ago. He has seen the James 1 promises work — and fail — more times than anyone present. This is an extraordinary resource that entered the room. Bryan connected him to the recovery ministry (excellent ministry move). But he didn’t ask Justin to speak into the lesson content. That was the disproportionate opportunity: a newcomer with 20 years of applied James experience, in a room studying James, on his first day.",
+                  "timestamp": "[00:10:47]"
+                },
+                {
+                  "detail": "Teaching Craft  (🟢 Capitalized · Teaching Craft)\n\nWhy it mattered: The most memorable takeaway from any session is usually a participant insight that the leader catches and crystallizes. Will identified the key distinction in James 1:2 — joy is volitional, not circumstantial — in his own words. Bryan’s move was to take Will’s framing (“a decision”) and tighten it to “a verdict.” Verdict is stronger than decision: a verdict is final, grounded in evidence, not just a choice. This is the primary bumper sticker from the session. Ten days from now, the men in this room will remember “joy is a verdict” — and many of them will remember it was Will who first said it.\n\nWhat would make it bigger: “Will, write that on the board — or say it again so everyone gets it: joy is a verdict, not a feeling.” Naming Will as the author and having the group echo it would have made it a shared canonical phrase rather than a Bryan teaching point. The credit should stay visible: it came from the room, not from the leader. That’s the culture you’re building.",
+                  "timestamp": "[00:40:16]"
+                }
+              ],
+              "paragraphs": [
+                "These are the 5 disproportionate moments in the session — exchanges that shaped what this group will remember, believe, and carry out. Ordered by impact."
               ]
             }
           ],
@@ -2516,197 +2771,246 @@
           ],
           "bigIdeas": [],
           "feedback": {
-            "headline": "A strong session — strongest in Newcomer Welcome and Scripture Engagement, with the clearest next step in Facilitation vs. Lecture.",
+            "headline": "Bryan’s deepest verse-by-verse session on James to date — 12 verses, 9 cross-references, two newcomers fully integrated, Clint’s vulnerable share handled with pastoral grace.",
             "strengths": [
-              "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
-              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-              "Homework was referenced and rewarded, differentiating the members who prepared."
+              "Cross-Reference Density at Full Benchmark — 9 Passages, All Integrated",
+              "Newcomer Integration Executed at Full Blueprint — Two First-Nighters Anchored",
+              "Clint’s Suicidal Disclosure Handled With Pastoral Grace"
             ],
             "improvements": [
-              "Leader talk crowded out discussion; the balance leaned toward lecture.",
-              "The session leaned audio-only; a visual anchor would aid retention.",
-              "Prior Big Ideas weren’t reviewed, so last week’s themes faded."
+              "Big Ideas Review from Lesson 1 — Not Observed at Session Start",
+              "Three Sustained Monologues Exceed the 90-Second Benchmark",
+              "Anthony’s Prayer Question — Pastoral Acknowledgment Before the Redirect"
             ],
             "recommendations": [
-              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-              "Next time, put one word-study lookup or a simple table on screen during the key term.",
-              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas."
+              "Open Lesson 3 With a Mandatory Big Ideas Review from L2",
+              "Give Hunter a 3-Minute Teaching Window — Introduce One Cross-Reference",
+              "Break the 8-Reasons List Into an Interactive Format"
             ],
             "overview": [
-              "A strong session — strongest in Newcomer Welcome and Scripture Engagement, with the clearest next step in Facilitation vs. Lecture. It scored 81.75/100 under the v3 weighted model.",
-              "The session played to its strengths in Newcomer Welcome and Scripture Engagement; the recommendations below turn Facilitation vs. Lecture into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+              "Bryan’s deepest verse-by-verse session on James to date — 12 verses, 9 cross-references, two newcomers fully integrated, Clint’s vulnerable share handled with pastoral grace.",
+              "This report carries the full written coaching for the session: 5 areas of strength, 5 areas for improvement, and 5 recommendations for next session, scored 81.75/100 on the v3 weighted model."
             ],
             "strengthsProse": [
               {
-                "title": "Newcomer Welcome anchored the session (5/5)",
+                "title": "Cross-Reference Density at Full Benchmark — 9 Passages, All Integrated",
                 "paragraphs": [
-                  "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
-                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
-                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Two newcomers (Anthony, Graham). Members gave testimonies before newcomers spoke. Bryan shared personal story. Both newcomers introduced with follow-up commitments (Luke’s number; Tristan for Anthony). Homework push at close."
+                  "For 12 verses of James, Bryan wove in nine supporting texts: Romans 5:3–5, 1 Peter 1:6–9, 1 Peter 4:12–13, Romans 11:33–36, Daniel 2:20–23, Job 12:13,16, Luke 6:20–26, and Revelation 2:10. Each text was assigned to a different reader by name and then immediately interrogated. This is exactly the parallel-text method that distinguishes Precept-style study from sermon attendance — the men built a scriptural case for the doctrine, not just heard Bryan assert it.",
+                  "“Tribulations bring about perseverance, and perseverance proven character, and proven character hope, and hope does not disappoint… [Romans 5:3–5]” [00:40:54]",
+                  "Bryan then stopped immediately: “Somebody explain to me the logic of this passage.” That pause — after a text that rewards rereading — is what separates a teacher from a facilitator. The cross-reference wasn’t decoration; it was evidence in a case being built together."
                 ]
               },
               {
-                "title": "Scripture Engagement anchored the session (5/5)",
+                "title": "Newcomer Integration Executed at Full Blueprint — Two First-Nighters Anchored",
                 "paragraphs": [
-                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 9 cross-references cited and read (benchmark: 6+). Blue Letter Bible with Strong’s Concordance on shared screen. Greek word studies for “consider” and “joy.” All 12 James verses read and interrogated."
+                  "Anthony and Graham were both strangers walking into a two-year-old group. Bryan ran the blueprint in order: existing members (Nandan, Hunter, Chris Scallion) gave personal testimonies before the newcomers spoke — modeling what authentic engagement looks like before asking it of guests. Bryan then shared his own story, and the newcomers introduced themselves. By 00:08, both Anthony and Graham had received specific, personal follow-up commitments (Luke’s number for Graham; Tristan as Anthony’s contact chain).",
+                  "“There’s no such thing as a little bit of accountability. It’s like saying I want to be a little bit pregnant.” [00:08:06]",
+                  "That line landed with Graham in the room — not as a rebuke but as a standard. At the close, Bryan personally told Anthony: “The trick with this Bible study is there’s five days of homework” and directed him to Tristan for the materials. The newcomer arc was complete from welcome to homework assignment."
                 ]
               },
               {
-                "title": "Homework References anchored the session (5/5)",
+                "title": "Clint’s Suicidal Disclosure Handled With Pastoral Grace",
                 "paragraphs": [
-                  "Homework was referenced and rewarded, differentiating the members who prepared.",
-                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
-                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: “The Guarantee” invoked multiple times. Bryan’s 25-year personal testimony to homework at close. “Best 25 bucks you’ll ever spend” to Anthony. 5-day homework framing delivered. Next session assignment implied (last verses of chapter 1)."
+                  "At 00:36:20, Clint named attempted suicide in the room: “tried to take my life, knew God was with me, but didn’t trust God. And I fully just surrendered and was humbled to my knees.” Bryan did not rescue, redirect, or rush. He normalized it (“Maybe they can be self-inflicted, I don’t know”) and connected it back to the passage’s point that adversity introduces a man to himself. The group held the moment without deflection.",
+                  "This matters more than any metric. Two newcomers were in the room. How a leader handles a disclosure like Clint’s determines the vulnerability ceiling for every person watching. By staying in the pastoral lane — not over-managing it, not pretending it didn’t happen — Bryan demonstrated that this group can hold real weight. Anthony and Graham filed that away."
                 ]
               },
               {
-                "title": "Prayer anchored the session (5/5)",
+                "title": "Closing Application Round — “Tell Your Wife” as Memory Architecture",
                 "paragraphs": [
-                  "Prayer was delegated to members, opening and closing the group in shared voice.",
-                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
-                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Opening prayer (Nandan) — substantive, scripture-connected, delegated appropriately. Closing prayer (Hunter) — on-topic, applied lesson themes, beautiful. Prayer chain infrastructure referenced. First session with both prayers fully captured and scored at maximum."
+                  "Rather than summarizing the lesson himself, Bryan spent the final 20 minutes asking every man to articulate what he would tell his wife, girlfriend, or daughter. Eight men gave substantive, personal answers. Nandan framed two Big Ideas for his daughter going to college. Hunter applied it to his wife’s recent medical scare. Taylor connected it to two years of shared trials. This is the Ebbinghaus application layer at its best — each man had to retrieve and restate the lesson in his own words, which doubles retention.",
+                  "“Consider it all joy. When you go through things, you should always try to take it as an opportunity to gain wisdom and understanding.” [01:55:07]",
+                  "The variety of answers — health trials, family strain, sales career, cancer fears — also made visible what the group holds in common. For Anthony and Graham, watching eight men apply scripture to their actual lives in real time is the single most powerful argument for doing the homework."
                 ]
               },
               {
-                "title": "Session Structure & Flow anchored the session (4/5)",
+                "title": "Blue Letter Bible Word Studies on Screen — Greek Roots Grounding the Discussion",
                 "paragraphs": [
-                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Blueprint executed: newcomer welcome, historical context, scripture, deep Socratic study, closing application, delegated prayer. No audible Big Ideas review from L1. 8 min over 2h target."
+                  "Bryan shared his screen with Blue Letter Bible and walked through the Greek roots of “consider” (hēgeomai — to count, to think, to esteem) and “joy” (chara — inner gladness independent of circumstances). He showed the Strong’s number system, cross-referenced where the same word appears elsewhere, and connected it to the contextual meaning of joy in James 1:2–4. For the engineers and data-minded men in the group (Nandan named this explicitly), this is the credibility layer.",
+                  "“The Bible wasn’t written in English. It was written in one of three languages, and most of the New Testament was written in Greek… that’s why we look at the words.” [00:27:42]",
+                  "The word-study method also answered Anthony’s implicit question (“where do you find that?”) before he had to ask it. Bryan pointed to the back of the Bible, then to Blue Letter Bible, as the tools — giving newcomers a concrete next step for their own study."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "title": "Big Ideas Review from Lesson 1 — Not Observed at Session Start",
                 "paragraphs": [
-                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Discussion-only ratio ~33% leader talk; above 30% Lifeway benchmark. Three monologues exceeded 90 sec. Consistent with all prior sessions in this arc."
+                  "The transcript opens mid-sentence with Nandan’s prayer. No Big Ideas review from James L1 is audible. This is the single most important structural miss for a Lesson 2: the Ebbinghaus spaced-repetition system — which Bryan built this study on — requires that prior session Big Ideas be surfaced from memory before new content begins. The L1 Big Ideas (wholehearted faith, trials, wisdom, tongue, two wisdoms, rich vs. poor, prayer) are directly relevant to what was studied tonight.",
+                  "Research benchmark: Spaced retrieval before new content improves retention of both old and new material by 40–60% (Roediger & Karpicke 2006). For a two-year-old group, this practice is also a powerful signal to newcomers: “we remember what we learn here.”",
+                  "Before/After: Instead of “anything. Okay, Nandan, open us in prayer” — try 3 minutes of “Give me the Big Ideas from last week, memory only. Who’s got one?” Let the room surface them. For newcomers Graham and Anthony, this shows what Lesson 3 will feel like and creates immediate motivation to do the homework."
                 ]
               },
               {
-                "title": "Visual Aids is a growth area (3/5)",
+                "title": "Three Sustained Monologues Exceed the 90-Second Benchmark",
                 "paragraphs": [
-                  "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: BLB shared on screen with Strong’s Concordance; Greek word studies presented. No color-coded charts or structural diagrams. Ernest photo used for humor/engagement. Better than L1 (2/5 overview session), below full-study benchmark."
+                  "Bryan ran three extended teaching segments without a question or pause: (1) the James historical context (~3 min, 00:09–00:13), (2) the 8 reasons for trials list (~4 min, 01:56–02:04), and (3) the prayer coaching segment (~2 min, 01:14–01:17). Each piece of content is excellent — the problem is the delivery format. A 4-minute list without a pause or a question loses the room and removes the generation effect that makes content stick.",
+                  "Research benchmark: Stuart & Rutherford (1978) — monologues beyond 90 seconds in a discussion format measurably reduce retention and engagement. Hattie’s meta-analysis shows discussion effect size of 0.82 vs. lecture at 0.35.",
+                  "Before/After: Instead of delivering all 8 reasons sequentially — try: give reason 1, ask “Who’s been through that? What did it feel like?” Then reason 2, same pattern. Distribute the list across two minutes of back-and-forth. The men will remember the reasons because they said them."
                 ]
               },
               {
-                "title": "Memory Reinforcement is a growth area (3/5)",
+                "title": "Anthony’s Prayer Question — Pastoral Acknowledgment Before the Redirect",
                 "paragraphs": [
-                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: No audible Big Ideas review from L1 at session start. Closing application round (“tell your wife”) functioned as strong memory anchoring. Four memorable bumper stickers surfaced. Consistent with L1 score."
+                  "At 01:13:01, Anthony (brand-new believer, first night) asked: “Do you like to repeat prayers? My fear is I’m a moron doing it wrong or doing immature or stupid prayers.” Bryan correctly kept the discussion in the James context (“This is a specific topic — prayer about God’s viewpoint of your trial”) and followed with helpful prayer coaching. But the redirect came without a pastoral beat first. Anthony named a fear of incompetence on his very first night — that needed direct acknowledgment before the contextual redirect.",
+                  "Before/After: Instead of “This is a specific topic…” — try: “Anthony, you cannot pray wrong if your heart is genuinely aimed at God — your question just proves you’re paying attention. Here’s what I’d tell you about prayer broadly, and then let’s park that and come back, because what we’re talking about in James is more specific.” Eight more seconds of acknowledgment, then the redirect. Anthony quieted down for 20 minutes after this exchange."
                 ]
               },
               {
-                "title": "Leader Development is a growth area (3/5)",
+                "title": "Leader Development Opportunity — Visible Apprentice Role in the Room",
                 "paragraphs": [
-                  "No in-session development of another leader was observable this week.",
-                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Hunter’s role as prayer chain manager and scribe is visible. Baptism announced. No formal teaching or facilitation role during the session. 2 Tim 2:2 multiplication principle not yet visible in session mechanics. Same as L1."
+                  "Hunter manages the prayer chain, handles documentation, sends the weekly Zoom invite, and is being baptized on June 6. He has every marker of an emerging leader. He is not yet being given a visible teaching or facilitation role during the session. The 2 Timothy 2:2 multiplication principle — the highest-weight cluster in the v3 scorecard — requires a coachee to be visible in action, not just in logistics.",
+                  "With two newcomers watching, having Hunter open a cross-reference, summarize a passage, or facilitate a 5-minute section would have demonstrated that this group produces leaders. Every man in the room (especially Anthony, who came specifically wanting accountability) would see the growth path made visible.",
+                  "Next session try: assign Hunter one cross-reference to introduce and contextualize (“Hunter, bring us Romans 5:3–5 and tell us why it belongs here”). Let him own a 3-minute window. This is the 2 Tim 2:2 mechanism — not logistics, but teaching-in-action."
                 ]
               },
               {
-                "title": "Application Questions is a growth area (4/5)",
+                "title": "Big Ideas Review Framing at Session Close — Capture Before Closing Prayer",
                 "paragraphs": [
-                  "Questions stayed heady; few moved the group to first-person, personal application.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: 8 Big Idea questions; 25% DOK 4, 50% DOK 3, 25% DOK 2. Strong closing application round (“tell your wife”) functioned as full-room application synthesis."
+                  "The “tell your wife” application round was excellent but produced a wide variety of framings. Bryan did not distill these into 3–5 canonical Big Ideas before Hunter’s closing prayer. Bryan’s signature close — “give me the bumper stickers of the Big Ideas” — was not audible this session. Without a canonical list, men walk out with their own phrasing rather than the shared language that prayer chain messages and next-week review depend on.",
+                  "Before/After: After the application round, take 60 seconds: “All right — give me the bumper stickers. What are the Big Ideas we’re taking from James 1:1–12? I want five. Go.” Write them in the prayer chain message. These become the L2 review cards for Lesson 3."
                 ]
               }
             ],
             "recommendationsProse": [
               {
-                "title": "Next session — Facilitation vs. Lecture",
+                "title": "Open Lesson 3 With a Mandatory Big Ideas Review from L2",
                 "paragraphs": [
-                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Before the prayer, before anything: “Give me the Big Ideas from last week — memory only.” Hold the silence. Let men pull up five from L2. For Anthony and Graham, watching the group retrieve from memory is the best demonstration of what consistent study produces. Then connect the L2 Big Ideas to tonight’s content (James 1:13–end). The review is also your test of whether the “tell your wife” application round stuck. Try: “Anthony, Graham — we do this at the top of every session. By Lesson 4, you’ll be saying them first. Go ahead, guys — who’s got a Big Idea from last week?”"
                 ]
               },
               {
-                "title": "Next session — Visual Aids",
+                "title": "Give Hunter a 3-Minute Teaching Window — Introduce One Cross-Reference",
                 "paragraphs": [
-                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Assign Hunter a specific text to introduce next session: “Hunter, bring us [X] and tell us why it belongs with what we’re studying.” Let him own the contextualization, not just the logistics. This is the 2 Timothy 2:2 mechanism — apprenticeship is visible leadership in a teaching moment, not prayer chain management. Every man in the room will see the growth path. Hunter’s baptism is June 6. The next session after that would be ideal to give him a formal “here’s what changed for me” moment woven into the lesson. Baptism testimony + teaching role = ministry visibility."
                 ]
               },
               {
-                "title": "Next session — Memory Reinforcement",
+                "title": "Break the 8-Reasons List Into an Interactive Format",
                 "paragraphs": [
-                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "The 8 reasons for trials content is excellent — the delivery as a 4-minute sequential list is the growth edge. Reason 1, then “Who’s experienced that? What did it feel like?” Reason 2, same pattern. By distributing the list through the group rather than presenting it from the front, you triple the retention rate and reduce your own talk time. The men remember reasons they said, not reasons they heard."
                 ]
               },
               {
-                "title": "Next session — Leader Development",
+                "title": "End Session With Canonical Big Idea Bumper Stickers — Before Closing Prayer",
                 "paragraphs": [
-                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "After the application round, 60 seconds: “All right — give me the bumper stickers. What are the Big Ideas from James 1:1–12? Five. Go.” Bryan writes them in the prayer chain message. These become the L3 review cards. Without this canonical capture, each man walks out with his own phrasing and there’s no shared language for the prayer chain."
                 ]
               },
               {
-                "title": "Next session — Application Questions",
+                "title": "Acknowledge New Believer Questions Pastorally Before Redirecting Contextually",
                 "paragraphs": [
-                  "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Anthony’s questions — and Graham’s likely follow-ups in coming weeks — will sometimes be off the immediate topic. The redirect is often right. But a pastoral beat before the redirect is required: “Great question, Anthony. Short answer is X. For the purpose of this passage, let’s focus on Y.” That pattern answers the person, then focuses the room. Without the acknowledgment first, the redirect reads as dismissal to a new believer who is still learning that his questions belong here. Session-Over-Session Comparison — L6 → L7 → James L1 → James L2 Four most recent sessions. Composite scores: L6 Apr 18 = 74.7 | L7 Apr 25 = 77.8 | James L1 May 16 = 74.4 | James L2 May 22 = 80.7. This is Bryan’s highest weekly score in the tracked arc. Key drivers: Scripture Engagement (5/5 — 9 cross-references), Vulnerability (4/5 — Clint’s pastoral hold), Prayer (5/5 — both Nandan and Hunter’s prayers fully captured and on-point). Facilitation (3/5) and Memory Reinforcement (3/5) remain the consistent growth levers across all four sessions. Consistent execution; Big Ideas review gap persists L7 had no newcomers; L1 and L2 both at ceiling 9 cross-refs in L2 (benchmark 6+); back to full score Consistently at 70%; 30% benchmark not yet cleared Stable; DOK 3–4 majority maintained Sustained improvement from L6 baseline L1 format (overview) dropped visual aids; L2 restored BLB on screen Clint’s share + pastoral hold drove L2 improvement No pre-session review observed; closing application partially compensates \"The Guarantee\" consistently delivered; personal story added in James arc First session with both opening and closing fully captured and on-topic Hunter’s role growing in logistics; formal teaching role not yet visible New arc high. Biggest weekly gain in tracked arc. Bible Leader Coaching | Bryan Bailey | May 22, 2026"
                 ]
               }
             ]
           },
           "sections": [
             {
-              "title": "Score composition",
-              "paragraphs": [
-                "How the four weighted clusters and any session bonuses combined into the composite score."
-              ],
+              "title": "Scorecard — Table 1",
               "bullets": [
-                "Teaching Craft: 76% × weight 33 → 25.08 pts",
-                "Building Ministry: 86.7% × weight 31 → 26.87 pts",
-                "Engaging People: 70% × weight 18 → 12.60 pts",
-                "Being Real: 90% × weight 18 → 16.20 pts",
-                "Base (sum of cluster contributions): 80.75 / 100",
-                "Session bonuses: group-size +1",
-                "Session score: 81.75 / 100"
+                "Number of Attendees: ~17–19 men (Zoom)  (Target: —)  → —",
+                "New Attendees: 2 (Anthony, Graham)  (Target: —)  → —"
               ]
             },
             {
-              "title": "Coaching notes by dimension",
-              "paragraphs": [
-                "The per-dimension rationale behind each score on the 12-dimension scorecard."
-              ],
+              "title": "Scorecard — Table 2",
               "bullets": [
-                "Session Structure & Flow (4/5): Blueprint executed: newcomer welcome, historical context, scripture, deep Socratic study, closing application, delegated prayer. No audible Big Ideas review from L1. 8 min over 2h target.",
-                "Newcomer Welcome (5/5): Two newcomers (Anthony, Graham). Members gave testimonies before newcomers spoke. Bryan shared personal story. Both newcomers introduced with follow-up commitments (Luke’s number; Tristan for Anthony). Homework push at close.",
-                "Scripture Engagement (5/5): 9 cross-references cited and read (benchmark: 6+). Blue Letter Bible with Strong’s Concordance on shared screen. Greek word studies for “consider” and “joy.” All 12 James verses read and interrogated.",
-                "Facilitation vs. Lecture (3/5): Discussion-only ratio ~33% leader talk; above 30% Lifeway benchmark. Three monologues exceeded 90 sec. Consistent with all prior sessions in this arc.",
-                "Application Questions (4/5): 8 Big Idea questions; 25% DOK 4, 50% DOK 3, 25% DOK 2. Strong closing application round (“tell your wife”) functioned as full-room application synthesis.",
-                "Participant Engagement (4/5): 17+ named voices; 8 scripture readers; 6 questioners; ~85–90% participation rate. Quiet members called by name. Both newcomers contributed substantively.",
-                "Visual Aids (3/5): BLB shared on screen with Strong’s Concordance; Greek word studies presented. No color-coded charts or structural diagrams. Ernest photo used for humor/engagement. Better than L1 (2/5 overview session), below full-study benchmark.",
-                "Vulnerability / Authenticity (4/5): Four Bryan disclosures weighted by depth: faith journey at 39, fax machine prayer, two largest trials (20–30 yrs later insight), homework humility. Clint’s suicidal disclosure handled pastorally without moralizing or rescue. Group vulnerability culture intact.",
-                "Memory Reinforcement (3/5): No audible Big Ideas review from L1 at session start. Closing application round (“tell your wife”) functioned as strong memory anchoring. Four memorable bumper stickers surfaced. Consistent with L1 score.",
-                "Homework References (5/5): “The Guarantee” invoked multiple times. Bryan’s 25-year personal testimony to homework at close. “Best 25 bucks you’ll ever spend” to Anthony. 5-day homework framing delivered. Next session assignment implied (last verses of chapter 1).",
-                "Prayer (5/5): Opening prayer (Nandan) — substantive, scripture-connected, delegated appropriately. Closing prayer (Hunter) — on-topic, applied lesson themes, beautiful. Prayer chain infrastructure referenced. First session with both prayers fully captured and scored at maximum.",
-                "Leader Development (3/5): Hunter’s role as prayer chain manager and scribe is visible. Baptism announced. No formal teaching or facilitation role during the session. 2 Tim 2:2 multiplication principle not yet visible in session mechanics. Same as L1."
+                "Leader Talk Ratio (w/ scripture reading): ~40%  (Target: ≤35% (Lifeway))  → NEEDS WORK",
+                "Leader Talk Ratio (discussion only): ~33%  (Target: ≤30% (Lifeway))  → ON TARGET",
+                "% of statements grounded in a Bible verse: ~82%  (Target: ≥75%)  → STRONG",
+                "Cross-references cited: 9 (Rom 5, 1 Pet 1, 1 Pet 4, Rom 11, Dan 2, Job 12, Lk 6, Rev 2 + primary)  (Target: ≥6 (benchmark))  → STRONG",
+                "Blue Letter Bible / word study used: Yes — shared screen; Greek roots for “consider” (hēgeomai) and “joy” (chara)  (Target: Session-appropriate)  → STRONG",
+                "Time to first scripture (after newcomer intros): ~16 min  (Target: ≤20 min)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 3",
+              "bullets": [
+                "Total Session Duration: ~2h 10m  (Target: ~2h ±10 min)  → ON TARGET",
+                "Opening prayer + newcomer welcome: ~16 min  (Target: 10–25 min)  → ON TARGET",
+                "Historical context (James background, diaspora): ~8 min  (Target: 5–10 min)  → STRONG",
+                "Main lesson (Jas 1:1–12, word studies, cross-refs): ~90 min  (Target: 60–90 min)  → STRONG",
+                "Application closure (“tell your wife” round): ~20 min  (Target: 10–20 min)  → STRONG",
+                "Closing prayer: ~3 min  (Target: 2–4 min)  → STRONG",
+                "Tangent time: ~3 min (Ernest photo moment, song discussion)  (Target: ≤5 min)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 4",
+              "bullets": [
+                "Big Idea question count: 8  (Target: 5–7 (Precept benchmark))  → STRONG",
+                "DOK Level 4 (apply to life): 25% (2 of 8)  (Target: ≥30%)  → ON TARGET",
+                "DOK Level 3 (reason/justify): 50% (4 of 8)  (Target: ≥40% majority)  → STRONG",
+                "DOK Level 2 (compare/analyze): 25% (2 of 8)  (Target: ≤20%)  → ON TARGET",
+                "DOK Level 1 (recall): 0%  (Target: Minimal)  → STRONG",
+                "Application spacing: Distributed throughout; strong closing application round  (Target: Woven throughout)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 5",
+              "bullets": [
+                "Named speakers / distinct voices: 17+ (including 2 newcomers)  (Target: ≥70% of attendees)  → STRONG",
+                "Participants who read scripture aloud: 8 (Taylor, Darryl, Nandan, Luke, Mark, Lance, Nandan again, Graham)  (Target: Multiple readers per session)  → STRONG",
+                "Participants asking questions: 6 (Anthony, Vashon, Ernest, Marcus, Graham, Lance)  (Target: ~30% of attendees)  → STRONG",
+                "Quiet members engaged by name: Yes — Taylor, Paul, Luke, Clint, Darryl called directly  (Target: Consistent)  → STRONG",
+                "Wait time after questions: 2–4 seconds typical  (Target: 3–5 sec (Rowe 1972))  → ON TARGET",
+                "Visual aid (BLB shared screen): Yes — Strong’s Concordance with Greek word studies  (Target: Session-appropriate)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 6",
+              "bullets": [
+                "Vulnerability moments (Bryan): 4 — faith journey at 39; fax machine prayer story; two largest trials (20–30 yrs later); homework humility  (Target: Weighted by depth)  → STRONG",
+                "Vulnerability response (Clint’s share): Pastoral — normalized, connected to passage, moved forward without moralizing  (Target: Shepherd-mode, no rescue)  → STRONG",
+                "Monologue count (>90 sec during discussion): 3 (James context, 8 reasons list, prayer coaching)  (Target: ≤2 sustained per session)  → NEEDS WORK",
+                "Longest monologue: ~4 min (8 reasons for trials, 01:56–02:04)  (Target: <90 sec benchmark)  → NEEDS WORK",
+                "Humor / engagement moments: 4 (Taylor “last shall be first,” Ernest’s photo, Tennessee baseball, Lance’s name on shirts)  (Target: Consistent)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 7",
+              "bullets": [
+                "% open-ended questions: ~88%  (Target: ≥75%)  → STRONG",
+                "% requiring text engagement: ~71%  (Target: ≥60%)  → STRONG",
+                "Follow-up probes after answers: Consistent — “What else?” “Say more.” “What does that mean?”  (Target: Frequent)  → STRONG",
+                "Productive struggle allowed: Yes — held silence; let men wrestle before adding  (Target: Redirect, don’t rescue)  → STRONG",
+                "Questions redirected vs. answered directly: Bryan redirected ~70% of time; answered directly ~30%  (Target: ≥65% redirect)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 8",
+              "bullets": [
+                "Question-to-statement ratio (discussion time): ~55:45 Q:S  (Target: ≥60:40)  → ON TARGET",
+                "Bumper stickers / memorable language: 4: “Joy is not a feeling, it’s a verdict”; “God is more interested in your holiness, not your happiness”; “want to destroy someone, give them success”; “stone-cold lock”  (Target: 5–7 per session)  → ON TARGET",
+                "Topic drift: ~3 min (Ernest photo, song discussion)  (Target: ≤5 min)  → STRONG",
+                "Summaries after key exchanges: Consistent — Bryan recapped word meanings, cross-ref conclusions  (Target: After every major exchange)  → STRONG",
+                "Big Ideas review at session start: Not observed (may be pre-recording)  (Target: Required by blueprint)  → NEEDS WORK",
+                "Big Ideas surfaced at close: Yes — full round of application sharing (8 members + Bryan)  (Target: 5–6 per session)  → STRONG"
+              ]
+            },
+            {
+              "title": "Key Moments",
+              "moments": [
+                {
+                  "detail": "Being Real  (🟢 Capitalized · Being Real)\n\nWhy it mattered: Anthony is a brand-new believer in the room. Graham is re-engaging faith after years away. How Bryan handled this moment determined the vulnerability ceiling for both of them — and for the group long-term. A deflection or over-managed response would have taught the room that real pain stays private. Bryan’s pastoral hold taught the opposite. Clint’s disclosure was not incidental; it was the passage made flesh. The Precept system produced exactly this kind of moment — and Bryan was ready for it.\n\nWhat would make it bigger: A 10-second check-in before moving on: “Clint, appreciate you sharing that. Guys, if you’ve been close to that place, you know what he means — the trial can get to the bottom of you.” This gives three or four others permission to silently identify. Bryan moved forward well; a single sentence of collective acknowledgment would have extended the effect.",
+                  "timestamp": "[00:36:20]"
+                },
+                {
+                  "detail": "Building Ministry  (🟢 Capitalized · Building Ministry)\n\nWhy it mattered: Hunter is the group’s prayer chain manager and scribe. He applied a lesson from the same session to a real medical crisis with his wife on the same day. For Anthony and Graham — both of whom came wanting accountability and community — watching Hunter demonstrate the homework in action, then hearing Bryan announce his baptism, is the most powerful argument in the room for why this study works. This is “the guarantee” visible in a person, not a slogan.\n\nWhat would make it bigger: “Hunter, your wife is watching the homework do its work in you right now. That’s the guarantee in action — not just a slogan.” Naming the mechanism makes it teachable for the newcomers. Bryan honored the moment beautifully; one more sentence would have made the learning explicit for Anthony and Graham.",
+                  "timestamp": "[01:41:27]"
+                },
+                {
+                  "detail": "Engaging People  (🔵 Pivot Point · Engaging People)\n\nWhy it mattered: Roediger & Karpicke (2006) measured a 40–60% retention improvement when learned material is retrieved before new content is introduced. But the stakes here are more than neurological: this is the session mechanism that makes the group feel like a learning community rather than a lecture series. For Anthony and Graham, a L1 review from other members — men naming Big Ideas from memory — would have demonstrated exactly what the study produces. That visual is irreplaceable. They can’t see what L1 men retained without a review that surfaces it.",
+                  "timestamp": "[01:13:01]"
+                },
+                {
+                  "detail": "Teaching Craft / Engaging People  (🟢 Capitalized · Teaching Craft / Engaging People)\n\nWhy it mattered: Vashon’s insight names a real spiritual trap that most people never articulate: we retroactively decide God wasn’t speaking when the outcome we wanted didn’t materialize. This is a DOK 4 contribution from a participant — applying a theological principle to explain a common human failure. Bryan honored it without stealing it, then layered his own answer on top. Two more men (Hunter, Paul) followed with deeper contributions immediately after.\n\nWhat would make it bigger: “Vashon, say more about that — what does that look like in practice?” A 15-second follow-up probe would have drawn out the full insight before Bryan’s synthesis landed on top. Vashon had more. Bryan’s instinct to capitalize was right; a brief probe first would have made the contribution feel even more valued and given Vashon one more exchange of ownership over the idea.",
+                  "timestamp": "[00:59:47]"
+                }
+              ],
+              "paragraphs": [
+                "These are the 5 disproportionate moments in the session — the exchanges that shaped what this group will remember, believe, and do. Aggregated scores average these away; Key Moments name each one explicitly so Bryan can rewatch with intent."
               ]
             }
           ],
@@ -2830,197 +3134,230 @@
           ],
           "bigIdeas": [],
           "feedback": {
-            "headline": "A strong session — strongest in Newcomer Welcome and Homework References, with the clearest next step in Visual Aids.",
+            "headline": "Context note: Lesson 1 of a new James series — a full-book orientation session designed to give the group ownership of the text before deep-dive study. Session format (bumper sticker survey across all 5 chapters) intentionally differs from a standard chapter-study lesson; some metrics (visual aids, memory review) are adjusted for context. Comparison against Bryan’s prior sessions (L6 Apr 18, L7 Apr 25) is included.",
             "strengths": [
-              "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
-              "Homework was referenced and rewarded, differentiating the members who prepared.",
-              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place."
+              "Exceptional Newcomer Integration — 8-9 Men Welcomed and Followed Up",
+              "The Bumper Sticker Survey — Masterful Lesson-1 Scaffold",
+              "Theological Depth Made Accessible — Rabbinical Teaching + Canonization History"
             ],
             "improvements": [
-              "The session leaned audio-only; a visual anchor would aid retention.",
-              "Leader talk crowded out discussion; the balance leaned toward lecture.",
-              "Teaching stayed at arm’s length; little personal cost was modeled."
+              "Visual Aids Absent — An Overview Map Would Have Anchored Newcomers",
+              "Leader Talk Ratio Above Benchmark — Overview Format Explains but Doesn’t Excuse",
+              "Cross-Reference Density Below Benchmark"
             ],
             "recommendations": [
-              "Next time, put one word-study lookup or a simple table on screen during the key term.",
-              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-              "Next time, open one teaching point with a first-person example that cost you something."
+              "Build a “James at a Glance” Visual for Lesson 2",
+              "Open L2 with a Full Big Ideas Recitation (Set the Pattern Now)",
+              "Convert Two Explanation Moments Per Hour Into Questions"
             ],
             "overview": [
-              "A strong session — strongest in Newcomer Welcome and Homework References, with the clearest next step in Visual Aids. It scored 82.51/100 under the v3 weighted model.",
-              "The session played to its strengths in Newcomer Welcome and Homework References; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+              "Context note: Lesson 1 of a new James series — a full-book orientation session designed to give the group ownership of the text before deep-dive study. Session format (bumper sticker survey across all 5 chapters) intentionally differs from a standard chapter-study lesson; some metrics (visual aids, memory review) are adjusted for context. Comparison against Bryan’s prior sessions (L6 Apr 18, L7 Apr 25) is included.",
+              "This report carries the full written coaching for the session: 5 areas of strength, 5 areas for improvement, and 5 recommendations for next session, scored 82.51/100 on the v3 weighted model."
             ],
             "strengthsProse": [
               {
-                "title": "Newcomer Welcome anchored the session (5/5)",
+                "title": "Exceptional Newcomer Integration — 8-9 Men Welcomed and Followed Up",
                 "paragraphs": [
-                  "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
-                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
-                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 8–9 newcomers; 2 member testimonials before introductions; Bryan personally organized follow-up calls (Steven, Bryce, Mike, Thomas each assigned a newcomer). Best of the series."
+                  "With 8–9 first-time visitors, this was among the largest newcomer classes observed in Bryan’s Saturday morning study. The sequence was executed at full depth: two existing members (Zach, then another) gave extended testimony-style pitches before the newcomers introduced themselves; Bryan personally collected contacts and assigned specific members to call each newcomer during the week (Steven→Weston, Bryce→one newcomer, Mike→another, Thomas→contact coordination). The relational infrastructure was activated on the spot.",
+                  "“Get his number. I want you to call him this week... Mike, I want you to call him and talk to him.” [02:03:35–02:04:07]",
+                  "The Paul Rush moment was especially pastoral — a man who had been sober for 10 days walked in off the street, and Bryan’s response was immediate, personalized, and theologically grounded: “You’re not going to make it unless you find Jesus.” That phrase was quoted verbatim and paired with the homework replace-the-habit prescription. Newcomer engagement at this scale with this level of follow-up organization is Dimension 2 at its highest."
                 ]
               },
               {
-                "title": "Homework References anchored the session (5/5)",
+                "title": "The Bumper Sticker Survey — Masterful Lesson-1 Scaffold",
                 "paragraphs": [
-                  "Homework was referenced and rewarded, differentiating the members who prepared.",
-                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
-                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: “The Guarantee” delivered in full; 5-day hard-work framing; workbooks distributed at close; next-week assignment (James 1:1–11, memorize vv. 2–11) given explicitly. Highest Dim 10 score of the series."
+                  "The design of this session was pedagogically sophisticated: read a paragraph, derive a bumper sticker, accumulate the list, and infer the book’s thesis at the end. This is not a passive overview — it gives participants immediate co-ownership of the text before deep-dive study begins. New men could participate meaningfully from their first encounter; veteran members had to synthesize rather than just recall. The bumper sticker method was explained, demonstrated, and sustained across all 5 chapters without losing momentum.",
+                  "“Here’s what we’re gonna do today. We are gonna read the entirety of the book of James. We’re gonna stop with each paragraph and we’re gonna try to get a bumper sticker — three to five to seven words that best represents what that paragraph’s about.” [00:15:45]",
+                  "By the close, Russ reviewed the full accumulated list [01:56:47] and the group was already beginning to converge on a thesis (“Be a doer, not a hearer” / “faith without works is dead”). Bryan had taught the group how to read James rather than reading James for them. This is the highest leverage thing a Lesson 1 can do."
                 ]
               },
               {
-                "title": "Session Structure & Flow anchored the session (4/5)",
+                "title": "Theological Depth Made Accessible — Rabbinical Teaching + Canonization History",
                 "paragraphs": [
-                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Blueprint well-executed: newcomer welcome, context overview, full-book reading, closing prayer. No Big Ideas review (appropriate for L1). Ran 14 min over target duration."
+                  "Bryan wove in two sophisticated theological concepts without losing the room: the canonization history of James (why it nearly didn’t make it into the Bible, Martin Luther’s attempt to bury it) and the chiasm / rabbinical teaching structure. The chiasm explanation was precise — he identified the dead-center verse (James 3:13), explained the mirroring pattern, and connected it to the overarching thesis — all in under 5 minutes. These moments elevated the session from overview to genuine study.",
+                  "“You want to know what the dead center verse phrase in this book is? Brenda just read it — read verse 13 again, chapter 3. ‘Who among you is wise and understanding? Let him show by his good behavior, his deeds, in the gentleness of wisdom.’ Yes — I’m going to leave you all with that.” [01:24:11]",
+                  "Martin Luther changed the order of his Bible to bury James at the end, hoping people would stop reading before they got there. Bryan told that story with humor and precision. For men new to serious Bible study, this kind of behind-the-curtain scholarship builds immediate trust in the leader and anticipation for the weeks ahead."
                 ]
               },
               {
-                "title": "Scripture Engagement anchored the session (4/5)",
+                "title": "“The Guarantee” Delivered With Full Weight to a Fresh Audience",
                 "paragraphs": [
-                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: All 5 chapters of James read in order, paragraph by paragraph. Cross-references: ~4 (below the 6+ benchmark). Overview format partly explains; parallel texts in L2–10 will address."
+                  "With 8–9 newcomers in the room, the Guarantee speech landed at maximum impact. Bryan gave the full version at [00:07:26]: the 5-day homework, the mechanics of the Precept method, the personal story of coming to Bible study at 39 thinking “it’s the right thing to do,” and the payoff (“Was I surprised?”). He paired it with immediate workbook distribution at the close and a next-week assignment (James 1:1–11, memorize vv. 2–11). The Guarantee’s power is that it is a concrete, testable promise — and Bryan made sure every newcomer heard exactly what they were signing up for.",
+                  "“If you do the homework and you come every week, I guarantee you eventually you will recognize God is speaking to you. And once you get in that mode — it’s game on.” [00:07:26]",
+                  "The scripture memorization emphasis [02:01:49–02:03:02] was a valuable addendum — Brendan’s testimony of using memorized James 1:2–8 in prayer during the week was exactly the social proof that anchors the Guarantee. Peer testimony reinforcing the leader’s promise is the most powerful form of trust-building in an adult learning context."
                 ]
               },
               {
-                "title": "Application Questions anchored the session (4/5)",
+                "title": "Multi-Voice Closing Prayer for Fred — Community Depth on Display",
                 "paragraphs": [
-                  "Application questions pushed members from concept to life, several at the reason/apply level.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 9 Big Idea questions; 22% DOK 4, 44% DOK 3. Even distribution across chapters 1–3; compressed in 4–5 due to pacing. DOK ceiling lower than deep-study sessions (67% DOK 3-4 vs. L6’s 89%)."
+                  "The 8-minute closing prayer for Fred’s upcoming EO speech (Isaiah 53 to a potentially hostile Jewish/Muslim audience) was extraordinary. Five to six different men prayed spontaneously and at length, with specificity — wisdom, boldness, peace, protection, humility. Bryan delegated, stepped back, and let the group pray. The quality of those prayers is a direct output of the group culture this leader has built over multiple years.",
+                  "“We’re going to pray for Fred. He’s kind of under attack. It’s a challenging environment to share the gospel.” [02:05:47]",
+                  "For newcomers in the room (Paul Rush, just 10 days sober; Logan, who said he was looking for men “different from me”; Noah, who came for wisdom), watching five men pray deeply for a brother was the most effective possible advertisement for this group. Prayer depth is a community cultural marker — and this session demonstrated it in full."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Visual Aids is a growth area (2/5)",
+                "title": "Visual Aids Absent — An Overview Map Would Have Anchored Newcomers",
                 "paragraphs": [
-                  "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Scripture screen only; no BLB, no structural chart, no color-coded visual. Chiasm described verbally without a diagram. Lowest single score; directly addressable in L2."
+                  "This is the single largest technical gap in the session. No Blue Letter Bible word studies, no structural chart, no color-coded visual for the book’s themes or chapter relationships. Bryan described the chiasm structure verbally and drew a spiral in the air [01:33:50–01:34:03], but nothing was visible on screen. For a Lesson 1 with 8–9 newcomers, a single one-page visual — a chapter map of James with the 5 chapters, key themes, and the “spiral converging on a center” structure — would have given every man an anchor to take home.",
+                  "“If I was to draw a picture of it, it’s doing this. It’s going in a circle, a spiral, around something. And we’re going to try to figure out what it’s converging on.” [01:33:56]",
+                  "The verbal description was evocative but impermanent. Mayer’s multimedia principle (1994) is clear: visual + verbal encoding doubles retention vs. verbal-only. The king chart approach from the 2 Kings arc is the model — apply it to James by building a one-page “James at a Glance” chart for Lesson 1. It takes 30 minutes to build; the retention dividend runs for 10 weeks."
                 ]
               },
               {
-                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "title": "Leader Talk Ratio Above Benchmark — Overview Format Explains but Doesn’t Excuse",
                 "paragraphs": [
-                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Discussion-only ratio ~38% leader talk; above 30% benchmark. Three extended monologues; context-setting demands partly justify the gap. Same dimension score as L6 and L7."
+                  "Discussion-only leader talk is estimated at ~38%, well above the 30% Lifeway benchmark. Several explanations apply: this was a first-lesson orientation requiring more context-setting; the 8-minute James background monologue at [00:15:45–00:21:15] was necessary and excellent; the chiasm explanation required sustained teaching. But the pattern holds even outside those legitimate monologues. The “what you say is what you are” section [01:04:44–01:10:00] could have been reframed as: “What does it mean that your revealed preference IS your actual belief?” and handed to the group.",
+                  "“You are what he did. You’re not those two things. No, that’s really the idea he’s introducing. And he’s saying, oh no, there’s no such thing.” [00:46:56]",
+                  "The Hattie 0.82 effect size for classroom discussion is one of the strongest in the literature. When time is short and material is dense, the reflex to broadcast rather than ask is understandable — but it compounds over a 2-hour session. Target: identify two “I’m about to tell you” moments per hour and convert them to questions before speaking."
                 ]
               },
               {
-                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "title": "Cross-Reference Density Below Benchmark",
                 "paragraphs": [
-                  "Teaching stayed at arm’s length; little personal cost was modeled.",
-                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
-                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: 3 moderate-depth moments. Brother-in-law disclosure is Bryan’s highest-cost personal share this session; depth slightly below L7’s peak. Weight: 1 family share + 1 relational directness + 1 personal-story entry."
+                  "Only 4 cross-references were used in the session (1 Corinthians 15, Elijah/1 Kings, Abraham/Genesis, Rahab/Joshua 2), against the 6+ research benchmark. For the 2 Kings arc, Bryan consistently ran 7+ passages. James L1 had natural cross-reference opportunities that weren’t taken: Abraham and Rahab in James 2 pointed directly to Genesis 22 and Joshua 2 (Bryan named them but didn’t pull them up); Elijah was named but 1 Kings 18–19 wasn’t opened; the Proverbs 16:18 connection to “pride blocks repentance” wasn’t made. For a book-overview session, one cross-reference per chapter would have been ideal.",
+                  "The overview format is the reason, not an excuse. Even in a bumper sticker survey, one parallel text per chapter plants the seed of the parallel-reading discipline Bryan models in deep-study sessions. James 1 on trials is enriched by Romans 5:3–5 (the same chain: trials → perseverance → character). James 2 on faith and works is enriched by Romans 3:28 (Luther’s proof text that James is arguing against). These two alone would have tripled the cross-reference count without adding 5 minutes."
                 ]
               },
               {
-                "title": "Memory Reinforcement is a growth area (3/5)",
+                "title": "Chapter 4–5 Engagement Thinned as Pacing Picked Up",
                 "paragraphs": [
-                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Lesson 1: no prior Big Ideas to review. Bryan actively taught the importance of scripture memorization; Brendan’s prayer testimony demonstrated the practice. Foundation set for L2 review pattern."
+                  "The first three chapters had rich back-and-forth discussion with multiple named voices. Chapters 4–5 were noticeably faster — Bryan’s own meta-comment (“We got to keep speed” at [01:25:07], “We’re going to get home” at [01:45:44]) showed the time pressure. The bumper sticker quality in chapters 4–5 was lower as a result: several were resolved quickly without the productive struggle that generated gems like “true religion: dirty hands and a clean heart” in chapter 1. The chapter 5 prayer section was reduced to a single-question exchange before Bryan moved to the close.",
+                  "“We just got to hit the high point. 11 through 17. Chris. With feeling.” [01:30:49]",
+                  "The fix is upstream: compress chapters 1–2 (they ran the longest), target 15 minutes per chapter, and protect the final 20 minutes. Alternatively, designate chapters 4–5 as “high-altitude flyover” from the start and set that expectation explicitly so the group doesn’t feel the session winding down prematurely."
                 ]
               },
               {
-                "title": "Leader Development is a growth area (3/5)",
+                "title": "No Visible Apprentice — A Large Group Moment Went Undeployed",
                 "paragraphs": [
-                  "No in-session development of another leader was observable this week.",
-                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Follow-up calls assigned through existing members (Steven, Bryce, Mike, Thomas). Prayer chain accountability invoked. No visible apprentice in formal co-teaching or leadership-in-action role. Opportunity missed with 25+ men and 8-9 newcomers."
+                  "With 25+ men and 8–9 newcomers, this was an ideal session for a developing leader to own a visible operational role: managing the contact collection, leading a portion of the bumper sticker exercise, or coordinating the newcomer follow-up assignment at the close. None of that happened in a visible, named-apprentice capacity. Bryan organized the follow-up calls himself rather than handing the logistics to a developing leader.",
+                  "The 2 Timothy 2:2 multiplication model is the highest-weight cluster in the v3 scorecard for a reason. Apprentice visibility is not about the apprentice — it is about showing the group that leadership is reproducible. Every man in the room (especially the newcomers) benefits from seeing a not-yet-Bryan operating in a real role and doing it well. This is the mechanism by which the ministry multiplies. Ricky Town or another developing leader was the right candidate to own the newcomer contact coordination at the close.",
+                  "\"Consider it all joy when you meet trials — what’s actually being said? What’s the message?\" (James 1:2–4)",
+                  "\"What is wisdom? What’s the difference between earthly wisdom and applied knowledge? And why do you need God’s viewpoint?\" (James 1:5–8)",
+                  "\"What is the test of wholehearted faith here — about your view of your status, your position?\" (James 1:9–11)",
+                  "\"What is the source of your sin? Who’s responsible?\" (James 1:12–18)",
+                  "\"You say you believe — but what do you actually do? How do you reconcile belief that isn’t reflected in behavior?\" (James 1:19–25)",
+                  "\"How does James define worthless religion? How does he define pure and undefiled religion? What’s the test?\" (James 1:26–27)",
+                  "\"If faith has no works, what does James say? What’s the new idea being introduced?\" (James 2:14–17)",
+                  "\"If you’re driven by friendship with the world — what does that make you in relation to God?\" (James 4:4)",
+                  "\"What makes prayer effective? What does Elijah’s example teach us about how to pray?\" (James 5:13–18)",
+                  "Application Questions — Big Idea Questions Only",
+                  "These are the profound, discussion-driving questions posed to provoke reflection, application, or theological wrestling during the James L1 survey. Regular classroom Q&A (scaffolding, recall, navigational) is excluded here. Questions scored using Webb’s Depth of Knowledge (DOK): DOK 1 = recall, DOK 2 = compare/analyze, DOK 3 = reason/justify, DOK 4 = apply to life.",
+                  "1 every ~15 min; even across chapters 1–3, compressed in 4–5"
                 ]
               }
             ],
             "recommendationsProse": [
               {
-                "title": "Next session — Visual Aids",
+                "title": "Build a “James at a Glance” Visual for Lesson 2",
                 "paragraphs": [
-                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "A single one-page visual showing the 5 chapters of James with their key themes, the chiasm structure, and the center verse (James 3:13) would anchor everything taught in L1. Model it after the Kings chart. Post it at the session open for L2 and reference it as each chapter is revisited. The group earned this visual — they built the bumper stickers that belong in it. Before: \"It’s going in a circle, a spiral, around something.\" [verbal only] After: Display the chiasm map at the start of L2. Ask: \"What did we say the dead center of this book was?\" Let the group fill it in."
                 ]
               },
               {
-                "title": "Next session — Facilitation vs. Lecture",
+                "title": "Open L2 with a Full Big Ideas Recitation (Set the Pattern Now)",
                 "paragraphs": [
-                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Lesson 1 ends with a list of 15+ bumper stickers. Lesson 2 should open with: “Don’t look at your notes — who can give me a bumper sticker from last week?” Hold the space for 5 minutes. Establish the memory infrastructure from session 2 onward so it is never again N/A. The spaced-retrieval pattern (Ebbinghaus) compounds over 10 weeks of James — start it immediately."
                 ]
               },
               {
-                "title": "Next session — Vulnerability / Authenticity",
+                "title": "Convert Two Explanation Moments Per Hour Into Questions",
                 "paragraphs": [
-                  "Next time, open one teaching point with a first-person example that cost you something.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "In L2, identify in advance two sections where the impulse will be to explain before asking. Flip them. For the faith-vs.-works section, try: “Why do you think James says the demons believe — and shudder? What does that tell you about the kind of faith that doesn’t save?” The theological point still lands — but it comes from the group, not from Bryan, and it sticks 40% longer (Stuart & Rutherford)."
                 ]
               },
               {
-                "title": "Next session — Memory Reinforcement",
+                "title": "Add One DOK 4 Push Per Chapter in Bumper Sticker Sessions",
                 "paragraphs": [
-                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "After the bumper sticker is established, add a 60-second personal application pivot: “Where did you encounter this test this week? Anyone?” Even a 30-second share from one man elevates the session from analytical to transformational. This is particularly powerful with newcomers — it shows that the study is not just about knowing James, it is about being confronted by James."
                 ]
               },
               {
-                "title": "Next session — Leader Development",
+                "title": "Assign a Developing Leader to Own Newcomer Logistics at the Close",
                 "paragraphs": [
-                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "For the next large-newcomer session, hand the contact-collection and follow-up-call assignment to a developing leader. Say explicitly: “Ricky, you’re running the newcomer follow-up this week — here’s the list, I want a report next Saturday.” The multiplication model requires visible handoffs. Every man in the room needs to see that Bryan’s role can be held by someone other than Bryan. Session-Over-Session Comparison — L6 → L7 → James L1 Comparison of this session against the two most recent sessions in the 2 Kings arc. Composite scores: L6 Apr 18 = 74.7, L7 Apr 25 = 77.8, James L1 May 16 = 74.4. The slight dip from L7 is context-driven: this was a format change (overview vs. deep-study) and a book change (James vs. 2 Kings). The core dimensions held; the visual aid and cross-reference drops are explained by the bumper sticker survey format. 5/5 (8–9 newcomers, full sequence, follow-up assigned) 5/5 (Guarantee + workbooks + next-wk assignment) 4/5 (multi-voice closing, 5+ men) 4/5 (James 1–5 + ~4 cross-refs) 3/5 (Lesson 1 — no prior sessions) Trajectory note: Bryan’s core blueprint (structure, facilitation, application, prayer) is locked in and stable across 3 consecutive sessions. The format-driven dip in visual aids and cross-references is understood and addressable in L2. The newcomer welcome (5/5) and homework framing (5/5) are the strongest single-session marks observed in the James arc. The development priority for the next 3 sessions is: (1) Visual aids for every session including overview sessions, (2) Apprentice visibility, and (3) Discussion-only ratio below 35%. Bible Leader Coaching | Bryan Bailey | May 16, 2026"
                 ]
               }
             ]
           },
           "sections": [
             {
-              "title": "Score composition",
-              "paragraphs": [
-                "How the four weighted clusters and any session bonuses combined into the composite score."
-              ],
+              "title": "Scorecard — Table 1",
               "bullets": [
-                "Teaching Craft: 68% × weight 33 → 22.44 pts",
-                "Building Ministry: 86.7% × weight 31 → 26.87 pts",
-                "Engaging People: 70% × weight 18 → 12.60 pts",
-                "Being Real: 70% × weight 18 → 12.60 pts",
-                "Base (sum of cluster contributions): 74.51 / 100",
-                "Session bonuses: newcomer growth +5, group-size +3",
-                "Session score: 82.51 / 100"
+                "Number of Attendees: ~25–27 men (in-person + Zoom)  (Target: —)  → —",
+                "New Attendees: 8–9 first-time visitors  (Target: —)  → —"
               ]
             },
             {
-              "title": "Coaching notes by dimension",
-              "paragraphs": [
-                "The per-dimension rationale behind each score on the 12-dimension scorecard."
-              ],
+              "title": "Scorecard — Table 2",
               "bullets": [
-                "Session Structure & Flow (4/5): Blueprint well-executed: newcomer welcome, context overview, full-book reading, closing prayer. No Big Ideas review (appropriate for L1). Ran 14 min over target duration.",
-                "Newcomer Welcome (5/5): 8–9 newcomers; 2 member testimonials before introductions; Bryan personally organized follow-up calls (Steven, Bryce, Mike, Thomas each assigned a newcomer). Best of the series.",
-                "Scripture Engagement (4/5): All 5 chapters of James read in order, paragraph by paragraph. Cross-references: ~4 (below the 6+ benchmark). Overview format partly explains; parallel texts in L2–10 will address.",
-                "Facilitation vs. Lecture (3/5): Discussion-only ratio ~38% leader talk; above 30% benchmark. Three extended monologues; context-setting demands partly justify the gap. Same dimension score as L6 and L7.",
-                "Application Questions (4/5): 9 Big Idea questions; 22% DOK 4, 44% DOK 3. Even distribution across chapters 1–3; compressed in 4–5 due to pacing. DOK ceiling lower than deep-study sessions (67% DOK 3-4 vs. L6’s 89%).",
-                "Participant Engagement (4/5): 15+ named voices; 11+ scripture readers; ~58–65% participation rate. Engagement thinned in chapters 4–5 as pacing picked up. Maintained above L6 baseline overall.",
-                "Visual Aids (2/5): Scripture screen only; no BLB, no structural chart, no color-coded visual. Chiasm described verbally without a diagram. Lowest single score; directly addressable in L2.",
-                "Vulnerability / Authenticity (3/5): 3 moderate-depth moments. Brother-in-law disclosure is Bryan’s highest-cost personal share this session; depth slightly below L7’s peak. Weight: 1 family share + 1 relational directness + 1 personal-story entry.",
-                "Memory Reinforcement (3/5): Lesson 1: no prior Big Ideas to review. Bryan actively taught the importance of scripture memorization; Brendan’s prayer testimony demonstrated the practice. Foundation set for L2 review pattern.",
-                "Homework References (5/5): “The Guarantee” delivered in full; 5-day hard-work framing; workbooks distributed at close; next-week assignment (James 1:1–11, memorize vv. 2–11) given explicitly. Highest Dim 10 score of the series.",
-                "Prayer (4/5): Multi-voice closing prayer (5–6 men, 8 min) for Fred’s EO speech. Opening prayer not captured (pre-recording). Prayer chain infrastructure emphasized with accountability language. Strong community prayer culture demonstrated.",
-                "Leader Development (3/5): Follow-up calls assigned through existing members (Steven, Bryce, Mike, Thomas). Prayer chain accountability invoked. No visible apprentice in formal co-teaching or leadership-in-action role. Opportunity missed with 25+ men and 8-9 newcomers."
+                "Leader Talk (incl. reading): ~48% / 52%  (Target: Lifeway 30% leader)  → NEEDS WORK",
+                "Leader Talk (discussion only): ~38% / 62%  (Target: Lifeway 30% leader)  → NEEDS WORK",
+                "Statements tied to verses: ~85%  (Target: 70%+ (Precept OIA))  → STRONG",
+                "Time to first scripture: ~15 min (after newcomer welcome)  (Target: <15 min (Ken Braddy))  → ON TARGET",
+                "Cross-references used: ~4 (1 Cor 15, Elijah/1 Kgs, Abraham/Gen, Rahab/Josh)  (Target: 6+ per session)  → NEEDS WORK"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 3",
+              "bullets": [
+                "Overall Class Time: ~2h 14m  (Target: 1.5–2h (BSF standard))  → NEEDS WORK",
+                "Pre-session + Newcomer Welcome: ~18 min (13%)  (Target: 7–25 min)  → STRONG",
+                "Historical/Contextual Overview: ~12 min (9%)  (Target: 5–10 min)  → STRONG",
+                "Scripture Reading + Bumper Stickers: ~90 min (67%)  (Target: 50–60% lesson)  → NEEDS WORK",
+                "Closing Prayer + Wrap-up: ~14 min (10%)  (Target: 5–10%)  → STRONG",
+                "Big Ideas Review (prior sessions): N/A — Lesson 1  (Target: 5–15 min)  → N/A"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 4",
+              "bullets": [
+                "Big Idea Questions (DOK 2+): ~9  (Target: 8–10 (normalized))  → ON TARGET",
+                "Distribution: 1 every ~15 min  (Target: Spread evenly)  → ON TARGET",
+                "Level 1 (simple recall): 0%  (Target: <25%)  → STRONG",
+                "Level 2 (compare/analyze): 33%  (Target: 30–40% (Webb))  → STRONG",
+                "Level 3 (reason/justify): 44%  (Target: 25–35%)  → STRONG",
+                "Level 4 (apply to life): 22%  (Target: 10–20%)  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 5",
+              "bullets": [
+                "Students reading scripture: 11+ named readers  (Target: 10+ (BSF))  → STRONG",
+                "Students asking questions / contributing: 15+ of ~26 (58–65%)  (Target: 70–80% (Gini))  → ON TARGET",
+                "Student talk time: ~40%  (Target: 50–70% (Hattie 0.82))  → ON TARGET",
+                "Quiet member engagement: Called by name 12+ times  (Target: Active outreach)  → STRONG",
+                "Wait time after bumper sticker prompts: 4–6 sec (held space well)  (Target: 3–5 sec (Rowe 1972))  → STRONG",
+                "Visual aids used: 1 (scripture screen); no BLB, no charts  (Target: 2+ multi-sensory)  → NEEDS WORK"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 6",
+              "bullets": [
+                "Vulnerability moments: 3 moments (moderate depth)  (Target: 2–3 per session)  → ON TARGET",
+                "Monologues >90 sec: 3 instances (historical context, faith-works, memory)  (Target: <1 during discussion (Stuart & Rutherford))  → NEEDS WORK",
+                "Longest monologue: ~8 min (James background + canonization history)  (Target: <90 sec during discussion)  → NEEDS WORK"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 7",
+              "bullets": [
+                "Open-ended questions: ~78%  (Target: 80%+)  → ON TARGET",
+                "Questions requiring text: ~70%  (Target: 70%+)  → ON TARGET",
+                "Follow-up probing questions: 14+  (Target: 15–20)  → ON TARGET",
+                "Wait before answering own question: 4–6 sec (consistent)  (Target: 5+ sec)  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 8",
+              "bullets": [
+                "Questions vs. statements: 42% Q / 58% S  (Target: 70% Q / 30% S)  → NEEDS WORK",
+                "Tonality / vocal variety: Wide range — authoritative, pastoral, humorous  (Target: Varied tone)  → STRONG",
+                "Topic drift: ~3% (prostate humor, minor rabbit trails)  (Target: <10%)  → STRONG",
+                "Bumper sticker method explained + executed: Yes — modeled then applied throughout  (Target: Key technique for Lesson 1)  → STRONG",
+                "Big Ideas accumulated at close: Yes — Russ reviewed all bumper stickers [01:56:47]  (Target: 1–2 takeaways reinforced)  → STRONG",
+                "Rabbinical structure / chiasm taught: Yes — chiasm explained, center verse identified [01:23:50]  (Target: Advanced hermeneutic)  → STRONG"
               ]
             }
           ],
@@ -3144,197 +3481,234 @@
           ],
           "bigIdeas": [],
           "feedback": {
-            "headline": "A strong session — strongest in Scripture Engagement and Visual Aids, with the clearest next step in Facilitation vs. Lecture.",
+            "headline": "Context note: This is a coaching report on Bryan's own session. Per the project's evaluation standards, this report compares against research benchmarks AND against Bryan's rolling historical baseline and prior session (L5, April 11, 2026). Session-over-session (L5 → L6) and historical-drift analyses are included as distinct sections. Tone: direct and actionable — honest coaching as requested.",
             "strengths": [
-              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-              "On-screen word study and visuals reinforced the teaching multi-modally.",
-              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place."
+              "Arc-Closing Christological Payoff — Group-Generated Landing",
+              "Yoke-as-Embodied-Metaphor Teaching (Jeremiah 27)",
+              "True vs. False Prophet Parallel-Column Synthesis"
             ],
             "improvements": [
-              "Leader talk crowded out discussion; the balance leaned toward lecture.",
-              "A few voices carried the discussion; quieter members went unheard.",
-              "Teaching stayed at arm’s length; little personal cost was modeled."
+              "Pacing Collapse in Final 20 Minutes — Blew Through the Close",
+              "Big Ideas Review Was Cursory vs. L5's Group Recitation",
+              "Leader Talk Ratio Regressed From L5 (58% → 62% Discussion-Only)"
             ],
             "recommendations": [
-              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-              "Next time, name one quiet regular early and invite their read on a passage.",
-              "Next time, open one teaching point with a first-person example that cost you something."
+              "Cut One Jeremiah Passage Next Arc to Protect the Close",
+              "Restore the 8-Minute Group Big Ideas Review at Session Open",
+              "Hand the Newcomer One Low-Stakes Reading"
             ],
             "overview": [
-              "A strong session — strongest in Scripture Engagement and Visual Aids, with the clearest next step in Facilitation vs. Lecture. It scored 76.92/100 under the v3 weighted model.",
-              "The session played to its strengths in Scripture Engagement and Visual Aids; the recommendations below turn Facilitation vs. Lecture into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+              "Context note: This is a coaching report on Bryan's own session. Per the project's evaluation standards, this report compares against research benchmarks AND against Bryan's rolling historical baseline and prior session (L5, April 11, 2026). Session-over-session (L5 → L6) and historical-drift analyses are included as distinct sections. Tone: direct and actionable — honest coaching as requested.",
+              "This report carries the full written coaching for the session: 5 areas of strength, 5 areas for improvement, and 5 recommendations for next session, scored 76.92/100 on the v3 weighted model."
             ],
             "strengthsProse": [
               {
-                "title": "Scripture Engagement anchored the session (5/5)",
+                "title": "Arc-Closing Christological Payoff — Group-Generated Landing",
                 "paragraphs": [
-                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 7 passages across 4 books; 82% verse-grounded; every teaching move anchored to text"
+                  "The 6-lesson 2 Kings arc landed exactly where it was designed to land: a participant — not Bryan — articulated the arc's christological payoff at [126:23] (“It puts you in the mindset of, I don't just need a new king. I need the perfect king.”). This is arc execution at its highest level. Six weeks of evil-king accumulation paid off as planned, and the group member did the synthesis Bryan had been setting up.",
+                  "“Here's the macro thing. It's making you think. Is there ever going to be a king just who does right? ... And guess what? There is.” [125:28]",
+                  "Bryan's framing at [125:44–126:00] (“This part of the Bible is pointing to that new king. You should be thinking, man, I need a new leader.”) opened the door; the group walked through it. The multi-week anticipation engineering worked — a pattern consistent with the rolling historical baseline for arc-closing sessions."
                 ]
               },
               {
-                "title": "Visual Aids anchored the session (5/5)",
+                "title": "Yoke-as-Embodied-Metaphor Teaching (Jeremiah 27)",
                 "paragraphs": [
-                  "On-screen word study and visuals reinforced the teaching multi-modally.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Three aids deployed synchronously — best of the arc (chart + live text + Big Ideas slide)"
+                  "Jeremiah 27's symbolic action became a visceral teaching moment rather than an abstract prophetic sign. After the mechanical explanation at [51:27–51:45] (“it's a piece of wood that we need... and a metal hook around both animals”), the embodied press at [60:15–60:26] turned the yoke physical — and when Hananiah broke the yoke at [87:53], the dramatic stakes landed because the wooden yoke had been made real 27 minutes earlier.",
+                  "“So God just told Jeremiah, go get a yoke of pieces of wood... He's walking around with a piece of wood and metal around his neck. That's what's happening.” [60:15]",
+                  "This is the “Complex-to-Accessible Translation” lever from the v2 scorecard (Category C) — translating dense prophetic symbolism into a physical image the men can feel. The escalation from wooden yoke to iron yoke in Jeremiah 28 landed harder because the wooden yoke had already been made visceral."
                 ]
               },
               {
-                "title": "Session Structure & Flow anchored the session (4/5)",
+                "title": "True vs. False Prophet Parallel-Column Synthesis",
                 "paragraphs": [
-                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Strong open (newcomer + chart + Big Ideas); closing truncated by run-over past 9:00 target"
+                  "Bryan built a four-attribute diagnostic framework (submission vs. freedom, judgment vs. denial, alignment vs. opposition, leads to life vs. leads to destruction) in real time with the group. The Socratic move was clean: state the true-prophet attribute, force the group to generate the opposite. This is the signature “Power of Four” teaching rhythm applied to prophet discernment.",
+                  "“A true prophet calls for submission. A false prophet — what do they call for? ... A true prophet speaks judgment. False prophet? ... A true prophet aligns with God's plan. What is the false prophet, dude? What's the opposite of alignment?” [77:57]",
+                  "The synthesis tied directly to the Joel Osteen and Logan Paul riff at [64:52–67:51] and was reinforced with the prosperity-gospel critique at [93:00–94:20]. The Joel Osteen callout — a recurring signature move across the arc — escalated in L6 (invoked 3x) without becoming a tangent; it functioned as a living case study for the framework being built."
                 ]
               },
               {
-                "title": "Newcomer Welcome anchored the session (4/5)",
+                "title": "Pride-Blocks-Repentance Bumper Sticker — Group-Generated",
                 "paragraphs": [
-                  "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
-                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
-                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Walker introduced; Keith's Guarantee pitch. 7 min vs. 7–25 range — intro-only, no integration post-[06:00]"
+                  "Classic signature move: Bryan held the space for ~90 seconds of productive struggle, called on Raven by name (“Let me go with Raven. What connects those two for me?”), and waited. When the word “block” emerged from the group, Bryan canonized it as a Big Idea. The whiteboard Big Ideas slide visible at [~75:00] confirms “Pride BLOCKS repentance” captured in writing — group-coined, leader-canonized.",
+                  "“What's the connection between pride, that viewpoint and repentance? ... That's the big idea. There's no — it's a block.” [30:22–31:48]",
+                  "This is the engine of the retention model — participants feel ownership because they coined the phrase. Consistent with historical pattern; executed cleanly in L6 despite the pacing pressure that shortened other signature moves."
                 ]
               },
               {
-                "title": "Application Questions anchored the session (4/5)",
+                "title": "Visual Aid Stack — Highest Density of the Arc (Chart + Bible + Whiteboard)",
                 "paragraphs": [
-                  "Application questions pushed members from concept to life, several at the reason/apply level.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 9 Big Ideas at 89% DOK 3-4; count regressed from L5 (11); spacing clustered first/last thirds"
+                  "Three distinct visual aids deployed synchronously, more than any prior lesson in the arc. The Kings chart at [07:00–09:30] with color coding (green = did right, pink = did evil, plus Assyrian and Babylonian captivity labels) was operated with Russell's narration. Live Bible text screen-share carried through the middle and late hours. The Big Ideas whiteboard slide at [~75:00] held all four cumulative takeaways simultaneously — pride blocks repentance, any extent of punishment to be with you, deliberate/progressive/covenant, goal is restoration.",
+                  "“Pull up the kings chart for me. And Russell, I want you to... the one with red.” [06:55]",
+                  "Dual-coding research (Paivio 1971) predicts a 30–50% retention lift from the combination of verbal + visual encoding; this session is the strongest example in the arc. The Big Ideas slide is a direct memory-reinforcement asset — even though the closing group recitation was truncated (see Improvement #2), the slide itself carried the load visually."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "title": "Pacing Collapse in Final 20 Minutes — Blew Through the Close",
                 "paragraphs": [
-                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: 62% leader talk (discussion only); regressed from L5 (58%); middle hour heavily leader-led"
+                  "This is the structural issue of the session. The lesson was overloaded — 7 passages across 4 books in 128 minutes — which forced the last 25 minutes (Jeremiah 37 exposition, ‘Not a Fan’ book reference, Big Ideas summary, prayer chain exhortation, closing prayer) into a compressed burst. Running past 9:00 into 9:09 is not a one-off; it cost the closing prayer its breathing room and prevented the group recitation of the four Big Ideas.",
+                  "“We'll be here until 11. ... I have no idea why they give us so much to read and expect us to just blow through it. Let's pick up some speed. There's so much here.” [59:49–60:57]",
+                  "Bryan's own words at [59:49] flagged the problem in real time. The fix is upstream, not in the moment: trim one of Jeremiah 27, 28, or 37 next time, or pre-commit to ending at one Big Idea rather than four. Research (Ken Braddy) is clean on this: cognitive retention drops sharply after 100 minutes, so the final 28 minutes of L6 likely did not land with the depth they deserved."
                 ]
               },
               {
-                "title": "Participant Engagement is a growth area (3/5)",
+                "title": "Big Ideas Review Was Cursory vs. L5's Group Recitation",
                 "paragraphs": [
-                  "A few voices carried the discussion; quieter members went unheard.",
-                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: 53% contribution rate; same core 5–6; Walker not pulled into substantive Q&A"
+                  "The Big Ideas review lasted approximately 2 minutes in L6 vs. 8 minutes in L5. Three themes surfaced (consequences, bad company, stone-cold sovereignty) and Bryan moved on with “and we'll jump in.” The engine move of the retention model — spaced-retrieval group recitation at session open — was shortchanged. With Walker present as a newcomer, a fuller review would have simultaneously oriented him AND reinforced the group's shared vocabulary; both benefits were lost.",
+                  "“Somebody give me a big idea. ... That our actions have inevitable consequences. Yeah, there's judgment for disobedience. ... Bad company, bad outcome. And we'll jump in.” [09:54–10:30]",
+                  "L5 held the space for 8 minutes and surfaced 6+ Big Ideas from the group. L6 regressed on the single highest-ROI retention intervention in the model. The research is unambiguous (BSF, Precept): spaced retrieval at session open outperforms every other reinforcement intervention measured. This is not a small miss — it is a miss of the engine."
                 ]
               },
               {
-                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "title": "Leader Talk Ratio Regressed From L5 (58% → 62% Discussion-Only)",
                 "paragraphs": [
-                  "Teaching stayed at arm’s length; little personal cost was modeled.",
-                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
-                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: 3 moderate moments; depth regressed from L5 (no marital-accountability-level disclosure)"
+                  "The Zedekiah-hypocrisy section [58:00–59:00] was delivered as a sustained monologue — ~50 seconds of dense theology that could have been group-generated. The true-prophet/false-prophet chart at [77:57–81:30], though Socratic in form, still landed at ~62% leader talk because every attribute was stated before the group was asked for the opposite. The Lifeway 30% benchmark is still a long way off, and the regression from L5 is real.",
+                  "“So if our lives can give our lives to him, they're no longer our own. So our will is no longer our own. So why are you keeping in time? We do the things that we want to do, just submitting the God and saying, God, I'm going to meet me or service. What can I not do for you?” [58:09–58:25]",
+                  "The regression from 58% to 62% is small but directionally wrong — and the mechanism is identifiable. Pacing pressure drove the reflex: when time runs short, the default is to teach rather than facilitate. The Hattie 0.82 discussion effect size argues for the reverse reflex. When time is short, ask more questions, not fewer."
                 ]
               },
               {
-                "title": "Memory Reinforcement is a growth area (3/5)",
+                "title": "Walker (the Newcomer) Was Welcomed But Not Integrated",
                 "paragraphs": [
-                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Big Ideas review cursory (~2 min vs. L5's 8 min); ‘Stone-cold’ and ‘Bad company’ referenced but not group-recited"
+                  "Walker got a 30-second self-intro and Keith delivered the testimony/Guarantee pitch at [04:05–04:30] — that part worked. But after [06:00], Walker was not called on by name to read, answer a question, or contribute across the remaining 2 hours of the session. For a first-time attendee, the blueprint is intro + at least one reading + one accessible question directed by name. L6 executed step 1 and skipped steps 2 and 3.",
+                  "“30 seconds on Walker. ... Yeah, I'm born. I was born in Memphis, Tennessee. But moved Austin. When I was about four. ... So then here, you know, most of my life... really looking forward to getting a chance to read the Bible with you guys.” [04:51–05:17]",
+                  "The opportunity is small but consequential. Walker said explicitly he was looking forward to reading — that phrase is the exact invitation a newcomer gives a leader. The fix is mechanical: pick one low-stakes passage (e.g., the first Jeremiah 22 read) and hand it to the newcomer with light context. A first-week newcomer who reads once is substantially more likely to return the following week than one who only watched."
                 ]
               },
               {
-                "title": "Homework References is a growth area (4/5)",
+                "title": "Monologue Length and Count Both Regressed From L5 (3 → 5; 3:30 → 4:13)",
                 "paragraphs": [
-                  "Homework went unmentioned, reducing its pull on the group.",
-                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Explicit Precept reference at [39:48]; Power of Four implicit; prayer chain call commitment at [120:27]"
+                  "Five monologues exceeded 90 seconds (vs. three in L5), and the longest ran ~4 min 20 sec during the true/false prophet synthesis at [77:57–82:10]. The prosperity-gospel/Joel Osteen riff at [93:00–94:20] and the ‘Not a Fan’ book promotion at [115:19–115:51] both exceeded 90 seconds without a return question to the group.",
+                  "“False teaching that contradicts God's Word brings severe judgment. So your false teaching that contradicts God's Word — that's basically what we had here. A guy literally contradicting God's Word. So brief, severe judgment because what does it say? I'm going from a yoke of wood to a yoke of what? Iron.” [90:42–91:19]",
+                  "Stuart & Rutherford's research on adult learning: after 90 seconds of uninterrupted leader talk, retention drops ~40%. The mechanical fix is a 75-second internal timer that fires mid-teaching and converts the next sentence into a question: “What do you see in that list?” rather than “Here's what you should see.” The framework still gets built — but with group-generated content rather than broadcast.",
+                  "\"What are you learning about God here?\" (Jer 22:24-30, Coniah)",
+                  "\"Is that [warning-then-judgment pattern] going to be true for us one day?\"",
+                  "\"What's the connection between pride, that viewpoint, and repentance?\" (Big Idea bumper-sticker moment)",
+                  "\"You can get to a point with God where there's no remedy. What would that mean?\" (2 Chron 36:16)",
+                  "\"Give me some words that describe God's judgment.\" (Generated 2nd Big Idea: deliberate, progressive, covenant)",
+                  "\"God has other people on His payroll. How is that informed — how you pray?\" (Jer 27:5-7)",
+                  "\"A true prophet calls for submission. A false prophet — what do they call for?\"",
+                  "\"Zedekiah asks for prayer without submitting. What would you call that?\" (Produced ‘spiritual hypocrisy’)",
+                  "\"What does it say about a Christian who faces no opposition, no persecution?\" (Jer 37 → 2 Tim 3)",
+                  "Application Questions — Big Idea Questions Only",
+                  "These are the profound, discussion-driving questions posed to provoke reflection, application, or theological wrestling during L6. Regular classroom Q&A (scaffolding, recall, navigational) is excluded here and documented in the Appendix. Questions scored using Webb's Depth of Knowledge (DOK): DOK 1 = recall, DOK 2 = compare/analyze, DOK 3 = reason/justify, DOK 4 = apply to life.",
+                  "1 every 14 min — clustered first/last thirds",
+                  "Rigor is excellent — 89% of Big Idea questions sit at Webb Level 3 or 4; 0% at Level 1. The weakness is spacing: the DOK 4 application questions clustered in the first and last thirds of the session, with a thin middle-hour stretch (60–95 min) dominated by leader-led exposition. Count regressed slightly from L5 (11 → 9) and density dropped from 1 every 11 min to 1 every 14 min. The rigor is not the problem — the distribution is."
                 ]
               }
             ],
             "recommendationsProse": [
               {
-                "title": "Next session — Facilitation vs. Lecture",
+                "title": "Cut One Jeremiah Passage Next Arc to Protect the Close",
                 "paragraphs": [
-                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "The session ran 2h 8m with the closing 3 minutes compressed. Pre-select 4 passages max per lesson, not 7. Target 2h 0m hard stop with 5 min buffered for group Big Ideas recitation. Before [60:57]: “We'll be here until 11. I have no idea why they give us so much to read and expect us to just blow through it.” Covered Jer 22, 24, 27, 28, 37 plus 2 Kings 24 and 2 Chron 36 in 128 minutes; closing compressed to 3 minutes. After: Pre-select 4 core passages (e.g., Jer 27, 28, 37 + 2 Chron 36) and pre-commit to 2h 0m end. If the arc demands all 7 passages, spread across 2 sessions. Target overall class time ≤ 2h 0m; closing segment ≥ 5 min."
                 ]
               },
               {
-                "title": "Next session — Participant Engagement",
+                "title": "Restore the 8-Minute Group Big Ideas Review at Session Open",
                 "paragraphs": [
-                  "Next time, name one quiet regular early and invite their read on a passage.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "The spaced-retrieval opening is the single highest-ROI retention intervention in the model — L5 held it, L6 shortchanged it. Before [09:54–10:30]: “Somebody give me a big idea.” — got 3 answers in 2 minutes, then “and we'll jump in.” L5 ran the same move for 8 minutes and surfaced 6+ themes. After: Hold the space for 8 minutes. With a newcomer present: “Walker, here's how this group does this — the guys recite the cumulative themes from memory. Listen to what they've built over 5 weeks.” Target: Big Ideas review 5–8 min; 5+ cumulative themes surfaced by the group."
                 ]
               },
               {
-                "title": "Next session — Vulnerability / Authenticity",
+                "title": "Hand the Newcomer One Low-Stakes Reading",
                 "paragraphs": [
-                  "Next time, open one teaching point with a first-person example that cost you something.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Walker said explicitly he was “really looking forward to getting a chance to read the Bible with you guys.” The invitation was given — act on it. Before [04:51]: Walker introduced and welcomed for 30 seconds; not called on by name for reading or Q&A across the remaining 2 hours. After: At the first Jeremiah passage: “Walker, would you read Jeremiah 22:24 for us? Just the verse — no pressure.” Follow up with a DOK-1 observation: “What word jumped out?” Target: every newcomer reads at least once; every newcomer gets one named question."
                 ]
               },
               {
-                "title": "Next session — Memory Reinforcement",
+                "title": "Apply the 75-Second Monologue Reflex",
                 "paragraphs": [
-                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Set a mechanical internal timer that fires at 75 seconds and converts the next sentence into a question. Before [77:57–82:10]: True/false prophet synthesis ran ~4 min 20 sec of leader-led content. Prosperity-gospel riff [93:00–94:20] and ‘Not a Fan’ promotion [115:19–115:51] both exceeded 90 sec without a return question. After: Instead of “A true prophet aligns with God's plan” → “Based on what we just read, what do you think a true prophet aligns with?” The framework still gets built — with group-generated content. Target: zero monologues >90 sec; longest ≤ 2:30."
                 ]
               },
               {
-                "title": "Next session — Homework References",
+                "title": "Speak the Closing Big Ideas Aloud as a Group Before Prayer",
                 "paragraphs": [
-                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "The Big Ideas slide was visible but the four takeaways were cited, not recited — cost a 40–60% retention lift. Before [127:07]: Named four takeaways from the Big Ideas whiteboard slide and moved directly to closing prayer; group did not speak them aloud. After: Before closing prayer: “Say with me — Pride blocks repentance. God will go to any extent of punishment in order to be with you. God's discipline is deliberate, progressive, rooted in unfaithfulness. The goal of discipline is restoration.” Activates verbal-memory encoding and seeds next week's review. Target: every Big Idea spoken aloud by the group before closing prayer. 4 passages / 5-min close at 2h 0m 8 min / 5+ themes (L5 standard) Direct comparison against the prior session (L5, April 11, 2026 — 2 Kings 21–25, Lesson 5: Good Figs/Bad Figs, Jeremiah 31 New Covenant, Luke 22). This comparison is expected per the project's coaching evaluation standards for Bryan's own sessions. The structure: what improved, what regressed, and which signature techniques stayed consistent across the two sessions. 11 min (L6, first ref 11:15, full read 14:35) 3 aids (chart + live Bible text + Big Ideas slide) Walker introduced + Keith's Guarantee pitch Big Ideas framework established ‘I need THE perfect King’ landed BY the group Arc resolution — participant-generated Leader Talk Ratio (discussion only) −4 points — both still NEEDS WORK −2 questions; density 1/11min → 1/14min 8 min group recitation; 6+ themes MAJOR regression — engine move shortchanged +3 points — still below 70% benchmark Marital accountability (L5, high personal cost) YouTube filter story + unfinished-theology (moderate) Depth regressed — L6 lower-cost than L5 Two Big Ideas written + recited (L5) Four on slide, NOT recited; prayer rushed at 127:10 Rushed close — ran past 9:00 target Consistent Signatures (L5 ≡ L6) Same chart, same logic (green=right, pink=evil). Arc anchor. Classic signature — deployed for newcomer welcome. Unconditional-covenant marker; consistent usage. Bumper-sticker synthesis (group-generated) ‘Partial obedience is disobedience’ L5 [31:48] ‘Pride blocks repentance’ L6 Participant-coined, leader-canonized. Engine of retention. [77:57–81:30] true/false prophet L6 Same 4-column build; opposite asked for each attribute. Joel Osteen false-teaching callout [28:48] L5 (‘top 20 stupid quotes’) [64:52] + [93:00] + [124:05] L6 — 3x Increased frequency in L6; prosperity-gospel foil. ‘What went down?’ opener after scripture [32:35], [88:44], [101:12] L6 (functional equivalents) Slightly fewer literal phrasings; same function 4x. Prayer Chain ministry reinforcement [120:27] L6 (‘get down on your knees’) Explicit weekly-call accountability in L6 closing. Arc Narrative Note: The 2 Kings arc (L1–L6) landed the intended destination — a group member himself articulated ‘I need the perfect king’ at [126:23], exactly the christological payoff set up across six weeks. That is arc execution at its highest level. However, L6 as a standalone session was uneven: the opening 45 minutes (newcomer + chart + pride-blocks-repentance) was excellent; the middle hour (yoke + true/false prophet + Hananiah) was content-dense but leader-heavy at 62–68% talk; the final 25 minutes were compressed by running over time, which truncated the closing prayer and prevented group recitation of the four Big Ideas. Energy sustained across 128 minutes, but depth was traded for breadth in the second half. The arc closed as intended; the individual session would have been stronger with one fewer Jeremiah passage and a preserved 5-minute close. This section audits L6 against the 13 distinctive teaching techniques and the bumper-sticker library that define the rolling historical baseline. The purpose is to flag drift early — are all the signature moves still in the repertoire, are they being executed at full depth, and which bumper stickers are still landing with the group? 13 Distinctive Techniques — L6 Presence Audit ‘What Went Down?’ opener after scripture Used in functional form 4x (e.g., [32:35] ‘What do we see about what role has God played?’; [88:44] ‘And what happened?’; [101:12] ‘So politically, what's just happened?’). Literal phrasing reduced vs. arc baseline. Socratic Method (questions before answers; names) Named call-outs to Stephen, Brandon, Matt, Walker, Scott, Peter, Raven. Usage held but 62% leader-talk in discussion dilutes Socratic density — see Improvement #3. Parallel Text Teaching (2–3 books simultaneously) 4 books / 7 passages triangulated (2 Kgs 24, 2 Chron 36, Jer 22/24/27/28/37, brief 2 Tim 3). Above baseline density — contributed to pacing overload (Improvement #1). Group coined ‘Pride blocks repentance’ [31:48]; Bryan canonized. ‘Stone-cold’ referenced [18:05]. ‘Bad company, bad life’ cited [10:14]. ‘If you don't live set apart...’ reinforced. Kings chart at [07:00] with full color logic (green=did right, pink=did evil, plus Assyrian/Babylonian captivity labels). Best visual density of the arc. Blue Letter Bible Word Studies (Greek/Hebrew) No BLB or Hebrew/Greek root work this session. Consistent with arc pattern for narrative lessons, but worth noting as drift from rolling baseline. Deployed during Keith's newcomer testimony at [04:28]: ‘If you are willing to commit, you're doing this homework every day for the foreseeable future. I guarantee it.’ Classic signature on newcomer welcome. 3 moments — unfinished-theology confession [36:41] (intellectual humility), mortality/legacy note to younger men [91:37], YouTube filter story [122:35]. Depth regressed from L5's marital accountability moment. Humor as Engagement (pop culture, memorable analogies) Joe Rogan / Logan Paul riff [64:52–67:51]; Bible filter app reference [122:35]; kids' homework story. Humor served the lesson (3% drift, STRONG). Leader Multiplication (apprenticeship visible) Russell visible throughout — operated Kings chart at [07:00–09:30], co-taught chart context. Apprenticeship evident but not actively coached in real time; hand-off minimal. Homework as Differentiator (Precept / Power of Four) Explicit Precept reference at [39:48]: ‘we're always hammered into looking at keywords said again and again.’ Power of Four implicit in Guarantee speech structure. Explicit weekly-call accountability at [120:27]: ‘If you're on the prayer chain and you did make your phone call this week — you need to get down on your knees.’ Relational infrastructure reinforced. Three-Source Parallel Reading (happened + why + God's POV) 2 Kings 24 (what happened) + Jer 27–28 (why — covenant fidelity test) + 2 Chron 36 (God's perspective on warning-then-judgment). Three-source pattern fully executed. Drift summary (13 techniques): 11 of 13 techniques present; 1 absent (Blue Letter Bible word studies — consistent with narrative-lesson pattern, not a concern); 2 at partial depth (Vulnerability as Authority — depth regressed from L5; Leader Multiplication — Russell operated but was not actively coached). Overall DNA is intact. The two partial-depth techniques align with the broader pacing-pressure theme: when the clock is tight, vulnerability-depth and apprentice-coaching are the first things compressed. Bumper Stickers — Did They Land in L6? ‘Stone-cold lock’ (God's promises are certain) Referenced at [18:05–18:12] re: Jeremiah 22:24 — ‘you can believe this is a stone-cold [thing].’ Group recognized the marker. ‘Partial obedience is disobedience’ Not explicitly invoked this session. The L6 Big Ideas replaced it with ‘Pride blocks repentance’ and ‘If you don't live set apart, you become a part’ as the foreground bumper stickers. ‘Bad company, bad influence, bad life’ Explicit at [10:14] during the cursory Big Ideas review — ‘Bad company, bad outcome.’ Group recalled from cumulative memory. ‘If you don't live set apart, you become a part’ Named as one of the seven Big Ideas in L6 context; reinforced through the yoke imagery and Hananiah confrontation sequences. ‘Give me the bumper stickers of the big ideas’ Implicit in [09:54] ‘Somebody give me a big idea’ — but group production was cursory (3 themes in 2 min). The L5 version held the space longer and surfaced more. ‘Trust, faith, obedience without action is just knowledge’ Not explicitly invoked; the Zedekiah-hypocrisy stretch at [99:00–110:00] functionally carried the concept through ‘spiritual hypocrisy’ rather than the bumper-sticker phrasing. NEW — ‘Pride BLOCKS repentance’ (group-coined in L6) Coined at [31:48] by the group; canonized by Bryan; captured on the Big Ideas whiteboard slide. Potential new entry to the permanent bumper-sticker library pending cross-session validation. 10-Step Blueprint Execution Check Steps 1 (pre-session), 2 (opening prayer — not captured on recording so presumed pre-record), 3 (newcomer welcome, 7 min), 5 (historical context via chart, 3 min), 6 (scripture reading — 9 readers, multiple rotations), 7 (deep teaching + Socratic, 80 min), 8 (application questions woven, 9 total), and 10 (post-session) all executed. Step 4 (Big Ideas review) was shortchanged at ~2 min vs. the 5–15 min standard — this is the one blueprint step that regressed. Step 9 (closing prayer, delegated) executed but rushed at [127:10]. Blueprint execution: 8 of 10 at full depth; 1 shortchanged (Step 4); 1 rushed (Step 9). Drift Verdict: No structural drift. DNA is intact across the 13 distinctive techniques and the bumper-sticker library. The observable weaknesses — compressed Big Ideas review at open, reduced group recitation at close, fewer but higher-rigor application questions, and more monologue minutes — all trace to a single upstream cause: 7-passage load in a 2-hour window. Trim the passage load and the downstream regressions self-correct. Bible Leader Coaching | Bryan Bailey | April 18, 2026 | L6 Benchmarks: Lifeway 30% Rule • Webb DOK • Rowe wait-time • Hattie Visible Learning • Stuart & Rutherford monologue threshold • BSF/Precept structural models. Page"
                 ]
               }
             ]
           },
           "sections": [
             {
-              "title": "Score composition",
-              "paragraphs": [
-                "How the four weighted clusters and any session bonuses combined into the composite score."
-              ],
+              "title": "Scorecard — Table 1",
               "bullets": [
-                "Teaching Craft: 84% × weight 33 → 27.72 pts",
-                "Building Ministry: 80% × weight 31 → 24.80 pts",
-                "Engaging People: 60% × weight 18 → 10.80 pts",
-                "Being Real: 70% × weight 18 → 12.60 pts",
-                "Base (sum of cluster contributions): 75.92 / 100",
-                "Session bonuses: group-size +1",
-                "Session score: 76.92 / 100"
+                "Number of Attendees: ~17 men (hybrid)  (Target: —)  → —",
+                "New Attendees: 1 (Walker)  (Target: —)  → —"
               ]
             },
             {
-              "title": "Coaching notes by dimension",
-              "paragraphs": [
-                "The per-dimension rationale behind each score on the 12-dimension scorecard."
-              ],
+              "title": "Scorecard — Table 2",
               "bullets": [
-                "Session Structure & Flow (4/5): Strong open (newcomer + chart + Big Ideas); closing truncated by run-over past 9:00 target",
-                "Newcomer Welcome (4/5): Walker introduced; Keith's Guarantee pitch. 7 min vs. 7–25 range — intro-only, no integration post-[06:00]",
-                "Scripture Engagement (5/5): 7 passages across 4 books; 82% verse-grounded; every teaching move anchored to text",
-                "Facilitation vs. Lecture (3/5): 62% leader talk (discussion only); regressed from L5 (58%); middle hour heavily leader-led",
-                "Application Questions (4/5): 9 Big Ideas at 89% DOK 3-4; count regressed from L5 (11); spacing clustered first/last thirds",
-                "Participant Engagement (3/5): 53% contribution rate; same core 5–6; Walker not pulled into substantive Q&A",
-                "Visual Aids (5/5): Three aids deployed synchronously — best of the arc (chart + live text + Big Ideas slide)",
-                "Vulnerability / Authenticity (3/5): 3 moderate moments; depth regressed from L5 (no marital-accountability-level disclosure)",
-                "Memory Reinforcement (3/5): Big Ideas review cursory (~2 min vs. L5's 8 min); ‘Stone-cold’ and ‘Bad company’ referenced but not group-recited",
-                "Homework References (4/5): Explicit Precept reference at [39:48]; Power of Four implicit; prayer chain call commitment at [120:27]",
-                "Prayer (4/5): Closing prayer delegated at [127:10] but rushed; opening prayer presumed pre-record",
-                "Leader Development (4/5): Russell operated chart at [07:00–09:30]; apprenticeship visible but not actively coached in real time"
+                "Leader Talk (incl. reading): 68% / 32%  (Target: Lifeway 30% leader)  → NEEDS WORK",
+                "Leader Talk (discussion only): 62% / 38%  (Target: Lifeway 30% leader)  → NEEDS WORK",
+                "Statements tied to verses: 82%  (Target: 70%+ (Precept OIA))  → STRONG",
+                "Time to first scripture: 11 min (full read at 14:35)  (Target: <15 min (Ken Braddy))  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 3",
+              "bullets": [
+                "Overall Class Time: 2h 08m 42s  (Target: 1.5–2h (BSF standard))  → NEEDS WORK",
+                "Newcomer Welcome: ~7 min (00:00–06:55)  (Target: 7–25 min)  → ON TARGET",
+                "Big Ideas Review: ~2 min (cursory)  (Target: 5–15 min)  → NEEDS WORK",
+                "Historical Context: ~3 min (via chart)  (Target: 5–10 min)  → ON TARGET",
+                "Lesson / Teaching: 80 min (62%)  (Target: 50–60%)  → NEEDS WORK",
+                "Discussion / Application: 28 min (22%)  (Target: 15–20%)  → STRONG",
+                "Closing / Homework / Prayer: ~3 min (rushed)  (Target: 5–10%)  → NEEDS WORK",
+                "Time on Tangents: ~4 min (3%)  (Target: <10%)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 4",
+              "bullets": [
+                "Big Idea Questions: 9  (Target: 8–10 (normalized))  → ON TARGET",
+                "Distribution: 1 every 14 min  (Target: Spread evenly)  → ON TARGET",
+                "Level 1 (simple recall): 0%  (Target: <25%)  → STRONG",
+                "Level 2 (compare/analyze): 11%  (Target: 30–40% (Webb))  → NEEDS WORK",
+                "Level 3 (reason/justify): 56%  (Target: 25–35%)  → STRONG",
+                "Level 4 (apply to life): 33%  (Target: 10–20%)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 5",
+              "bullets": [
+                "Students reading Bible: ~9 readers  (Target: 10+ (BSF))  → ON TARGET",
+                "Students asking questions: 9 of ~17 (53%)  (Target: 70–80% (Gini))  → NEEDS WORK",
+                "Student question cadence: 1 every 3–4 min  (Target: 1 every 3–5 min)  → ON TARGET",
+                "Student talk time: 32%  (Target: 50–70% (Hattie 0.82))  → NEEDS WORK",
+                "Quiet member engagement: Called by name 6+ times  (Target: Active outreach)  → ON TARGET",
+                "Wait time after questions: 3–5 sec (occasional rush)  (Target: 3–5 sec (Rowe 1972))  → ON TARGET",
+                "Visual aids used: 3 (chart + Bible text + Big Ideas slide)  (Target: 2+ multi-sensory)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 6",
+              "bullets": [
+                "Vulnerability moments: 3 moments (moderate depth)  (Target: 2–3 per session)  → ON TARGET",
+                "Monologues >90 sec: 5 instances  (Target: 0 in discussion (Stuart & Rutherford))  → NEEDS WORK",
+                "Longest monologue: ~4m 20s (true/false prophet chart)  (Target: <90 sec)  → NEEDS WORK"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 7",
+              "bullets": [
+                "Open-ended questions: 74%  (Target: 80%+)  → ON TARGET",
+                "Questions requiring text: 72%  (Target: 70%+)  → ON TARGET",
+                "Follow-up probing questions: 18  (Target: 15–20)  → STRONG",
+                "Wait before answering own Q: 3–4 sec (inconsistent)  (Target: 5+ sec)  → NEEDS WORK"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 8",
+              "bullets": [
+                "Questions vs. statements: 38% Q / 62% S  (Target: 70% Q / 30% S)  → NEEDS WORK",
+                "Tonality / vocal variety: Wide range (authoritative, humorous, pleading)  (Target: Varied tone)  → STRONG",
+                "Topic drift: 3% (Joe Rogan/Logan Paul, kids' homework, Bible filter)  (Target: <10%)  → STRONG",
+                "Periodic summaries: Yes — true/false prophet dual-column synthesis  (Target: At key points)  → STRONG",
+                "Big Ideas at close: Cited not recited (4 named, group did not speak)  (Target: 1–2 takeaways actively reinforced)  → NEEDS WORK"
               ]
             }
           ],
@@ -3458,197 +3832,248 @@
           ],
           "bigIdeas": [],
           "feedback": {
-            "headline": "An exceptional session — strongest in Session Structure & Flow and Scripture Engagement, with the clearest next step in Facilitation vs. Lecture.",
+            "headline": "\"Salvation is God's system, not man's system\" + \"God's goal is not to improve your circumstances\"",
             "strengths": [
-              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-              "Application questions pushed members from concept to life, several at the reason/apply level."
+              "Scripture Architecture — 7 Passages Across 6 Books",
+              "DOK Question Quality — 45% at Level 4",
+              "Big Ideas Review — Group Recitation from Memory"
             ],
             "improvements": [
-              "Leader talk crowded out discussion; the balance leaned toward lecture.",
-              "A few voices carried the discussion; quieter members went unheard.",
-              "The session leaned audio-only; a visual anchor would aid retention."
+              "Leader Talk Ratio Still Above Target: 70%/58%",
+              "Time to First Scripture: 20 Minutes",
+              "Participant Breadth: 50% Asking Questions"
             ],
             "recommendations": [
-              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-              "Next time, name one quiet regular early and invite their read on a passage.",
-              "Next time, put one word-study lookup or a simple table on screen during the key term."
+              "Target 55% Leader Talk (from 58%)",
+              "Get to Scripture in 12 Minutes",
+              "Call on 3 Quiet Members by Name Each Session"
             ],
             "overview": [
-              "An exceptional session — strongest in Session Structure & Flow and Scripture Engagement, with the clearest next step in Facilitation vs. Lecture. It scored 87.58/100 under the v3 weighted model.",
-              "The session played to its strengths in Session Structure & Flow and Scripture Engagement; the recommendations below turn Facilitation vs. Lecture into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+              "\"Salvation is God's system, not man's system\" + \"God's goal is not to improve your circumstances\"",
+              "This report carries the full written coaching for the session: 5 areas of strength, 5 areas for improvement, and 5 recommendations for next session, scored 87.58/100 on the v3 weighted model."
             ],
             "strengthsProse": [
               {
-                "title": "Session Structure & Flow anchored the session (5/5)",
+                "title": "Scripture Architecture — 7 Passages Across 6 Books",
                 "paragraphs": [
-                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Excellent 10-step adherence"
+                  "Bryan constructed a masterful OT-to-NT theological arc spanning 2 Kings 21-25, 2 Chronicles 36, Jeremiah 24, Jeremiah 29, Jeremiah 31, Ezekiel 36, and Luke 22. The architecture was not random; it traced a deliberate narrative from the fall of Judah (historical), through God's promises to exiles (prophetic), to the New Covenant prophecy (theological), and finally to Jesus at the Last Supper fulfilling that prophecy (christological). This four-layer structure gave the men a framework to see how the entire Bible connects around the concept of covenant. At [99:03], Bryan made the connection explicit: \"This is for us. Read Jeremiah 31... This starts that. What do you mean? There's more — people's minds are being blown. We just take it for granted, but they're like, what?\" The moment landed because Bryan had spent 80 minutes building the historical and prophetic foundation that made the NT fulfillment feel inevitable rather than imposed.",
+                  "The payoff came at [98:46] when a participant read Luke 22: \"This cup which is poured out for you is the new covenant in my blood.\" Bryan then asked the group to connect it back: \"What did Jesus just say about this blood? This is the blood of the covenant.\" Because the men had spent the prior hour tracing the covenant promises through Jeremiah and Ezekiel, this reading was not a standalone NT reference but the climax of an argument they had built together across six books. This is cross-referencing at its highest level — not citing parallel verses but constructing a theological narrative that makes the connections self-evident."
                 ]
               },
               {
-                "title": "Scripture Engagement anchored the session (5/5)",
+                "title": "DOK Question Quality — 45% at Level 4",
                 "paragraphs": [
-                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 7 passages across 6 books, OT-NT bridge"
+                  "Bryan's Big Idea questions jumped from 11% DOK Level 4 in L1 to 45% in this session — a fourfold improvement. The quality is visible in the questions themselves. At [52:57]: \"Is this saying that God can abandon you?\" This question emerged from the group reading Jeremiah 24:8 about the bad figs, and it forced the men to confront a theological tension that cannot be resolved with a simple yes or no. At [104:42]: \"Is salvation about you or about him?\" — a question Bryan held until after the men had read Ezekiel 36:22 (\"It is not for your sake... but for my holy name\"). The timing was critical: the men had just heard God explicitly say the New Covenant was not primarily for their benefit, and Bryan's question forced them to sit with that disorienting reality.",
+                  "The strongest question sequence came at [103:22-104:42] where Bryan pressed four times on the motive behind the New Covenant: \"Why is this new covenant? What's the motive?\" followed by \"No, no, but why is he doing it?\" then \"What does verse 22 say? Why?\" and finally \"Is salvation about you or about him?\" Each repetition stripped away a layer of comfortable theology until the men arrived at: \"My great name. This is going to — he is doing it for his name.\" This is DOK Level 4 at its best — not merely applying scripture to life, but fundamentally reorienting how the men understand God's purposes. Norman Webb's research shows that sustained exposure to Level 3-4 questioning produces measurably deeper theological reasoning over time."
                 ]
               },
               {
-                "title": "Application Questions anchored the session (5/5)",
+                "title": "Big Ideas Review — Group Recitation from Memory",
                 "paragraphs": [
-                  "Application questions pushed members from concept to life, several at the reason/apply level.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 11 Big Ideas, 45% DOK 4"
+                  "The 8-minute review at [01:20-09:30] was not Bryan recapping previous lessons; it was the GROUP reciting cumulative themes from memory. Bryan prompted with \"Somebody give me a big idea\" [04:59] and the men fired back: \"Bad company, bad influence, bad life\" [05:07], \"Partial obedience is disobedience\" [05:22], and the sovereignty of God — \"Stone cold lock\" [06:49]. Bryan's \"bumper sticker\" approach to theological summaries is paying compounding dividends: these phrases have become the group's shared vocabulary, and the men are retaining and reciting them weeks after first hearing them. At [06:49], when a participant said \"stone cold lock,\" Bryan didn't need to explain what it meant — the entire room understood the reference to God's certain promises.",
+                  "The review also surfaced a deeper insight: the men were connecting themes across multiple weeks of study. One participant added \"God warns first\" [09:33] and another built on it: \"There is judgment for disobedience\" [09:04]. These are not isolated factoids but a cumulative theological framework being assembled in real-time by the group. This is exactly what Precept Ministries and BSF research identifies as the mark of a maturing study group: when participants begin synthesizing across sessions without prompting. Bryan's technique of opening every session with this review is the engine driving that synthesis. The fact that 16 men can collectively recite 6+ Big Ideas from previous weeks is evidence that the teaching is sticking."
                 ]
               },
               {
-                "title": "Memory Reinforcement anchored the session (5/5)",
+                "title": "Joel Osteen Teaching Exercise — Active Discernment Training",
                 "paragraphs": [
-                  "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Strong cumulative Big Ideas review"
+                  "At approximately [28:43-29:30], Bryan deployed one of his most distinctive teaching techniques: reading false teaching convincingly to the group, then asking them to identify what was wrong. \"I've got on my phone the top 20 most stupid Joel Osteen quotes\" [28:48]. He described the exercise: \"I wouldn't even say who it was. I said, hey, I read this book of the day... and I would read it real convincingly. And people would be like, yeah. No, that's Joel Osteen. What's wrong with this?\" [28:55-29:14]. Then the payoff: \"People in Bible study that is nonsense. If I don't do any good job leading, y'all will spot it. It's like, so you keep coming, you'll be able to spot Joel's stuff at work\" [29:23-29:33].",
+                  "This exercise accomplished three things simultaneously: (1) it trained the men to evaluate teaching critically rather than accepting it passively, (2) it reinforced the value of the group's weekly study as a defense against false teaching, and (3) it connected directly to the session's later discussion of false prophets in Jeremiah 29:8-9 (\"Do not let your prophets... deceiving you\"). Bryan later made the prosperity gospel connection explicit at [78:44]: \"Spiritual deception usually involves premature comfort. Prosperity gospel is premature comfort — completely false.\" The Joel Osteen exercise was not a tangent but an active-learning introduction to the session's core warning about false prophets. This is teaching through experience rather than lecture — the highest form of adult education."
                 ]
               },
               {
-                "title": "Prayer anchored the session (5/5)",
+                "title": "Improved Facilitation Balance — 58% Discussion-Only Talk Ratio",
                 "paragraphs": [
-                  "Prayer was delegated to members, opening and closing the group in shared voice.",
-                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
-                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Delegated opening, closing present"
+                  "Bryan's discussion-only talk ratio improved from 72% in L1 to 58% in this session — a 14-percentage-point improvement that represents a genuine shift in teaching posture. The improvement is most visible in the Jeremiah 24 and 29 sections. During the good figs/bad figs discussion [41:39-57:01], Bryan asked: \"Who are the people that are the good figs?\" and got a participant response: \"The exiles are the good things\" [44:57]. He then pushed: \"What are the promises God says he's going to do for these good figs that are in exile?\" [45:10] and the men began listing the promises themselves rather than Bryan delivering them. This pattern — question, participant response, follow-up question — is the mark of facilitated discovery.",
+                  "The Ezekiel 36 section [100:00-120:00] showed similar facilitation strength. Bryan asked the group to build a list of New Covenant promises from the text, and the men contributed: \"I will put my law within them\" [86:42], \"I will be their God\" [87:48], \"They will know me\" [88:09], and \"I will forgive their iniquity\" [90:05]. Bryan's role was prompting (\"What's next on the list?\") and confirming rather than delivering. The Lifeway 30% leader-talk target remains the goal, but the trajectory from 72% to 58% shows that Bryan is actively shifting his teaching approach from delivery to discovery. At this rate of improvement, the 50% mark is achievable within 2-3 sessions."
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Facilitation vs. Lecture is a growth area (4/5)",
+                "title": "Leader Talk Ratio Still Above Target: 70%/58%",
                 "paragraphs": [
-                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: 58% discussion-only; improved but above target"
+                  "While Bryan improved significantly from L1 (82%/72%), the overall ratio of 70% (including reading) and 58% (discussion-only) remains above the Lifeway benchmark of 30% leader talk. The gap is most visible in the early context section [09:30-21:00], where Bryan delivered approximately 12 minutes of historical background about the three waves of Babylonian invasion with limited group interaction. He explained the 605 BC, 597 BC, and 586 BC invasion sequence: \"So it doesn't just happen in like a three month or a one year... It's a multi, over a lot of times\" [17:55-18:02]. This content could have been drawn from the group through guided questions: \"How many waves of invasion do you see in the text? What years?\" would yield the same information through discovery.",
+                  "The later sections prove Bryan already possesses the facilitation skill. During the Jeremiah 29 discussion [68:00-80:00] and the Ezekiel 36 New Covenant list-building [100:00-120:00], Bryan's talk ratio dropped to approximately 40-45%. The coaching opportunity is not learning a new skill but applying an existing one earlier in the session. The first 20 minutes after Big Ideas review is where the men are most cognitively fresh; converting even 3-4 teaching statements in that window to questions would shift the overall ratio closer to 55%."
                 ]
               },
               {
-                "title": "Participant Engagement is a growth area (4/5)",
+                "title": "Time to First Scripture: 20 Minutes",
                 "paragraphs": [
-                  "A few voices carried the discussion; quieter members went unheard.",
-                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: 50% asking questions; improved but below 70-80%"
+                  "Bryan opened a Bible at approximately the 20-minute mark, after 8 minutes of Big Ideas review [01:20-09:30] and 12 minutes of historical context [09:30-21:00]. While this is improved from 32 minutes in L1 (no newcomer introductions this time), it still exceeds the research benchmark of 10-15 minutes. The Big Ideas review (8 minutes) is valuable and should be preserved. The historical context section is the compression opportunity: Bryan could open the Bible during the context discussion rather than after it. Instead of narrating the invasion timeline, he could say: \"Let's look at 2 Kings 24:10 — what year do you see here? Now compare verse 14 — what changed?\" This delivers context through the text rather than before the text.",
+                  "The 20-minute gap means the group's sharpest attention window is spent building context without scripture rather than building context from scripture. The difference matters: when context precedes scripture, men receive the interpretive framework from the leader. When context emerges from scripture, men develop the skill of extracting context themselves. Target for next session: first Bible open by the 12-minute mark, which requires embedding scripture into the Big Ideas review itself — for example, having men read the verse that generated each Big Idea as part of the recitation."
                 ]
               },
               {
-                "title": "Visual Aids is a growth area (4/5)",
+                "title": "Participant Breadth: 50% Asking Questions",
                 "paragraphs": [
-                  "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Kings chart used effectively"
+                  "Approximately 8 of 16 men (50%) asked questions or offered substantive comments during the session. This is improved from 40% in L1, but still below the research benchmark of 70-80% participation (Gini coefficient approach). The core discussion participants are consistent: the same 6-8 men contribute most of the verbal interaction, while 6-8 others participate primarily through reading prompts or brief affirmations. Bryan does call on men by name — at [10:51] he called on Derek and at [01:51] on Keith — but these are typically for reading tasks rather than discussion questions.",
+                  "The fix is targeted: identify 3 quieter members each session and direct specific, accessible questions to them by name. Example: \"Derek, you were in the military — what does it mean when God says 'I will be their God'? What does that kind of authority sound like to you?\" Name-specific questions with a personal hook dramatically increase the likelihood of a substantive response. The goal is not to put quiet men on the spot but to create an entry point that makes their specific perspective valuable to the group."
                 ]
               },
               {
-                "title": "Vulnerability / Authenticity is a growth area (4/5)",
+                "title": "Questions vs Statements Ratio: 40/60",
                 "paragraphs": [
-                  "Teaching stayed at arm’s length; little personal cost was modeled.",
-                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
-                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: 4 moments weighted by depth"
+                  "Bryan's ratio improved from 30/70 in L1 to 40/60 in this session, but still falls below the 70/30 research target. The gap is most visible in the Ezekiel 36 section where Bryan delivered interpretive statements that could have been questions. At [105:07-106:29], Bryan re-read Ezekiel 36:22 with emphasis: \"It is not for your sake... but for my holy name\" and then delivered the Big Idea: \"Salvation is God's system, not man's system\" [106:37-106:45]. This is effective teaching, but the Big Idea could have been drawn from the group: \"Based on what you just heard, whose system is salvation? Put it in your own words.\"",
+                  "The conversion technique is mechanical: for every planned teaching statement, ask \"Can I turn this into a question that yields the same insight?\" Bryan's strongest moments in this session were when he did exactly that — at [103:22] he asked \"Why is this new covenant? What's the motive?\" instead of explaining the motive. The opportunity is to apply this instinct to the remaining 60% of statements. Target for next session: pre-convert 8 planned statements into questions and achieve 50% Q / 50% S ratio."
                 ]
               },
               {
-                "title": "Homework References is a growth area (4/5)",
+                "title": "Structured Close: Big Ideas Could Be Stronger",
                 "paragraphs": [
-                  "Homework went unmentioned, reducing its pull on the group.",
-                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Referenced throughout session"
+                  "Bryan delivered two strong Big Ideas at the close: \"Salvation is God's system, not man's system\" [106:37] and \"God's goal is not to improve your circumstances\" [122:09]. Both are theologically rich and memorable. However, the close could be strengthened by having the GROUP recite the new Big Ideas before the closing prayer, mirroring the review format that opens each session. At [106:37], Bryan said \"I'm going to give you a big idea. You need to write it down. Don't have to accept it today.\" This is strong delivery, but the men heard it passively rather than speaking it aloud.",
+                  "The fix is simple: after presenting each Big Idea, Bryan asks the group to repeat it back: \"Say it with me: Salvation is God's system, not man's system.\" This activates verbal memory encoding, which research shows improves retention by 40-60% over passive listening alone. It also creates the foundation for the cumulative review next week — the men are more likely to recall a phrase they spoke aloud than one they heard. Bryan already does this masterfully in the opening review; extending it to the closing Big Ideas would create a bookend structure that reinforces the session's key takeaways.",
+                  "\"Why does he get angry about us?\"",
+                  "\"What does it mean that God doesn't support your flesh?\"",
+                  "\"What is a prayer of a believer seeking to have his flesh affirmed?\"",
+                  "\"What's God telling the people in exile?\"",
+                  "\"Why is this new covenant? What's the motive?\"",
+                  "\"Is salvation about you or about him?\"",
+                  "\"Salvation is God's system, not man's system\" — consider this Big Idea",
+                  "\"True obedience requires what?\"",
+                  "APPLICATION QUESTIONS — Big Idea Questions Only",
+                  "These are the leader's profound, discussion-driving questions posed to provoke reflection, application, or theological wrestling. Regular classroom Q&A is excluded and documented in the Metrics Detail appendix. Questions are scored using Webb's Depth of Knowledge (DOK) framework: DOK 1 = recall, DOK 2 = compare/analyze, DOK 3 = reason/justify, DOK 4 = apply to life."
                 ]
               }
             ],
             "recommendationsProse": [
               {
-                "title": "Next session — Facilitation vs. Lecture",
+                "title": "Target 55% Leader Talk (from 58%)",
                 "paragraphs": [
-                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "The 14-point improvement from L1 (72%) to L5 (58%) proves Bryan is actively shifting toward facilitation. The next step is converting 3 more teaching statements to questions per section. Before: At [17:55], Bryan narrated the three-wave invasion timeline as context. After: \"Look at 2 Kings 24:10 and 24:14 — how many waves of invasion do you count? What changed between them?\" This delivers the same historical context through the text rather than before it. The Jeremiah 29 section already shows this technique in action — Bryan prompted \"What's God telling the people in exile?\" [72:02] and the men discovered the answer themselves. Apply this same approach to the historical context sections that currently run as monologue. Target: no section above 60% leader talk."
                 ]
               },
               {
-                "title": "Next session — Participant Engagement",
+                "title": "Get to Scripture in 12 Minutes",
                 "paragraphs": [
-                  "Next time, name one quiet regular early and invite their read on a passage.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "The 20-minute gap (down from 32 in L1) can be compressed further by embedding scripture into the Big Ideas review. Before: Big Ideas review [01:20-09:30] is a standalone verbal exercise, then historical context [09:30-21:00] precedes any Bible reading. After: During Big Ideas review, ask a participant to read the verse that generated each Big Idea. \"Who remembers 'partial obedience is disobedience'? Turn to Deuteronomy 28:1 — read the first verse. That's where it came from.\" This accomplishes review and scripture engagement simultaneously. The historical context then starts inside the Bible rather than before it. Target: first Bible open by the 12-minute mark."
                 ]
               },
               {
-                "title": "Next session — Visual Aids",
+                "title": "Call on 3 Quiet Members by Name Each Session",
                 "paragraphs": [
-                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "With 50% participation (8 of 16 asking questions), the opportunity is to activate the quieter half. Bryan already calls on men by name for reading tasks; the next step is directing accessible discussion questions to specific individuals. Before: Bryan asks \"What's God telling the people in exile?\" to the room at large, and the same 6-8 men respond. After: \"Derek, based on what we just read in Jeremiah 29 — what jumps out to you about God's instructions?\" Name-specific questions with a low barrier to entry make it safe for quieter men to contribute. Pick 3 men who did not speak substantively this session and prepare one question for each before the next session. Target: 10 of 16 men (63%) asking questions or offering substantive comments."
                 ]
               },
               {
-                "title": "Next session — Vulnerability / Authenticity",
+                "title": "Continue the Joel Osteen Exercise Pattern",
                 "paragraphs": [
-                  "Next time, open one teaching point with a first-person example that cost you something.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "The false-teaching discernment exercise was one of this session's highest-impact moments. This format — active learning through experience rather than passive reception through lecture — should become a recurring tool. Before: Bryan warns about false gospels through direct teaching statements. After: Read a prosperity gospel quote convincingly and ask: \"What's wrong with this? Where does this break from what we just read in Ezekiel 36:22?\" This forces the men to use the session's text as a diagnostic tool, reinforcing both the lesson content and critical thinking skills simultaneously. Build one discernment exercise into each session tied directly to the week's passage."
                 ]
               },
               {
-                "title": "Next session — Homework References",
+                "title": "Close with Group Recitation of New Big Ideas",
                 "paragraphs": [
-                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Bryan's Big Ideas (\"Salvation is God's system, not man's system\" and \"God's goal is not to improve your circumstances\") are theologically powerful and memorable. The fix is mechanical: after presenting each Big Idea, have the men repeat it aloud before moving to the closing prayer. Before: Bryan delivers the Big Idea at [106:37] — \"I'm going to give you a big idea. You need to write it down.\" After: \"Everyone say it with me: Salvation is God's system, not man's system.\" This activates verbal memory encoding and creates the foundation for next week's cumulative review. Bryan already does this masterfully in the opening review; extending it to the close creates a bookend structure. Target: every new Big Idea spoken aloud by the group before the closing prayer."
                 ]
               }
             ]
           },
           "sections": [
             {
-              "title": "Score composition",
-              "paragraphs": [
-                "How the four weighted clusters and any session bonuses combined into the composite score."
-              ],
+              "title": "Scorecard — Table 1",
               "bullets": [
-                "Teaching Craft: 96% × weight 33 → 31.68 pts",
-                "Building Ministry: 80% × weight 31 → 24.80 pts",
-                "Engaging People: 80% × weight 18 → 14.40 pts",
-                "Being Real: 90% × weight 18 → 16.20 pts",
-                "Base (sum of cluster contributions): 87.08 / 100",
-                "Session bonuses: group-size +0.5",
-                "Session score: 87.58 / 100"
+                "Number of Attendees: ~16 men  (Target: —)  → —",
+                "New Attendees: 0  (Target: —)  → N/A"
               ]
             },
             {
-              "title": "Coaching notes by dimension",
-              "paragraphs": [
-                "The per-dimension rationale behind each score on the 12-dimension scorecard."
-              ],
+              "title": "Scorecard — Table 2",
               "bullets": [
-                "Session Structure & Flow (5/5): Excellent 10-step adherence",
-                "Newcomer Welcome (N/A): No newcomers present",
-                "Scripture Engagement (5/5): 7 passages across 6 books, OT-NT bridge",
-                "Facilitation vs. Lecture (4/5): 58% discussion-only; improved but above target",
-                "Application Questions (5/5): 11 Big Ideas, 45% DOK 4",
-                "Participant Engagement (4/5): 50% asking questions; improved but below 70-80%",
-                "Visual Aids (4/5): Kings chart used effectively",
-                "Vulnerability / Authenticity (4/5): 4 moments weighted by depth",
-                "Memory Reinforcement (5/5): Strong cumulative Big Ideas review",
-                "Homework References (4/5): Referenced throughout session",
-                "Prayer (5/5): Delegated opening, closing present",
-                "Leader Development (4/5): Russell mentioned, group leadership evident"
+                "Leader Talk (incl. reading): 70% / 30%  (Target: 30% audience)  → NEEDS WORK",
+                "Leader Talk (discussion only): 58% / 42%  (Target: 30% audience)  → ON TARGET",
+                "Statements tied to verses: 85%  (Target: 70%)  → STRONG",
+                "Time to first scripture: 20 min  (Target: <15 min)  → NEEDS WORK"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 3",
+              "bullets": [
+                "Overall Class Time: 2h 06m  (Target: 1.5-2h)  → ON TARGET",
+                "Big Ideas Review: 8 min (6%)  (Target: 5-10 min)  → ON TARGET",
+                "Historical Context: 12 min (10%)  (Target: 5-10 min)  → ON TARGET",
+                "Lesson / Teaching: 70 min (55%)  (Target: 50-60%)  → ON TARGET",
+                "Discussion / Application: 30 min (24%)  (Target: 15-20%)  → STRONG",
+                "Closing / Homework / Prayer: 6 min (5%)  (Target: 5-10%)  → ON TARGET",
+                "Time on Tangents: 3 min (2%)  (Target: <10%)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 4",
+              "bullets": [
+                "Big Idea Questions: 11  (Target: 8-10)  → STRONG",
+                "Distribution: 1 every 11 min  (Target: Spread evenly)  → ON TARGET",
+                "Level 1 (simple recall): 0%  (Target: <25%)  → STRONG",
+                "Level 2 (compare/analyze): 0%  (Target: 30-40%)  → ON TARGET",
+                "Level 3 (reason/justify): 55%  (Target: 25-35%)  → STRONG",
+                "Level 4 (apply to life): 45%  (Target: 10-20%)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 5",
+              "bullets": [
+                "Students reading Bible: ~10 readers  (Target: 10+)  → ON TARGET",
+                "Students asking questions: 8 of 16 (50%)  (Target: 70-80%)  → NEEDS WORK",
+                "Student questions/comments: 1 every 3-4 min  (Target: 1 every 3-5 min)  → ON TARGET",
+                "Student talk time: 30%  (Target: 50-70%)  → NEEDS WORK",
+                "Quiet member engagement: Called by name  (Target: Active outreach)  → ON TARGET",
+                "Wait time after questions: 3-5 sec  (Target: 3-5 sec)  → ON TARGET",
+                "Visual aids used: Kings chart  (Target: 2+ aids)  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 6",
+              "bullets": [
+                "Vulnerability: 4 moments  (Target: 2-3 per session)  → STRONG",
+                "Monologues >90 sec: 3 instances  (Target: 0 in discussion)  → ON TARGET",
+                "Longest monologue: 3 min 30 sec  (Target: <90 sec)  → NEEDS WORK"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 7",
+              "bullets": [
+                "Open-ended questions: 78%  (Target: 80%+)  → ON TARGET",
+                "Questions requiring text: 70%  (Target: 70%+)  → ON TARGET",
+                "Follow-up probing questions: 22  (Target: 15-20)  → STRONG",
+                "Wait before answering own Q: 3-5 sec  (Target: 5+ sec)  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Scorecard — Table 8",
+              "bullets": [
+                "Questions vs statements: 40% Q / 60% S  (Target: 70% Q / 30% S)  → NEEDS WORK",
+                "Tonality/vocal variety: Wide range  (Target: Varied tone)  → STRONG",
+                "Topic drift: 2%  (Target: <10%)  → STRONG",
+                "Periodic summaries: Yes, at transitions  (Target: At key points)  → STRONG",
+                "Big Ideas at close: 2 takeaways  (Target: 1-2 takeaways)  → STRONG",
+                "#: Dimension  (Target: Score)  → Notes",
+                "1: Session Structure & Flow  (Target: 5)  → Excellent 10-step adherence",
+                "2: Newcomer Welcome  (Target: N/A)  → No newcomers present",
+                "3: Scripture Engagement  (Target: 5)  → 7 passages across 6 books, OT-NT bridge",
+                "4: Facilitation vs. Lecture  (Target: 4)  → 58% discussion-only; improved but above target",
+                "5: Application Questions  (Target: 5)  → 11 Big Ideas, 45% DOK 4",
+                "6: Participant Engagement  (Target: 4)  → 50% asking questions; improved but below 70-80%",
+                "7: Visual Aids  (Target: 4)  → Kings chart used effectively",
+                "8: Vulnerability/Authenticity  (Target: 4)  → 4 moments weighted by depth",
+                "9: Memory Reinforcement  (Target: 5)  → Strong cumulative Big Ideas review",
+                "10: Homework References  (Target: 4)  → Referenced throughout session",
+                "11: Prayer  (Target: 5)  → Delegated opening, closing present",
+                "12: Leader Development  (Target: 4)  → Russell mentioned, group leadership evident",
+                "Leader Talk (incl. reading): 82% / 18%  (Target: 70% / 30%)  → ↑ Improved",
+                "Leader Talk (discussion only): 72% / 28%  (Target: 58% / 42%)  → ↑ Improved",
+                "Statements tied to verses: 83%  (Target: 85%)  → ↑ Improved",
+                "Time to first scripture: 32 min  (Target: 20 min)  → ↑ Improved",
+                "Big Idea Questions: 12  (Target: 11)  → → Stable",
+                "DOK 4 (Apply to Life): 11%  (Target: 45%)  → ↑↑ Major Gain",
+                "DOK 3 (Reason/Justify): 25%  (Target: 55%)  → ↑↑ Major Gain",
+                "Students asking questions: 8/20 (40%)  (Target: 8/16 (50%))  → ↑ Improved",
+                "Monologues >90 sec: 6  (Target: 3)  → ↑ Improved",
+                "Longest monologue: 6 min 24 sec  (Target: 3 min 30 sec)  → ↑ Improved",
+                "Q vs S ratio: 30% Q / 70% S  (Target: 40% Q / 60% S)  → ↑ Improved",
+                "Wait time: 2-4 sec  (Target: 3-5 sec)  → ↑ Improved",
+                "Topic drift: 2%  (Target: 2%)  → → Stable",
+                "Discussion / Application time: 12%  (Target: 24%)  → ↑↑ Major Gain",
+                "Overall Score: 52/60 (L1)  (Target: 49/55 (A-))  → → Stable"
               ]
             }
           ],

--- a/packages/backend-base/src/coach/coach.data.json
+++ b/packages/backend-base/src/coach/coach.data.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "generatedAt": "2026-07-20",
+  "generatedAt": "2026-07-21",
   "model": "v3-weighted-100",
   "admins": ["andytryba@gmail.com"],
   "clusters": [
@@ -58,6 +58,378 @@
       "isCoach": true,
       "zoomLink": "",
       "reports": [
+        {
+          "id": "bryan-bailey-2026-07-18-james-lesson-9-saturday-morning-",
+          "date": "2026-07-18",
+          "dateLabel": "July 18, 2026",
+          "session": "James, Lesson 9 — Saturday Morning Group (Austin Ridge, in-person)",
+          "topic": "James 4:13–5:12 — Wealth, Patience, and the Last Days",
+          "duration": "~2 hr 18 min (incl. join buffer) · in-person, solo (no mentor)",
+          "attendees": 28,
+          "newcomers": 6,
+          "score": 91.69,
+          "base": 83.69,
+          "newcomerBonus": 5,
+          "sizeBonus": 3,
+          "status": "Exceptional",
+          "statusEmoji": "🔷",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 92,
+              "contribution": 30.36
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 73.3,
+              "contribution": 22.73
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 90,
+              "contribution": 16.2
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": "Clear 10-step arc — cold-recall open, context, reading, verse-by-verse, cross-ref chains, wrap-up, prayer chain — but the ~94-min main block ran unbroken with no midpoint recap and the session went ~18 min over the 120-min target."
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 5,
+              "note": "6 first-timers introduced individually over ~11 min, opened by Bryan's own conversion testimony as the on-ramp; every newcomer gave a specific personal reason for being there."
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "Seven distinct books beyond James — Hebrews 1:2, Job 1/2/42, 2 Cor 4, 1 Thess 2, Matthew 5 — with ~85%+ of exchanges tied directly to a text."
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "Discussion-only leader talk ran ~42–48%, above the 30–35% target, elevated by three >90-sec monologue stretches; strong Socratic routing otherwise."
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "8 DOK-scored Big Idea questions (37.5% DOK-4), but only one first-person confession surfaced — below the ≥2 target for application depth."
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 5,
+              "note": "20+ named substantive contributors, ~70%+ of a ~28-man room — a high share for a room this size — with consistent by-name cold-calling."
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 5,
+              "note": "On-screen VerseMate word-study throughout James 4–5 (live Greek/Hebrew pop-ups — σήπω 'have rotted', 'Lord of Sabaoth', perfect-tense 'withheld') plus a 2 Corinthians 4 screen-share."
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": "Consistent with the leader's established ~4/5 baseline — no fresh high-cost confession from Bryan himself, but he modeled his own testimony and drew out Mike's real mortality disclosure, evidence of built trust."
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 5,
+              "note": "Opened with a genuinely unaided 'give me the bumper stickers' cold recall across the whole book of James, and closed with a cumulative Big Ideas recap."
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 3,
+              "note": "'The Guarantee' offered to newcomers, but no explicit workbook/homework review or reward surfaced in-session this week."
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 5,
+              "note": "Delegated opening prayer (captured after the recording gap), closing prayer, and a full prayer-chain ministry emphasis with named call assignments."
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 3,
+              "note": "Solo-led with no named apprentice handoff or delegated facilitation window; the nine newcomer call-pairings are Building-Ministry multiplication, not in-session leader development."
+            }
+          ],
+          "bigIdeas": [
+            "Faith without works is dead — it's literally useless",
+            "Your riches have already rotted — judgment writes in past tense",
+            "You can't take it with you, but you'll answer for every dime"
+          ],
+          "feedback": {
+            "headline": "A newcomer-heavy Saturday — 6 new men, Bryan's own testimony, and a real mortality confession from Mike.",
+            "strengths": [
+              "The Newcomer Multiplication System: Nine Named Pairings in Real Time",
+              "Bryan's Own Testimony as the Newcomer On-Ramp",
+              "The Cold 'Give Me the Bumper Stickers' Recall Drill"
+            ],
+            "improvements": [
+              "Confirm Recording Audio Is Live Before the Opening Prayer",
+              "Three Monologue Stretches Exceeded the ≤2 Target",
+              "Verse Confusion Compounded by an Unusually Large, New Room"
+            ],
+            "recommendations": [
+              "Confirm Recording Audio Is Live Before Any Delegated Prayer",
+              "Break Any Explanation Past 90 Seconds With a Question",
+              "Keep the Newcomer Follow-Up Loop Visible Week to Week"
+            ],
+            "overview": [
+              "A newcomer-heavy Saturday — 6 new men, Bryan's own testimony, and a real mortality confession from Mike.",
+              "This report carries the full written coaching for the session: 5 areas of strength, 5 areas for improvement, and 5 recommendations for next session, scored 91.69/100 on the v3 weighted model."
+            ],
+            "strengthsProse": [
+              {
+                "title": "The Newcomer Multiplication System: Nine Named Pairings in Real Time",
+                "paragraphs": [
+                  "Rather than a generic \"welcome, hope you come back,\" Bryan closed the session by naming a specific existing member and pairing him with a specific newcomer, one at a time, out loud: \"Mike, you know him, right? I would like you to get his phone number and call him this week... Bryce and Shaddy, I want you to get Mason's number, call him, welcome him into the group... Mason and Kevin, get Rob, okay?... Austin, Hassan, get his number, call him, welcome him, see what's on his mind\" [02:10:25–02:12:19]. Nine pairings in under two minutes, each with a concrete deliverable (get the number, place the call, ask what's on his mind). This is 2 Timothy 2:2 multiplication executed as an operational checklist, not an aspiration — it converts a one-time Saturday visit into a tracked relational commitment before anyone leaves the room."
+                ]
+              },
+              {
+                "title": "Bryan's Own Testimony as the Newcomer On-Ramp",
+                "paragraphs": [
+                  "Instead of a scripted welcome speech, Bryan opened the newcomer segment by telling his own conversion story in specific, unflattering detail — \"I went to church, I listened, I paid attention... but it wasn't a daily thing... At 39, I came to a group that was using the materials we use here\" [00:10:00–00:12:25], including the admission that it \"took years for me\" and \"I had a thick skull.\" He then converted the story directly into an invitation: \"if you would like God to speak to you... I've got a guarantee\" [00:13:06]. Modeling vulnerability-as-authority BEFORE asking six total strangers to introduce themselves is a deliberate sequencing choice — it set the room's safety level for what followed, and every one of the six newcomers responded with a specific, personal reason for being there (a cross-country move, a search for accountability, a background as a Muslim-Background Believer, a recent move to Austin)."
+                ]
+              },
+              {
+                "title": "The Cold 'Give Me the Bumper Stickers' Recall Drill",
+                "paragraphs": [
+                  "Before opening a single Bible this session, Bryan ran a genuinely unaided cumulative review across the entire book of James: \"Now give me some bumper stickers from this study, some big ideas that we have seen... Mike, what do you think the biggest idea is of the book?\" [00:20:41–00:24:44]. Members recalled — without being fed the answer — faith without works being dead, hearers vs. doers, trials producing endurance, friendship with the world as enmity with God, the tongue reflecting the heart, wisdom available by faith, and partiality as judging by face value. This is precisely the Ebbinghaus cold-retrieval technique the Thursday group has now skipped two sessions running — the Saturday group ran it this week, unprompted, as a matter of course."
+                ]
+              },
+              {
+                "title": "Job's Arc Built the Definition of Patience Incrementally, Not Upfront",
+                "paragraphs": [
+                  "Rather than defining patience and then illustrating it, Bryan built the definition progressively across Job's story, stopping after chapter 1 to ask \"if we could only have chapter one, we don't know how the story ends — how would we define patience?\" [01:34:58], landing \"endurance under stress,\" then continuing into chapter 2's second trial (Job's wife: \"do you still hold fast your integrity? Curse God and die\" [01:36:48]) before finally reaching the restoration in chapter 42. The technique — pause the story, ask the room to name what they know so far, then continue — forces the room to sit with an unresolved Job rather than jumping straight to the tidy ending, which is a more accurate rendering of what patience actually costs."
+                ]
+              },
+              {
+                "title": "Mike's Heart-Attack Confession Validated the Session's Entire Thesis",
+                "paragraphs": [
+                  "Closing with \"Mike, what are you thinking about your wealth?\" [02:06:28], Bryan drew out a genuine, previously undisclosed testimony: \"it came on me suddenly, one day, no signs... I certainly wasn't thinking about my stuff, I was thinking about where I might be going and about my family\" [02:07:16–02:07:34], and when asked how long he had to process it — \"probably about an hour and a half\" [02:07:42]. This landed the session's central claim (James 4:14's \"you are just a vapor\") as lived experience rather than doctrine, in the room, from a named member with real stakes — exactly the kind of moment the Application Depth metric is designed to surface."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Confirm Recording Audio Is Live Before the Opening Prayer",
+                "paragraphs": [
+                  "Audio analysis of this session's recording (silence-level scan, not transcript) shows near-total silence from 00:00:00 to roughly 00:02:15 — consistent with exactly what Bryan flagged: the opening prayer very likely happened but the Fireflies bot's microphone hadn't yet picked up the room (heads bowed, voices lowered, and/or the bot still finishing its join sequence). This is a recording capture gap, not a leadership gap — no dimension in this report treats it as a missing prayer, and Session Structure and Prayer are both scored on the assumption the delegated opening prayer occurred. Fix: give the recorder ~15–20 seconds of normal-volume room audio (a clear \"alright men, let's pray\") right before heads bow, so the archive captures the prayer in full next time — a one-time habit, not a leadership change."
+                ]
+              },
+              {
+                "title": "Three Monologue Stretches Exceeded the ≤2 Target",
+                "paragraphs": [
+                  "Three separate stretches ran past 90 seconds largely uninterrupted: the James-authorship history [00:21:59–00:24:41, ~2.7 min], the Milky Way/galaxy-scale digression [01:52:41–01:55:24, ~2.7 min], and the prayer-chain closing instructions [02:12:22–02:16:23, ~4 min]. Each is individually defensible content, but together they pushed the discussion-only talk ratio to ~42–48%, well above the 30–35% target. See the Monologues section below for the specific fix on each."
+                ]
+              },
+              {
+                "title": "Verse Confusion Compounded by an Unusually Large, New Room",
+                "paragraphs": [
+                  "Bryan mid-corrected himself on the passage reference more than once — \"No, just, I mean, excuse me, excuse me, chapter 5 verse 11, I said that wrong\" [01:41:34] — and named the cause directly: \"I'm having trouble with people now, you know, enough people changing in here. I'm struggling a little bit overload\" [01:41:16]. This is an honest, in-the-moment admission rather than a hidden problem, and it is a reasonable cost of learning six new names in one sitting while still teaching at full pace. No specific fix is prescribed here — Bryan named the trade-off himself, live, which is itself the right response."
+                ]
+              },
+              {
+                "title": "Only One First-Person Confession Surfaced From the Application Round",
+                "paragraphs": [
+                  "The wealth block landed its concept well, but most responses stayed third-person and prescriptive (\"we should hold our stuff loosely\") rather than first-person and specific. Only one genuine first-person confession surfaced from a Big-Idea question this session — below the ≥2-per-session target for Application depth. The teaching was strong; the gap is in converting a conceptual answer into a personal one. Fix: after a conceptual reply on a Big Idea, add one probe that forces a personal, specific response — \"where has your own wallet argued with your faith this week?\" — and hold the silence until someone answers about themselves, not about \"us.\" One such probe per Big-Idea block would clear the target next week regardless of passage."
+                ]
+              },
+              {
+                "title": "The Main Teaching Block Ran ~94 Minutes With No Structural Break",
+                "paragraphs": [
+                  "From the first scripture reading [00:29:32] to the start of wrap-up [02:03:31], the session ran continuously for roughly 94 minutes — above the 60–90-min target and with no built-in stretch, recap, or re-focus point along the way, on a night the room itself was unusually large and full of first-timers. Fix: on heavy-newcomer weeks especially, insert one explicit 60-second \"where are we / what have we covered\" recap at the session's rough midpoint (e.g., right after the 'last days' cross-ref chain, before Job begins) — it costs a minute and re-anchors newcomers who may have lost the thread."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Confirm Recording Audio Is Live Before Any Delegated Prayer",
+                "paragraphs": [
+                  " Audio analysis of this session shows near-total silence for the first ~2:15, consistent with the opening prayer happening but not being fully picked up by the Fireflies bot mic. Before: the prayer begins as soon as the room quiets down and heads bow. After: whoever's praying opens at normal volume (\"Let's pray\") and holds a beat before bowing heads, giving the recorder a moment to lock onto the room audio — a one-time habit that protects the archive going forward, independent of this week's specific gap."
+                ]
+              },
+              {
+                "title": "Break Any Explanation Past 90 Seconds With a Question",
+                "paragraphs": [
+                  " Three stretches this week ran past 90 seconds largely uninterrupted (James history, the galaxy-scale digression, the prayer-chain instructions). Before: continuous narration through the full explanation. After: pause at the 60–90-second mark and ask a specific question about what was just said before continuing — same content, but the room stays in the answering seat."
+                ]
+              },
+              {
+                "title": "Keep the Newcomer Follow-Up Loop Visible Week to Week",
+                "paragraphs": [
+                  " Nine call-pairings were assigned this week, but there's no in-session mechanism to confirm they happened. Before: a one-time announcement of who calls whom. After: open next Saturday with a 30-second public check-in (\"who made their call this week?\") before moving into the lesson — makes the multiplication system self-reinforcing rather than a single ask."
+                ]
+              },
+              {
+                "title": "Add One First-Person Probe to Every Application Block",
+                "paragraphs": [
+                  " The application round drew strong conceptual answers but only one first-person confession — below the ≥2 target. Before: a conceptual answer (\"we should hold wealth loosely\") is accepted and the room moves on. After: follow every conceptual answer with one probe that forces a personal, specific response — \"where did your own money argue with your faith this week?\" — and hold the silence until someone answers about themselves. Transferable to any passage."
+                ]
+              },
+              {
+                "title": "Insert a Midpoint Recap on Long, Newcomer-Heavy Sessions",
+                "paragraphs": [
+                  " The main lesson ran ~94 minutes continuously with no structural break, on a night with 6 first-time visitors who had the least context to hang onto. Before: an unbroken 94-minute teaching block. After: one explicit 60-second \"where are we / what have we covered\" recap at the rough midpoint — cheap insurance against losing newcomers mid-session."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Scorecard — Attendees",
+              "bullets": [
+                "Total attendees: ~28 men (Saturday 7am in-person, Austin Ridge) — 27+ named/heard in the recording, including a large newcomer wave  (Target: Consistent growth)  → STRONG",
+                "Newcomers / first-timers: 6 first-timers introduced individually — Sebastian, Jeff, Hassan, Rob, Mason, Zach [00:14:48–00:20:15]  (Target: Organic growth over time)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Scripture Focus",
+              "bullets": [
+                "Cross-references used: 7 distinct books beyond the primary text — Hebrews 1:2; Job 1, 2, 42 (read nearly in full); 2 Corinthians 4:7–10, 16–18; 1 Thessalonians 2:14–15; Matthew 5:12  (Target: 6+ per session (Lifeway))  → STRONG",
+                "Leader talk ratio (with scripture reading): ~50–55% (whole session; three separate monologue stretches plus extensive narrated cross-ref connective tissue)  (Target: ≤35%)  → NEEDS WORK",
+                "Leader talk ratio (discussion only — graded): ~42–48% (excludes scripture reading and newcomer-welcome testimony; elevated by the three >90-sec monologue stretches)  (Target: ≤30–35% (Lifeway 30% Rule))  → NEEDS WORK",
+                "Time to first scripture reading: ~8–9 min after the welcome ends (James 4:13–17 read at [00:29:46]; welcome/testimony ends ~00:21:00)  (Target: Within 15 min of lesson start)  → STRONG",
+                "Discussion scripture-grounded: ~85%+ of exchanges tied directly to a text  (Target: 75%+)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Time Management",
+              "bullets": [
+                "Total session time: ~2 hr 18 min (incl. ~10-min pre-session join buffer before teaching content begins)  (Target: 120 min)  → NEEDS WORK",
+                "Newcomer welcome + leader testimony: ~11 min (00:10–00:21) — Bryan's own 39-year conversion story, then 6 individual newcomer introductions  (Target: 7–25 min)  → STRONG",
+                "Big Ideas cumulative review + book history: ~8 min (00:21–00:29) — cold 'give me the bumper stickers' recall across the whole book of James, then James/authorship context  (Target: 5–15 min)  → STRONG",
+                "Main lesson (James 4:13–5:12 + Job + cross-ref chains): ~94 min (00:29–02:03), continuous with no structural break  (Target: 60–90 min)  → NEEDS WORK",
+                "Wrap-up application + newcomer call assignments + prayer chain + closing prayer: ~15 min (02:03–02:18) — high-value time  (Target: High-value time)  → STRONG",
+                "Tangent time: ~2 min (Hansel-and-Gretel aside [00:37:38]; parking-lot joke [02:03:02])  (Target: < 5 min)  → STRONG",
+                "Pacing (self-managed): Bryan self-managed throughout — no external redirect — but ran ~18 min over the 120-min target, driven mainly by the extended, unbroken main-lesson block  (Target: Self-managed throughout)  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Scorecard — Application Questions",
+              "bullets": [
+                "Big Idea questions (DOK scored): 8 questions  (Target: 5–7 per session)  → ON TARGET",
+                "DOK Level 4 (apply to life): 37.5% (3 questions — the 'give me a real prayer for your future'; 'why are we so challenged by wealth'; 'what are you thinking about your wealth' → Mike's heart-attack answer)  (Target: 35–50% for DOK 4)  → STRONG",
+                "DOK Level 3 (reason/justify): 62.5% (5 questions — presumption/future critique; basis of patience; Job ch.1 patience definition; 2 Cor 4 contrast; why a treasure in an earthen vessel)  (Target: 35–50% for DOK 3)  → ON TARGET",
+                "DOK Level 1–2 scaffolding (excluded): ~25+ navigation/reading/word-definition prompts — unusually high, driven by the newcomer-heavy pacing and frequent re-reads  (Target: Excluded from scoring)  → N/A",
+                "Confession / Personal-Response Rate: 1 clear first-person confession this week (Mike's heart-attack disclosure [02:07:16])  (Target: ≥2 per session)  → NEEDS WORK",
+                "Leader follow-up probe frequency: 10+ probes ('Say more', 'Tell me more', 'Come on')  (Target: ≥3 per session)  → STRONG"
+              ]
+            },
+            {
+              "title": "Scorecard — Engagement",
+              "bullets": [
+                "Named substantive contributors: 20+ (Mike, Noah, Kevin, Brendan, Caleb, Danny, Zach ×2, Weston, Jason, Andy, Bryce, Shaddy, Lake, Justin, Hassan, Sebastian, Jeff, Rob, Mason, Fred, Austin, Nick, Ron, Russ, and more)  (Target: 70–80% of attendees)  → STRONG",
+                "Substantive % of group: ~70%+ of a ~28-man room — a high percentage for a room this size  (Target: ≥70%)  → STRONG",
+                "Read-aloud assignments (reported, not scored): 15+ reading turns across James, Job, 2 Corinthians, 1 Thessalonians, Matthew  (Target: Reported only)  → N/A",
+                "Wait time / productive struggle: Bryan repeatedly holds silence ('Come on', 'no, no, what is...') and redirects partial answers before supplying the point  (Target: 3–5 sec (Rowe 1972))  → STRONG",
+                "Quiet member flag: Cannot be reliably isolated this week — the room is unusually large and audio-only attribution makes a single silent regular hard to name; worth a visual check next session  (Target: All regulars contribute)  → N/A"
+              ]
+            },
+            {
+              "title": "Scorecard — Leadership",
+              "bullets": [
+                "Vulnerability moments: 3 — Bryan's 39-year conversion testimony opening the newcomer welcome [00:10:00]; Bryan's live 'I'm struggling a little bit overload' admission [01:41:16]; Mike's heart-attack mortality disclosure [02:07:16]  (Target: ≥1 per session with depth)  → STRONG",
+                "Vulnerability depth (rolling baseline ±1): 4/5 — consistent with the leader's established ~4/5 baseline; no fresh high-cost unresolved confession from Bryan himself this week, but strong member-side vulnerability (Mike) as evidence of built trust  (Target: 4–5/5 for experienced leader)  → STRONG",
+                "Extended monologues > 90 sec: 3 — James-authorship history [00:21:59–00:24:41]; Milky Way/galaxy-scale digression [01:52:41–01:55:24]; prayer-chain closing instructions [02:12:22–02:16:23]  (Target: ≤2 per session (each named with fix))  → NEEDS WORK",
+                "Monologue details: See Monologues section below  (Target: —)  → —"
+              ]
+            },
+            {
+              "title": "Scorecard — Question Quality",
+              "bullets": [
+                "% open-ended questions: ~70%  (Target: ≥60%)  → STRONG",
+                "% text-requiring questions: ~55%  (Target: ≥50%)  → STRONG",
+                "Leader follow-up probes: 10+ ('Say more', 'Tell me more', 'Come on')  (Target: ≥3 per session)  → STRONG",
+                "Productive struggle rate: HIGH — Bryan repeatedly declines to hand over the answer ('No, no, what is... if you're showing partiality, what are you doing?'), routing the room back to the text  (Target: Redirect, don't rescue (Hiebert & Grouws 2007))  → STRONG",
+                "Peer-to-peer exchanges: Present — several members build directly on each other's answers (the hoarding/fraud word-list build, the 'past-tense judgment' back-and-forth)  (Target: Members respond to each other)  → ON TARGET"
+              ]
+            },
+            {
+              "title": "Scorecard — Study Method & Communication",
+              "bullets": [
+                "Study flow: Newcomer welcome + leader testimony → whole-book Big Ideas cold recall → James authorship history → James 4:13–5:12 verse-by-verse (money's four problems: hoarding, fraud, self-indulgence, injustice) → 'last days' cross-ref chain → Job 1/2/42 → patience definition → 2 Corinthians 4 → oaths passage → wrap-up application → prayer chain  (Target: OIA method)  → STRONG",
+                "Bumper stickers generated: 6 — see Big Ideas on title page  (Target: 3–5 per session)  → STRONG",
+                "Visual aids: On-screen VerseMate word-study tool used throughout James 4–5 (Summary / By Line / Study / Visuals tabs; live Greek/Hebrew pop-ups — σήπω 'have rotted' with Hebrew kālâh, 'Lord of Sabaoth' military title, perfect-tense 'withheld'), plus a plain-text 2 Corinthians 4 screen-share  (Target: Multiple tools (Mayer))  → STRONG",
+                "Tone & delivery: N/A — audio only; energetic, high-tempo cold-calling evident from transcript (name-by-name questioning, frequent 'come on')  (Target: N/A — audio only)  → N/A",
+                "Topic drift: Hansel-and-Gretel aside ~1 min [00:37:38]; parking-lot joke ~30 sec [02:03:02]; total ~2 min  (Target: < 5% off-topic)  → STRONG",
+                "Big Ideas at close: Genuine closing recap ('What are our big ideas here today?' [02:03:31]) plus the wealth application round — strong bookending with the opening cold-recall drill  (Target: Cumulative review at close)  → STRONG"
+              ]
+            },
+            {
+              "title": "Monologues — Detail & Fix",
+              "paragraphs": [
+                "Three stretches exceeded the 90-second threshold (Stuart & Rutherford) — above the ≤2 target. Each named with its fix.",
+                "Monologue 1 — James Authorship & Church History [00:21:59–00:24:41] (~2.7 min): Bryan narrated James's identity as Jesus's half-brother, his rise to lead the Jerusalem church, and the martyrdom that scattered the church, almost entirely solo before opening it back up with \"now give me some bumper stickers.\" Valuable context, but delivered as a lecture. Fix: break it into two beats with a question between them — \"James was Jesus's half-brother, but he didn't believe in him during his lifetime — what do you think changed that?\" — before continuing to the martyrdom/scattering half.",
+                "Monologue 2 — Milky Way / Galaxy-Scale Digression [01:52:41–01:55:24] (~2.7 min): Illustrating \"the things which are seen are temporal,\" Bryan built an extended cosmological-scale riff (200 billion stars, 2 trillion galaxies, a 6-million-light-year gap to the nearest one) largely uninterrupted except for Andy supplying a number. The illustration lands, but it ran long. Fix: cut the recitation to one or two scale facts (galaxy count, nearest-galaxy distance) and ask the room to finish the thought — \"so if all of that is temporary, what does that make the thing right in front of you today?\" — before moving on.",
+                "Monologue 3 — Prayer-Chain Closing Instructions [02:12:22–02:16:23] (~4 min): Explaining the prayer-chain mechanics and importance (\"This is super important... please make your call... it's designed where it's literally we can rely on\") ran almost entirely solo for four minutes at the very end of a 2-hour-plus session, when attention is at its lowest. The content (Bryan's signature Prayer Chain Ministry technique) is valuable and worth keeping — the length is the issue. Fix: hand a returning member the closing prayer-chain reminder in 60 seconds (\"hey, quick reminder on the prayer chain — Austin, take 30 seconds\") and reserve Bryan's own voice for the one line that matters most: \"the chain works because we make it 100%.\""
+              ]
+            },
+            {
+              "title": "Key Moments",
+              "moments": [
+                {
+                  "detail": "Mike's Heart-Attack Confession  (Real · Capitalized · Being Real)\n\nWhat happened: Closing the wealth application with \"Mike, what are you thinking about your wealth?\" [02:06:28], Bryan drew out a disclosure the room hadn't heard before: \"it came on me suddenly, one day, no signs. But I tell you one thing, I certainly wasn't thinking about my stuff. I was thinking about where I might be going and about my family.\" Bryan followed up — \"how long was that time period that you had to evaluate that?\" — and Mike answered, \"probably about an hour and a half.\" Bryan then turned to the room: \"I thought that was super powerful... some of these guys didn't hear that.\"\n\nWhy it mattered: The entire session's thesis — James 4:14's \"you are just a vapor,\" James 5's warning against hoarded wealth — is easy to affirm intellectually and hard to feel. A named member's real, unscripted brush with mortality, disclosed live, converted the lesson from doctrine into lived testimony in front of 6 brand-new visitors on their very first Saturday. It is also the kind of moment that raises the room's disclosure ceiling for everyone who witnessed it.\n\nWhat would make it bigger: Land it with one forward step: \"Mike, an hour and a half to think about what mattered — what's one thing that hour and a half changed about how you're living this week?\" The disclosure did the diagnostic work; a named follow-through would have converted it into an assignment the room could track.",
+                  "timestamp": "02:07:16"
+                },
+                {
+                  "detail": "Nine Newcomer Call-Pairings, Named One at a Time  (Capitalized · Building Ministry)\n\nWhat happened: In under two minutes, Bryan named nine specific existing members and paired each with a specific newcomer for a follow-up call this week: \"Mike, you know him, right? Get his phone number and call him this week... Bryce and Shaddy, get Mason's number, call him, welcome him into the group... Austin, Hassan, get his number, call him, welcome him, see what's on his mind.\"\n\nWhy it mattered: Six newcomers walked in for the first time this week. Without a tracked follow-up mechanism, first-time visitors have a well-documented tendency to not return — the assignment converts a warm Saturday morning into nine concrete relational commitments with an owner and a deadline (this week) attached to each one.\n\nWhat would make it bigger: Close the loop next Saturday with a 30-second public check: \"quick show of hands — who made their call this week?\" This makes the multiplication system self-reinforcing rather than a one-time announcement.",
+                  "timestamp": "02:10:25–02:12:19"
+                },
+                {
+                  "detail": "Bryan's Own Testimony Opens the Session for Six Newcomers  (Capitalized · Being Real + Building Ministry)\n\nWhat happened: Rather than a scripted welcome, Bryan told his own conversion story in specific, unflattering detail before asking anyone else to speak — \"it took years for me... I had a thick skull\" [00:10:00–00:13:52] — then converted it into a direct invitation: \"if you would like God to speak to you... I've got a guarantee, 100% guarantee.\"\n\nWhy it mattered: Sequencing matters: Bryan modeled vulnerable disclosure BEFORE asking six strangers to introduce themselves. Every one of the six newcomers who followed gave a specific, personal reason for being there rather than a guarded one-liner — evidence the modeling worked.\n\nWhat would make it bigger: Already a strength as executed — the one addition worth testing is naming the technique out loud to the room once the newcomers have finished: \"that's why I went first — I wanted y'all to know it's safe to be honest here.\"",
+                  "timestamp": "00:10:00"
+                },
+                {
+                  "detail": "Naming the Strain of a Big New Room, Live  (Pivot Point (mixed) · Teaching Craft + Being Real)\n\nWhat happened: Mid-correcting a chapter/verse reference, Bryan paused to name the cause out loud: \"I'm having trouble with people now, you know, enough people changing in here. I'm struggling a little bit overload.\"\n\nWhy it mattered: This is a small but real authenticity moment — a 17-year veteran leader naming a live limitation in front of a room half-full of people he just met, rather than papering over the mistake. It doubles as a structure signal: a 6-newcomer week measurably strains even an experienced leader's tracking.\n\nWhat would make it bigger: Turn the moment into a light, reusable bit rather than a passing aside — \"give me grace on names this week, I've got nine new faces to learn\" — normalizing the strain for the room instead of just naming it once and moving on.",
+                  "timestamp": "01:41:16"
+                }
+              ],
+              "paragraphs": [
+                "Four disproportionately important moments — the pivots that shaped what this group will remember, believe, and do this week. Named explicitly so Bryan can see the pattern and replicate it."
+              ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "Give me a real prayer — how should you be praying and thinking about your future? [00:34:39] — Level 4 — Apply to life — Produced a specific, personal prayer from a member rather than a paraphrase — the session's clearest DOK-4 model answer.",
+                "Why are we so challenged by wealth? [00:53:39] — Level 4 — Apply to life — Room named self-sufficiency and false security as the mechanism, not just the symptom.",
+                "Mike, what are you thinking about your wealth? [02:06:28] — Level 4 — Apply to life — The session's signature moment — produced Mike's unscripted heart-attack disclosure.",
+                "What is the challenge about presuming on your future ('if the Lord wills')? [00:31:53] — Level 3 — Reason/justify — Room named 'the illusion of control' and functioning like an atheist as the core failure.",
+                "What's the basis of the patience commanded in verses 7–11? [01:06:10] — Level 3 — Reason/justify — Room correctly located the answer in 'knowing the Lord is coming,' tying patience to eschatology rather than temperament.",
+                "If we could only have Job chapter 1, how would we define patience? [01:34:58] — Level 3 — Reason/justify — Forced a definition ('endurance under stress') before the room knew the story's resolution.",
+                "What's the contrast being drawn in 2 Corinthians 4? [01:51:23] — Level 3 — Reason/justify — Room named the inside/outside, temporal/eternal contrast and connected it back to James 5's 'vapor' language.",
+                "Why has God put a treasure in an earthen vessel? [01:46:49] — Level 3 — Reason/justify — Room reasoned toward 'so the power is seen as God's, not the container's' — a clean theological inference from the text's own logic."
+              ],
+              "paragraphs": [
+                "8 Big Idea questions (DOK scored) — slightly above the 5–7 target, reflecting the session's unusually wide cross-reference sweep. Scaffolding / reading / navigation prompts (~25+, DOK 1–2) excluded. Distribution: DOK 4 — 37.5% (3 questions); DOK 3 — 62.5% (5 questions). Confession/Personal-Response Rate: 1 (below the ≥2 target). Leader Follow-up Probe Frequency: 10+ throughout."
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
         {
           "id": "bryan-bailey-2026-07-16-james-lesson-9-thursday-evening-",
           "date": "2026-07-16",


### PR DESCRIPTION
## Summary

Data-only refresh of `packages/backend-base/src/coach/coach.data.json`, mirroring the pipeline in andytryba/bible-study-coaching. Two additive updates:

1. **Legacy migration** (pairs with BSC #39, merged): Bryan's 9 older sessions — previously thin score-derived fallbacks — now carry full-format content reshaped from their original reports: 8 scorecard tables, Top-5 strengths/improvements, key moments, DOK application questions, and recommendations.
2. **New July 18 (Sat) James Lesson 9 session** (pairs with BSC #40): adds Bryan's July 18 Saturday-morning report (James 4:13–5:12, Wealth & Patience), a newcomer-heavy in-person session (~28 men, 6 first-timers), **91.69/100 → 🔷 Exceptional**, with the full written coaching — 8 scorecard tables, 5 strengths, 5 improvements, 3 monologues, 4 key moments, 8 DOK questions, 5 recommendations, and per-dimension notes.

No code/schema change — the content uses fields the schema already declares (the `feedback` prose blocks + the generic `sections` channel).

## Verify

- All reports validate against `ReportSchema` via `Value.Check` (0 invalid) — nothing is stripped from `/coach/reports`. The July 18 report survives `Value.Clean` with all 11 sections + 5 strengths intact.
- `bun test src/coach/coach.service.test.ts` — 11 pass.
- Bryan now carries 12 sessions; the newest (2026-07-18) renders 11 rich sections.

Additive / order-independent — until it lands the portal simply shows the previous thinner content for those sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EStqy8KBpFJHPfvnW37xYn

---
_Generated by [Claude Code](https://claude.ai/code/session_01EStqy8KBpFJHPfvnW37xYn)_