### PR TITLE
coach: backfill Application Questions into Bryan's 6 oldest reports

### DIFF
--- a/packages/backend-base/src/coach/coach.data.json
+++ b/packages/backend-base/src/coach/coach.data.json
@@ -2652,6 +2652,25 @@
               "paragraphs": [
                 "These are the disproportionate moments in this session — the exchanges that shaped what this group will remember, believe, and do. Aggregated scores average these away; Key Moments names each one explicitly so Bryan can rewatch with intent."
               ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "What do we know about the author, background, and recipients — tell Cole what he needs to know? — Level 2 — Compare/analyze",
+                "What's the summary of trials — what are we supposed to understand and do with them? — Level 3 — Reason/justify",
+                "What does the prayer of a doubting man sound like — pray it for us? — Level 3 — Reason/justify",
+                "Where is the source of temptation located, according to this passage? — Level 2 — Compare/analyze",
+                "What is at the heart of every sin? — Level 4 — Apply to life",
+                "Why is the temptation passage the next topic after trials? What connects them? — Level 4 — Apply to life",
+                "What's the big idea of James 1:17–18 — every good thing is from above — and how does it connect to lust/sin/death? — Level 3 — Reason/justify",
+                "What does it mean to 'delude yourself' as a hearer only? — Level 3 — Reason/justify",
+                "Contrast: Tristan is stained by the world. What does that look like? Pocan is not stained. What does that look like? — Level 4 — Apply to life",
+                "Who are the orphans and widows in your life? What does your tongue reveal about what you actually believe? — Level 4 — Apply to life",
+                "What's your practical takeaway — rubber meets the road — from James 1:12–27? — Level 4 — Apply to life"
+              ],
+              "paragraphs": [
+                "Big-Idea questions from the session, scored by Webb’s Depth-of-Knowledge (DOK) level. Reading/navigation prompts are excluded."
+              ]
             }
           ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
@@ -3021,6 +3040,23 @@
               "paragraphs": [
                 "These are the 5 disproportionate moments in the session — exchanges that shaped what this group will remember, believe, and carry out. Ordered by impact."
               ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "What does your faith do? (overarching Big Idea for the book of James) — Level 4 — Apply to life",
+                "If you're God, what's the first message you give to persecuted Christians on the run? — Level 4 — Apply to life",
+                "Joy as happiness vs. joy as verdict — what's the difference? — Level 3 — Reason/justify",
+                "What does it mean to 'remain under' the weight of a trial? — Level 3 — Reason/justify",
+                "What would be a barrier to receiving this teaching? — Level 3 — Reason/justify",
+                "What's the difference between praying in faith vs. praying without faith? — Level 3 — Reason/justify",
+                "Is there a parenting technique in this passage? — Level 4 — Apply to life",
+                "What's the advantage of being rich in this world? What's the disadvantage? — Level 3 — Reason/justify",
+                "What are the Big Ideas we're taking from James 1:1–11 today? — Level 4 — Apply to life"
+              ],
+              "paragraphs": [
+                "Big-Idea questions from the session, scored by Webb’s Depth-of-Knowledge (DOK) level. Reading/navigation prompts are excluded."
+              ]
             }
           ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
@@ -3384,6 +3420,20 @@
               "paragraphs": [
                 "These are the 5 disproportionate moments in the session — the exchanges that shaped what this group will remember, believe, and do. Aggregated scores average these away; Key Moments name each one explicitly so Bryan can rewatch with intent."
               ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "If you were God writing the first message to people fleeing persecution, what kind of message would you convey? — Level 4 — Apply to life",
+                "What would be a barrier to receiving this teaching — something that makes it impossible to accept? — Level 3 — Reason/justify",
+                "How do you know if you've gotten God's wisdom? — Level 4 — Apply to life",
+                "Rich and poor face completely different challenges. What is the same solution they both need? — Level 3 — Reason/justify",
+                "What would you go home and tell your wife, girlfriend, daughter, or call your mama about from tonight? — Level 4 — Apply to life",
+                "Why does James say 'when' you encounter trials — not 'if'? — Level 3 — Reason/justify"
+              ],
+              "paragraphs": [
+                "Big-Idea questions from the session, scored by Webb’s Depth-of-Knowledge (DOK) level. Reading/navigation prompts are excluded."
+              ]
             }
           ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
@@ -3730,6 +3780,23 @@
                 "Bumper sticker method explained + executed: Yes — modeled then applied throughout  (Target: Key technique for Lesson 1)  → STRONG",
                 "Big Ideas accumulated at close: Yes — Russ reviewed all bumper stickers [01:56:47]  (Target: 1–2 takeaways reinforced)  → STRONG",
                 "Rabbinical structure / chiasm taught: Yes — chiasm explained, center verse identified [01:23:50]  (Target: Advanced hermeneutic)  → STRONG"
+              ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "Consider it all joy when you meet trials — what’s actually being said? What’s the message? (James 1:2–4) — Level 3 — Reason/justify",
+                "What is wisdom? What’s the difference between earthly wisdom and applied knowledge? And why do you need God’s viewpoint? (James 1:5–8) — Level 2 — Compare/analyze",
+                "What is the test of wholehearted faith here — about your view of your status, your position? (James 1:9–11) — Level 3 — Reason/justify",
+                "What is the source of your sin? Who’s responsible? (James 1:12–18) — Level 3 — Reason/justify",
+                "You say you believe — but what do you actually do? How do you reconcile belief that isn’t reflected in behavior? (James 1:19–25) — Level 4 — Apply to life",
+                "How does James define worthless religion? How does he define pure and undefiled religion? What’s the test? (James 1:26–27) — Level 4 — Apply to life",
+                "If faith has no works, what does James say? What’s the new idea being introduced? (James 2:14–17) — Level 3 — Reason/justify",
+                "If you’re driven by friendship with the world — what does that make you in relation to God? (James 4:4) — Level 3 — Reason/justify",
+                "What makes prayer effective? What does Elijah’s example teach us about how to pray? (James 5:13–18) — Level 4 — Apply to life"
+              ],
+              "paragraphs": [
+                "Big-Idea questions from the session, scored by Webb’s Depth-of-Knowledge (DOK) level. Reading/navigation prompts are excluded."
               ]
             }
           ],
@@ -4081,6 +4148,32 @@
                 "Topic drift: 3% (Joe Rogan/Logan Paul, kids' homework, Bible filter)  (Target: <10%)  → STRONG",
                 "Periodic summaries: Yes — true/false prophet dual-column synthesis  (Target: At key points)  → STRONG",
                 "Big Ideas at close: Cited not recited (4 named, group did not speak)  (Target: 1–2 takeaways actively reinforced)  → NEEDS WORK"
+              ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "What are you learning about God here? (Jer 22:24-30, Coniah) — Level 3 — Reason/justify",
+                "Is that [warning-then-judgment pattern] going to be true for us one day? — Level 4 — Apply to life",
+                "What's the connection between pride, that viewpoint, and repentance? (Big Idea bumper-sticker moment) — Level 4 — Apply to life",
+                "You can get to a point with God where there's no remedy. What would that mean? (2 Chron 36:16) — Level 4 — Apply to life",
+                "God has other people on His payroll. How is that informed — how you pray? (Jer 27:5-7) — Level 4 — Apply to life",
+                "A true prophet calls for submission. A false prophet — what do they call for? — Level 3 — Reason/justify",
+                "Zedekiah asks for prayer without submitting. What would you call that? (Produced ‘spiritual hypocrisy’) — Level 3 — Reason/justify",
+                "What does it say about a Christian who faces no opposition, no persecution? (Jer 37 → 2 Tim 3) — Level 4 — Apply to life",
+                "What else do you see? — Level 2 — Compare/analyze",
+                "What do we see about what role has God played in this story? — Level 2 — Compare/analyze",
+                "What do we learn about the opponent that's going to administer the consequences from verse 7? — Level 2 — Compare/analyze",
+                "Okay, what do you see about God's judgment? — Level 2 — Compare/analyze",
+                "What are we seeing here? What's God's build up for himself? — Level 2 — Compare/analyze",
+                "What do we really get behind the curtain now? What do you see in verses 8-10? — Level 2 — Compare/analyze",
+                "Now we've changed target audience. Jeremiah's now speaking to whom? — Level 2 — Compare/analyze",
+                "Based on how this ends, what appears to be the purpose of the Babylonian act here? — Level 2 — Compare/analyze",
+                "Now you're going — who's right, who's wrong, you think? — Level 2 — Compare/analyze",
+                "What did you just have? You have a repeated theme — which slogan does this fit nicely into? — Level 2 — Compare/analyze"
+              ],
+              "paragraphs": [
+                "Big-Idea questions from the session, scored by Webb’s Depth-of-Knowledge (DOK) level. Reading/navigation prompts are excluded."
               ]
             }
           ],
@@ -4446,6 +4539,44 @@
                 "Topic drift: 2%  (Target: 2%)  → → Stable",
                 "Discussion / Application time: 12%  (Target: 24%)  → ↑↑ Major Gain",
                 "Overall Score: 52/60 (L1)  (Target: 49/55 (A-))  → → Stable"
+              ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "Why does he get angry? — Level 3 — Reason/justify",
+                "Why does he get angry about us? — Level 3 — Reason/justify",
+                "Can God abandon you? — Level 4 — Apply to life",
+                "What does it mean that God doesn't support your flesh? — Level 3 — Reason/justify",
+                "What is a prayer of a believer seeking to have his flesh affirmed? — Level 4 — Apply to life",
+                "What's a better prayer? — Level 3 — Reason/justify",
+                "What's God telling the people in exile? — Level 3 — Reason/justify",
+                "Why is this new covenant? What's the motive? — Level 4 — Apply to life",
+                "Is salvation about you or about him? — Level 4 — Apply to life",
+                "True obedience requires what? — Level 3 — Reason/justify",
+                "What defines the kings being red, being evil? What defines being not good? — Level 2 — Compare/analyze",
+                "What about the southern kingdom, Judah? What do you notice? — Level 2 — Compare/analyze",
+                "What else? What's another big idea? — Level 1 — Simple recall",
+                "What do you see about the political situation? — Level 2 — Compare/analyze",
+                "What do you see going on down? What's happening? — Level 2 — Compare/analyze",
+                "What do you see that was added in Chronicles? — Level 2 — Compare/analyze",
+                "What is the meaning behind discipline from God? — Level 3 — Reason/justify",
+                "Who are the people that are the good figs? — Level 2 — Compare/analyze",
+                "What does that sound like? A new covenant? — Level 2 — Compare/analyze",
+                "What's happening to the ones that stay behind? — Level 2 — Compare/analyze",
+                "You're seeing God's kingdom upside down — what's happening here? — Level 3 — Reason/justify",
+                "What does it mean to be blessed? — Level 3 — Reason/justify",
+                "What are the prophets saying in this time of captivity? — Level 2 — Compare/analyze",
+                "What would be the opposite of what God said in verse 4 through 7? — Level 3 — Reason/justify",
+                "What are the features of this new covenant? — Level 2 — Compare/analyze",
+                "What does that mean — they will know me? — Level 3 — Reason/justify",
+                "What are the promises from Ezekiel 36? — Level 2 — Compare/analyze",
+                "What does it mean — new heart, new spirit? — Level 3 — Reason/justify",
+                "What's next on the list? — Level 1 — Simple recall",
+                "What's the last promise? — Level 1 — Simple recall"
+              ],
+              "paragraphs": [
+                "Big-Idea questions from the session, scored by Webb’s Depth-of-Knowledge (DOK) level. Reading/navigation prompts are excluded."
               ]
             }
           ],


### PR DESCRIPTION
## Summary

Data-only refresh of `packages/backend-base/src/coach/coach.data.json`, mirroring the pipeline in andytryba/bible-study-coaching.

Bryan's **6 earliest reports** reached the portal with **no Application Questions section**, while newer reports had one. Those reports were written in an earlier format that listed Big-Idea questions as prose rather than a DOK table, so they weren't extracted. The migrator now recovers those questions from the source reports.

**All 12 of Bryan's reports now carry a DOK-scored Application Questions section.**

## Verify

- All 19 reports validate against `ReportSchema` via `Value.Check` (0 invalid) — nothing is stripped from `/coach/reports`.
- `bun test src/coach/` — 11 pass.
- No code/schema change — the recovered questions use the generic `sections` channel the schema already declares.

Additive / order-independent — until it lands the portal simply shows the previous content (no Questions section on those 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EStqy8KBpFJHPfvnW37xYn

---
_Generated by [Claude Code](https://claude.ai/code/session_01EStqy8KBpFJHPfvnW37xYn)_