### PR TITLE
coach: expand bundled dataset to full leader cohort (16 coaches, 50 reports)

### DIFF
--- a/packages/backend-base/src/coach/coach.data.json
+++ b/packages/backend-base/src/coach/coach.data.json
@@ -13964,6 +13964,1987 @@
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
         {
+          "id": "james-davis-2026-04-11-2-kings-study-exile-theology-jeh",
+          "date": "2026-04-11",
+          "dateLabel": "April 11, 2026",
+          "session": "2 Kings study — Exile theology (Jehoahaz, Jehoiakim, Jeremiah 29, Ezekiel 36)",
+          "topic": "God's promise to change hearts through exile; New Covenant from judgment to redemption",
+          "duration": "~2h 13 min",
+          "attendees": 8,
+          "newcomers": 0,
+          "score": 56.92,
+          "base": 56.92,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "Developing",
+          "statusEmoji": "🟠",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 64,
+              "contribution": 21.12
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 40,
+              "contribution": 12.4
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 60,
+              "contribution": 10.8
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": ""
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": ""
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 1,
+              "note": ""
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 2,
+              "note": ""
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 2,
+              "note": ""
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 1,
+              "note": ""
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A developing session — strongest in Scripture Engagement and Session Structure & Flow, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+              "Application questions pushed members from concept to life, several at the reason/apply level."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "No in-session development of another leader was observable this week.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas."
+            ],
+            "overview": [
+              "A developing session — strongest in Scripture Engagement and Session Structure & Flow, with the clearest next step in Visual Aids. It scored 56.92/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Session Structure & Flow; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity anchored the session (4/5)",
+                "paragraphs": [
+                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (1/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (1/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (2/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Prayer is a growth area (2/5)",
+                "paragraphs": [
+                  "Prayer was leader-only or rushed; the group’s voice was thin.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Prayer",
+                "paragraphs": [
+                  "Next time, ask one member to open and a different member to close in prayer.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 64% × weight 33 → 21.12 pts",
+                "Building Ministry: 40% × weight 31 → 12.40 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 60% × weight 18 → 10.80 pts",
+                "Base (sum of cluster contributions): 56.92 / 100",
+                "Session score: 56.92 / 100"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "james-davis-2026-03-28-build-james-davis-2026-03-28-js",
+          "date": "2026-03-28",
+          "dateLabel": "March 28, 2026",
+          "session": "build_james_davis_2026-03-28.js",
+          "topic": "",
+          "duration": "",
+          "attendees": 0,
+          "newcomers": 0,
+          "score": 58.7,
+          "base": 58.7,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "Developing",
+          "statusEmoji": "🟠",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 60,
+              "contribution": 19.8
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 50,
+              "contribution": 15.5
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 60,
+              "contribution": 10.8
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": ""
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": ""
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 5,
+              "note": ""
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 1,
+              "note": ""
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 1,
+              "note": ""
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 1,
+              "note": ""
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A developing session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "A high share of the room contributed substantively, called on by name."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+              "No in-session development of another leader was observable this week."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\""
+            ],
+            "overview": [
+              "A developing session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Visual Aids. It scored 58.7/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Application Questions; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (5/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Homework References anchored the session (4/5)",
+                "paragraphs": [
+                  "Homework was referenced and rewarded, differentiating the members who prepared.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (3/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (1/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (1/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (1/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 60% × weight 33 → 19.80 pts",
+                "Building Ministry: 50% × weight 31 → 15.50 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 60% × weight 18 → 10.80 pts",
+                "Base (sum of cluster contributions): 58.70 / 100",
+                "Session score: 58.7 / 100"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "james-davis-2026-03-14-build-james-davis-2026-03-14-js",
+          "date": "2026-03-14",
+          "dateLabel": "March 14, 2026",
+          "session": "build_james_davis_2026-03-14.js",
+          "topic": "",
+          "duration": "",
+          "attendees": 0,
+          "newcomers": 0,
+          "score": 52.94,
+          "base": 52.94,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "Developing",
+          "statusEmoji": "🟠",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 48,
+              "contribution": 15.84
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 50,
+              "contribution": 15.5
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 50,
+              "contribution": 9
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": ""
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 2,
+              "note": ""
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 1,
+              "note": ""
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 1,
+              "note": ""
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 1,
+              "note": ""
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A developing session — strongest in Scripture Engagement and Homework References, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Homework was referenced and rewarded, differentiating the members who prepared.",
+              "Prayer was delegated to members, opening and closing the group in shared voice."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+              "No in-session development of another leader was observable this week."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\""
+            ],
+            "overview": [
+              "A developing session — strongest in Scripture Engagement and Homework References, with the clearest next step in Visual Aids. It scored 52.94/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Homework References; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Homework References anchored the session (4/5)",
+                "paragraphs": [
+                  "Homework was referenced and rewarded, differentiating the members who prepared.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Prayer anchored the session (4/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (3/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (3/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (1/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (1/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (1/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (2/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Participant Engagement is a growth area (3/5)",
+                "paragraphs": [
+                  "A few voices carried the discussion; quieter members went unheard.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Participant Engagement",
+                "paragraphs": [
+                  "Next time, name one quiet regular early and invite their read on a passage.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 48% × weight 33 → 15.84 pts",
+                "Building Ministry: 50% × weight 31 → 15.50 pts",
+                "Engaging People: 50% × weight 18 → 9.00 pts",
+                "Being Real: 70% × weight 18 → 12.60 pts",
+                "Base (sum of cluster contributions): 52.94 / 100",
+                "Session score: 52.94 / 100"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "james-davis-2026-03-07-build-james-davis-2026-03-07-js",
+          "date": "2026-03-07",
+          "dateLabel": "March 7, 2026",
+          "session": "build_james_davis_2026-03-07.js",
+          "topic": "",
+          "duration": "",
+          "attendees": 0,
+          "newcomers": 0,
+          "score": 51.52,
+          "base": 51.52,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "Developing",
+          "statusEmoji": "🟠",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 64,
+              "contribution": 21.12
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 40,
+              "contribution": 12.4
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 50,
+              "contribution": 9
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 50,
+              "contribution": 9
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": ""
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 2,
+              "note": ""
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 1,
+              "note": ""
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 2,
+              "note": ""
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 1,
+              "note": ""
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A developing session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "The session opened by recalling prior Big Ideas, reinforcing cumulative learning."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "No in-session development of another leader was observable this week.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds."
+            ],
+            "overview": [
+              "A developing session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Visual Aids. It scored 51.52/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Application Questions; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement anchored the session (4/5)",
+                "paragraphs": [
+                  "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (3/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (3/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (1/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (1/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (2/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (2/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (3/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 64% × weight 33 → 21.12 pts",
+                "Building Ministry: 40% × weight 31 → 12.40 pts",
+                "Engaging People: 50% × weight 18 → 9.00 pts",
+                "Being Real: 50% × weight 18 → 9.00 pts",
+                "Base (sum of cluster contributions): 51.52 / 100",
+                "Session score: 51.52 / 100"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "james-davis-2026-02-21-build-james-davis-2026-02-21-js",
+          "date": "2026-02-21",
+          "dateLabel": "February 21, 2026",
+          "session": "build_james_davis_2026-02-21.js",
+          "topic": "",
+          "duration": "",
+          "attendees": 0,
+          "newcomers": 0,
+          "score": 62.2,
+          "base": 62.2,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "On Target",
+          "statusEmoji": "🟡",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 80,
+              "contribution": 26.4
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 40,
+              "contribution": 12.4
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 60,
+              "contribution": 10.8
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": ""
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 2,
+              "note": ""
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 5,
+              "note": ""
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 2,
+              "note": ""
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 5,
+              "note": ""
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 1,
+              "note": ""
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "An on target session — strongest in Application Questions and Memory Reinforcement, with the clearest next step in Leader Development.",
+            "strengths": [
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place."
+            ],
+            "improvements": [
+              "No in-session development of another leader was observable this week.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "The session leaned audio-only; a visual anchor would aid retention."
+            ],
+            "recommendations": [
+              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term."
+            ],
+            "overview": [
+              "An on target session — strongest in Application Questions and Memory Reinforcement, with the clearest next step in Leader Development. It scored 62.2/100 under the v3 weighted model.",
+              "The session played to its strengths in Application Questions and Memory Reinforcement; the recommendations below turn Leader Development into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Application Questions anchored the session (5/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement anchored the session (5/5)",
+                "paragraphs": [
+                  "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Scripture Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Leader Development is a growth area (1/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (2/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (2/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (3/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 80% × weight 33 → 26.40 pts",
+                "Building Ministry: 40% × weight 31 → 12.40 pts",
+                "Engaging People: 60% × weight 18 → 10.80 pts",
+                "Being Real: 70% × weight 18 → 12.60 pts",
+                "Base (sum of cluster contributions): 62.20 / 100",
+                "Session score: 62.2 / 100"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "james-davis-2026-02-14-build-james-davis-2026-02-14-js",
+          "date": "2026-02-14",
+          "dateLabel": "February 14, 2026",
+          "session": "build_james_davis_2026-02-14.js",
+          "topic": "",
+          "duration": "",
+          "attendees": 0,
+          "newcomers": 0,
+          "score": 59.08,
+          "base": 59.08,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "Developing",
+          "statusEmoji": "🟠",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 76,
+              "contribution": 25.08
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 40,
+              "contribution": 12.4
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 60,
+              "contribution": 10.8
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 60,
+              "contribution": 10.8
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": ""
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 2,
+              "note": ""
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 2,
+              "note": ""
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 5,
+              "note": ""
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 1,
+              "note": ""
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A developing session — strongest in Memory Reinforcement and Session Structure & Flow, with the clearest next step in Leader Development.",
+            "strengths": [
+              "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse."
+            ],
+            "improvements": [
+              "No in-session development of another leader was observable this week.",
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Teaching stayed at arm’s length; little personal cost was modeled."
+            ],
+            "recommendations": [
+              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, open one teaching point with a first-person example that cost you something."
+            ],
+            "overview": [
+              "A developing session — strongest in Memory Reinforcement and Session Structure & Flow, with the clearest next step in Leader Development. It scored 59.08/100 under the v3 weighted model.",
+              "The session played to its strengths in Memory Reinforcement and Session Structure & Flow; the recommendations below turn Leader Development into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Memory Reinforcement anchored the session (5/5)",
+                "paragraphs": [
+                  "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Scripture Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Prayer anchored the session (4/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Leader Development is a growth area (1/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (2/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (2/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Participant Engagement is a growth area (3/5)",
+                "paragraphs": [
+                  "A few voices carried the discussion; quieter members went unheard.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Participant Engagement",
+                "paragraphs": [
+                  "Next time, name one quiet regular early and invite their read on a passage.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 76% × weight 33 → 25.08 pts",
+                "Building Ministry: 40% × weight 31 → 12.40 pts",
+                "Engaging People: 60% × weight 18 → 10.80 pts",
+                "Being Real: 60% × weight 18 → 10.80 pts",
+                "Base (sum of cluster contributions): 59.08 / 100",
+                "Session score: 59.08 / 100"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "james-davis-2026-01-31-build-james-davis-2026-01-31-js",
+          "date": "2026-01-31",
+          "dateLabel": "January 31, 2026",
+          "session": "build_james_davis_2026-01-31.js",
+          "topic": "",
+          "duration": "",
+          "attendees": 0,
+          "newcomers": 0,
+          "score": 54.28,
+          "base": 54.28,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "Developing",
+          "statusEmoji": "🟠",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 56,
+              "contribution": 18.48
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 40,
+              "contribution": 12.4
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 60,
+              "contribution": 10.8
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": ""
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 1,
+              "note": ""
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 2,
+              "note": ""
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 1,
+              "note": ""
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A developing session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "A high share of the room contributed substantively, called on by name."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "No in-session development of another leader was observable this week.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas."
+            ],
+            "overview": [
+              "A developing session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Visual Aids. It scored 54.28/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Application Questions; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (3/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture anchored the session (3/5)",
+                "paragraphs": [
+                  "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (1/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (1/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (2/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (3/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 56% × weight 33 → 18.48 pts",
+                "Building Ministry: 40% × weight 31 → 12.40 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 60% × weight 18 → 10.80 pts",
+                "Base (sum of cluster contributions): 54.28 / 100",
+                "Session score: 54.28 / 100"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
           "id": "james-davis-2026-01-17-2-kings-8-10-god-s-sovereignty-c",
           "date": "2026-01-17",
           "dateLabel": "January 17, 2026",
@@ -15877,7 +17858,576 @@
       "coachName": "Bryan Bailey",
       "isCoach": true,
       "zoomLink": "",
-      "reports": []
+      "reports": [
+        {
+          "id": "jt-dettman-2026-06-06-revelation-2-8-11-week-2-the-chu",
+          "date": "2026-06-06",
+          "dateLabel": "June 6, 2026",
+          "session": "Revelation 2:8–11 — Week 2, The Church of Smyrna",
+          "topic": "Suffering, endurance, and the faithful crown; cross-references on why God’s people suffer",
+          "duration": "~95 min",
+          "attendees": 13,
+          "newcomers": 1,
+          "score": 65.39,
+          "base": 64.39,
+          "newcomerBonus": 1,
+          "sizeBonus": 0,
+          "status": "On Target",
+          "statusEmoji": "🟡",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 64,
+              "contribution": 21.12
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 46.7,
+              "contribution": 14.47
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 1,
+              "note": ""
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": ""
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 2,
+              "note": ""
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 2,
+              "note": ""
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 2,
+              "note": ""
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "An on target session — strongest in Scripture Engagement and Facilitation vs. Lecture, with the clearest next step in Newcomer Welcome.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+              "Application questions pushed members from concept to life, several at the reason/apply level."
+            ],
+            "improvements": [
+              "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded."
+            ],
+            "recommendations": [
+              "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas."
+            ],
+            "overview": [
+              "An on target session — strongest in Scripture Engagement and Facilitation vs. Lecture, with the clearest next step in Newcomer Welcome. It scored 65.39/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Facilitation vs. Lecture; the recommendations below turn Newcomer Welcome into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture anchored the session (4/5)",
+                "paragraphs": [
+                  "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity anchored the session (4/5)",
+                "paragraphs": [
+                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Newcomer Welcome is a growth area (1/5)",
+                "paragraphs": [
+                  "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (2/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (2/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (2/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Session Structure & Flow is a growth area (3/5)",
+                "paragraphs": [
+                  "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Newcomer Welcome",
+                "paragraphs": [
+                  "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Session Structure & Flow",
+                "paragraphs": [
+                  "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 64% × weight 33 → 21.12 pts",
+                "Building Ministry: 46.7% × weight 31 → 14.47 pts",
+                "Engaging People: 80% × weight 18 → 14.40 pts",
+                "Being Real: 80% × weight 18 → 14.40 pts",
+                "Base (sum of cluster contributions): 64.39 / 100",
+                "Session bonuses: newcomer growth +1",
+                "Session score: 65.39 / 100"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "jt-dettman-2026-05-16-revelation-part-one-week-1-intro",
+          "date": "2026-05-16",
+          "dateLabel": "May 16, 2026",
+          "session": "Revelation Part One, Week 1 — Introduction and seven-church overview",
+          "topic": "Rev 1–5 overview; seven churches; throne room; Worthy is the Lamb",
+          "duration": "~68 min (recorded portion)",
+          "attendees": 8,
+          "newcomers": 1,
+          "score": 51.59,
+          "base": 50.59,
+          "newcomerBonus": 1,
+          "sizeBonus": 0,
+          "status": "Developing",
+          "statusEmoji": "🟠",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 44,
+              "contribution": 14.52
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 46.7,
+              "contribution": 14.47
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 40,
+              "contribution": 7.2
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 1,
+              "note": ""
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 2,
+              "note": ""
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 1,
+              "note": ""
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 2,
+              "note": ""
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 2,
+              "note": ""
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": null,
+              "note": ""
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 2,
+              "note": ""
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A developing session — strongest in Facilitation vs. Lecture and Participant Engagement, with the clearest next step in Newcomer Welcome.",
+            "strengths": [
+              "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+              "A high share of the room contributed substantively, called on by name.",
+              "Homework was referenced and rewarded, differentiating the members who prepared."
+            ],
+            "improvements": [
+              "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Discussion drifted from the text; a few more passages would ground the teaching."
+            ],
+            "recommendations": [
+              "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, pre-mark 3 cross-references to pull in during the densest teaching block."
+            ],
+            "overview": [
+              "A developing session — strongest in Facilitation vs. Lecture and Participant Engagement, with the clearest next step in Newcomer Welcome. It scored 51.59/100 under the v3 weighted model.",
+              "The session played to its strengths in Facilitation vs. Lecture and Participant Engagement; the recommendations below turn Newcomer Welcome into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Facilitation vs. Lecture anchored the session (4/5)",
+                "paragraphs": [
+                  "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Homework References anchored the session (4/5)",
+                "paragraphs": [
+                  "Homework was referenced and rewarded, differentiating the members who prepared.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (3/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (3/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Newcomer Welcome is a growth area (1/5)",
+                "paragraphs": [
+                  "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (1/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Scripture Engagement is a growth area (2/5)",
+                "paragraphs": [
+                  "Discussion drifted from the text; a few more passages would ground the teaching.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (2/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (2/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Newcomer Welcome",
+                "paragraphs": [
+                  "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Scripture Engagement",
+                "paragraphs": [
+                  "Next time, pre-mark 3 cross-references to pull in during the densest teaching block.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 44% × weight 33 → 14.52 pts",
+                "Building Ministry: 46.7% × weight 31 → 14.47 pts",
+                "Engaging People: 80% × weight 18 → 14.40 pts",
+                "Being Real: 40% × weight 18 → 7.20 pts",
+                "Base (sum of cluster contributions): 50.59 / 100",
+                "Session bonuses: newcomer growth +1",
+                "Session score: 51.59 / 100"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        }
+      ]
     },
     {
       "id": "josh-samuels",
@@ -16535,7 +19085,574 @@
       "coachName": "Bryan Bailey",
       "isCoach": true,
       "zoomLink": "",
-      "reports": []
+      "reports": [
+        {
+          "id": "david-kartozia-2026-04-18-2-kings-study-fall-of-judah-jeho",
+          "date": "2026-04-18",
+          "dateLabel": "April 18, 2026",
+          "session": "2 Kings study — Fall of Judah (Jehoiachin, Zedekiah, Jeremiah vs Hananiah)",
+          "topic": "Covenant-breaking, false prophecy, and God's delayed-but-certain judgment",
+          "duration": "~2h 6 min",
+          "attendees": 7,
+          "newcomers": 0,
+          "score": 59.12,
+          "base": 59.12,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "Developing",
+          "statusEmoji": "🟠",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 84,
+              "contribution": 27.72
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 20,
+              "contribution": 6.2
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": ""
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": ""
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 5,
+              "note": ""
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 2,
+              "note": ""
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 5,
+              "note": ""
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 1,
+              "note": ""
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 1,
+              "note": ""
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A developing session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Homework References.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "The session opened by recalling prior Big Ideas, reinforcing cumulative learning."
+            ],
+            "improvements": [
+              "Homework went unmentioned, reducing its pull on the group.",
+              "No in-session development of another leader was observable this week.",
+              "The session leaned audio-only; a visual anchor would aid retention."
+            ],
+            "recommendations": [
+              "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+              "Next time, put one word-study lookup or a simple table on screen during the key term."
+            ],
+            "overview": [
+              "A developing session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Homework References. It scored 59.12/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Application Questions; the recommendations below turn Homework References into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (5/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement anchored the session (5/5)",
+                "paragraphs": [
+                  "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Homework References is a growth area (1/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (1/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (2/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Prayer is a growth area (3/5)",
+                "paragraphs": [
+                  "Prayer was leader-only or rushed; the group’s voice was thin.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Prayer",
+                "paragraphs": [
+                  "Next time, ask one member to open and a different member to close in prayer.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 84% × weight 33 → 27.72 pts",
+                "Building Ministry: 20% × weight 31 → 6.20 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 70% × weight 18 → 12.60 pts",
+                "Base (sum of cluster contributions): 59.12 / 100",
+                "Session score: 59.12 / 100"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "david-kartozia-2026-02-07-build-david-kartozia-2026-02-07-",
+          "date": "2026-02-07",
+          "dateLabel": "February 7, 2026",
+          "session": "build_david_kartozia_2026-02-07.js",
+          "topic": "",
+          "duration": "",
+          "attendees": 0,
+          "newcomers": 0,
+          "score": 63.16,
+          "base": 63.16,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "On Target",
+          "statusEmoji": "🟡",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 72,
+              "contribution": 23.76
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 40,
+              "contribution": 12.4
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": ""
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 2,
+              "note": ""
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 3,
+              "note": ""
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": ""
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 1,
+              "note": ""
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "An on target session — strongest in Session Structure & Flow and Scripture Engagement, with the clearest next step in Leader Development.",
+            "strengths": [
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level."
+            ],
+            "improvements": [
+              "No in-session development of another leader was observable this week.",
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture."
+            ],
+            "recommendations": [
+              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds."
+            ],
+            "overview": [
+              "An on target session — strongest in Session Structure & Flow and Scripture Engagement, with the clearest next step in Leader Development. It scored 63.16/100 under the v3 weighted model.",
+              "The session played to its strengths in Session Structure & Flow and Scripture Engagement; the recommendations below turn Leader Development into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Scripture Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity anchored the session (4/5)",
+                "paragraphs": [
+                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Leader Development is a growth area (1/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (2/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (3/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (4/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 72% × weight 33 → 23.76 pts",
+                "Building Ministry: 40% × weight 31 → 12.40 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 80% × weight 18 → 14.40 pts",
+                "Base (sum of cluster contributions): 63.16 / 100",
+                "Session score: 63.16 / 100"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        }
+      ]
     }
   ]
 }

--- a/packages/backend-base/src/coach/coach.data.json
+++ b/packages/backend-base/src/coach/coach.data.json
@@ -13013,7 +13013,7 @@
     {
       "id": "james-davis",
       "name": "James Davis",
-      "email": "james-davis@needs-real-email.invalid",
+      "email": "anthocar@gmail.com",
       "group": "James D’Apolito’s Group",
       "coachName": "Bryan Bailey",
       "isCoach": true,
@@ -16259,646 +16259,9 @@
       ]
     },
     {
-      "id": "cameron-relic",
-      "name": "Cameron Relic",
-      "email": "cameron-relic@needs-real-email.invalid",
-      "group": "James Study",
-      "coachName": "Bryan Bailey",
-      "isCoach": true,
-      "zoomLink": "",
-      "reports": [
-        {
-          "id": "cameron-relic-2026-05-28-james-lesson-1-faith2see-group-c",
-          "date": "2026-05-28",
-          "dateLabel": "May 28, 2026",
-          "session": "James, Lesson 1 (faith2see group) — Crown of Life, Temptation, Doers of the Word, True Religion (Jas 1:12–27)",
-          "topic": "Trials vs. temptation; sin progression (lust→carried away→death); doers vs. hearers; bridling the tongue; pure religion",
-          "duration": "~2h 3m (6:00 PM – 8:03 PM CT; ended 5 min over target)",
-          "attendees": 15,
-          "newcomers": 0,
-          "score": 73.3,
-          "base": 73.3,
-          "newcomerBonus": 0,
-          "sizeBonus": 0,
-          "status": "Strong",
-          "statusEmoji": "🟢",
-          "clusters": [
-            {
-              "name": "Teaching Craft",
-              "weight": 33,
-              "scorePct": 80,
-              "contribution": 26.4
-            },
-            {
-              "name": "Building Ministry",
-              "weight": 31,
-              "scorePct": 70,
-              "contribution": 21.7
-            },
-            {
-              "name": "Engaging People",
-              "weight": 18,
-              "scorePct": 70,
-              "contribution": 12.6
-            },
-            {
-              "name": "Being Real",
-              "weight": 18,
-              "scorePct": 70,
-              "contribution": 12.6
-            }
-          ],
-          "dimensions": [
-            {
-              "n": 1,
-              "name": "Session Structure & Flow",
-              "score": 4,
-              "note": "Strong blueprint adherence; dual-leader handoff smooth; both prayers captured; homework anchored"
-            },
-            {
-              "n": 2,
-              "name": "Newcomer Welcome",
-              "score": null,
-              "note": "No newcomers — Building Ministry max reduced proportionally"
-            },
-            {
-              "n": 3,
-              "name": "Scripture Engagement",
-              "score": 5,
-              "note": "14 cross-references; Cameron's arc high; Isaiah 1 cross-ref at close exceptional"
-            },
-            {
-              "n": 4,
-              "name": "Facilitation vs. Lecture",
-              "score": 3,
-              "note": "~30–35% leader talk; Cameron's best facilitation ratio in tracked arc; productive struggle honored"
-            },
-            {
-              "n": 5,
-              "name": "Application Questions",
-              "score": 4,
-              "note": "10 Big Idea questions; 40% DOK 4; distributed throughout; productive struggle defended"
-            },
-            {
-              "n": 6,
-              "name": "Participant Engagement",
-              "score": 4,
-              "note": "~13 members called by name; 12 distinct voices in discussion; strong go-around even if brief"
-            },
-            {
-              "n": 7,
-              "name": "Visual Aids",
-              "score": 3,
-              "note": "Russell's sin-progression diagram (Cameron invited it); no BLB on-screen; no leader-prepared visual"
-            },
-            {
-              "n": 8,
-              "name": "Vulnerability / Authenticity",
-              "score": 3,
-              "note": "Cameron: 3 mild disclosures; no high-cost personal moment; member vulnerability (Uri, Andy) present but not fully honored"
-            },
-            {
-              "n": 9,
-              "name": "Memory Reinforcement",
-              "score": 4,
-              "note": "Russell's 14-min review of James 1:1–11 + Cameron's Big Ideas opening; strong closing synthesis 'three things that cost you'"
-            },
-            {
-              "n": 10,
-              "name": "Homework References",
-              "score": 5,
-              "note": "Explicit page references (pg 25, 27, 28); homework structure spine of lesson; Cameron's arc high on this dimension"
-            },
-            {
-              "n": 11,
-              "name": "Prayer",
-              "score": 4,
-              "note": "Opening prayer by Cameron (Russell's invitation, on-topic); closing prayer delegated to Andy (substantive, applied lesson themes); prayer chain awareness implied"
-            },
-            {
-              "n": 12,
-              "name": "Leader Development",
-              "score": 2,
-              "note": "No visible apprentice or facilitation-window assignment; Russell is peer co-leader not Cameron's coachee; no 2:2 signal visible"
-            }
-          ],
-          "bigIdeas": [],
-          "feedback": {
-            "headline": "A strong session — strongest in Scripture Engagement and Homework References, with the clearest next step in Leader Development.",
-            "strengths": [
-              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-              "Homework was referenced and rewarded, differentiating the members who prepared.",
-              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place."
-            ],
-            "improvements": [
-              "No in-session development of another leader was observable this week.",
-              "Leader talk crowded out discussion; the balance leaned toward lecture.",
-              "The session leaned audio-only; a visual anchor would aid retention."
-            ],
-            "recommendations": [
-              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
-              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-              "Next time, put one word-study lookup or a simple table on screen during the key term."
-            ],
-            "overview": [
-              "A strong session — strongest in Scripture Engagement and Homework References, with the clearest next step in Leader Development. It scored 73.3/100 under the v3 weighted model.",
-              "The session played to its strengths in Scripture Engagement and Homework References; the recommendations below turn Leader Development into transferable technique for the next session, so the momentum carries forward regardless of the passage."
-            ],
-            "strengthsProse": [
-              {
-                "title": "Scripture Engagement anchored the session (5/5)",
-                "paragraphs": [
-                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 14 cross-references; Cameron's arc high; Isaiah 1 cross-ref at close exceptional"
-                ]
-              },
-              {
-                "title": "Homework References anchored the session (5/5)",
-                "paragraphs": [
-                  "Homework was referenced and rewarded, differentiating the members who prepared.",
-                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
-                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Explicit page references (pg 25, 27, 28); homework structure spine of lesson; Cameron's arc high on this dimension"
-                ]
-              },
-              {
-                "title": "Session Structure & Flow anchored the session (4/5)",
-                "paragraphs": [
-                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Strong blueprint adherence; dual-leader handoff smooth; both prayers captured; homework anchored"
-                ]
-              },
-              {
-                "title": "Application Questions anchored the session (4/5)",
-                "paragraphs": [
-                  "Application questions pushed members from concept to life, several at the reason/apply level.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 10 Big Idea questions; 40% DOK 4; distributed throughout; productive struggle defended"
-                ]
-              },
-              {
-                "title": "Participant Engagement anchored the session (4/5)",
-                "paragraphs": [
-                  "A high share of the room contributed substantively, called on by name.",
-                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
-                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: ~13 members called by name; 12 distinct voices in discussion; strong go-around even if brief"
-                ]
-              }
-            ],
-            "improvementsProse": [
-              {
-                "title": "Leader Development is a growth area (2/5)",
-                "paragraphs": [
-                  "No in-session development of another leader was observable this week.",
-                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: No visible apprentice or facilitation-window assignment; Russell is peer co-leader not Cameron's coachee; no 2:2 signal visible"
-                ]
-              },
-              {
-                "title": "Facilitation vs. Lecture is a growth area (3/5)",
-                "paragraphs": [
-                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: ~30–35% leader talk; Cameron's best facilitation ratio in tracked arc; productive struggle honored"
-                ]
-              },
-              {
-                "title": "Visual Aids is a growth area (3/5)",
-                "paragraphs": [
-                  "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Russell's sin-progression diagram (Cameron invited it); no BLB on-screen; no leader-prepared visual"
-                ]
-              },
-              {
-                "title": "Vulnerability / Authenticity is a growth area (3/5)",
-                "paragraphs": [
-                  "Teaching stayed at arm’s length; little personal cost was modeled.",
-                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
-                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Cameron: 3 mild disclosures; no high-cost personal moment; member vulnerability (Uri, Andy) present but not fully honored"
-                ]
-              },
-              {
-                "title": "Memory Reinforcement is a growth area (4/5)",
-                "paragraphs": [
-                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Russell's 14-min review of James 1:1–11 + Cameron's Big Ideas opening; strong closing synthesis 'three things that cost you'"
-                ]
-              }
-            ],
-            "recommendationsProse": [
-              {
-                "title": "Next session — Leader Development",
-                "paragraphs": [
-                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              },
-              {
-                "title": "Next session — Facilitation vs. Lecture",
-                "paragraphs": [
-                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              },
-              {
-                "title": "Next session — Visual Aids",
-                "paragraphs": [
-                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              },
-              {
-                "title": "Next session — Vulnerability / Authenticity",
-                "paragraphs": [
-                  "Next time, open one teaching point with a first-person example that cost you something.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              },
-              {
-                "title": "Next session — Memory Reinforcement",
-                "paragraphs": [
-                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              }
-            ]
-          },
-          "sections": [
-            {
-              "title": "Score composition",
-              "paragraphs": [
-                "How the four weighted clusters and any session bonuses combined into the composite score."
-              ],
-              "bullets": [
-                "Teaching Craft: 80% × weight 33 → 26.40 pts",
-                "Building Ministry: 70% × weight 31 → 21.70 pts",
-                "Engaging People: 70% × weight 18 → 12.60 pts",
-                "Being Real: 70% × weight 18 → 12.60 pts",
-                "Base (sum of cluster contributions): 73.30 / 100",
-                "Session score: 73.3 / 100"
-              ]
-            },
-            {
-              "title": "Coaching notes by dimension",
-              "paragraphs": [
-                "The per-dimension rationale behind each score on the 12-dimension scorecard."
-              ],
-              "bullets": [
-                "Session Structure & Flow (4/5): Strong blueprint adherence; dual-leader handoff smooth; both prayers captured; homework anchored",
-                "Newcomer Welcome (N/A): No newcomers — Building Ministry max reduced proportionally",
-                "Scripture Engagement (5/5): 14 cross-references; Cameron's arc high; Isaiah 1 cross-ref at close exceptional",
-                "Facilitation vs. Lecture (3/5): ~30–35% leader talk; Cameron's best facilitation ratio in tracked arc; productive struggle honored",
-                "Application Questions (4/5): 10 Big Idea questions; 40% DOK 4; distributed throughout; productive struggle defended",
-                "Participant Engagement (4/5): ~13 members called by name; 12 distinct voices in discussion; strong go-around even if brief",
-                "Visual Aids (3/5): Russell's sin-progression diagram (Cameron invited it); no BLB on-screen; no leader-prepared visual",
-                "Vulnerability / Authenticity (3/5): Cameron: 3 mild disclosures; no high-cost personal moment; member vulnerability (Uri, Andy) present but not fully honored",
-                "Memory Reinforcement (4/5): Russell's 14-min review of James 1:1–11 + Cameron's Big Ideas opening; strong closing synthesis 'three things that cost you'",
-                "Homework References (5/5): Explicit page references (pg 25, 27, 28); homework structure spine of lesson; Cameron's arc high on this dimension",
-                "Prayer (4/5): Opening prayer by Cameron (Russell's invitation, on-topic); closing prayer delegated to Andy (substantive, applied lesson themes); prayer chain awareness implied",
-                "Leader Development (2/5): No visible apprentice or facilitation-window assignment; Russell is peer co-leader not Cameron's coachee; no 2:2 signal visible"
-              ]
-            }
-          ],
-          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
-          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
-        },
-        {
-          "id": "cameron-relic-2026-04-16-destruction-of-jerusalem-zedekia",
-          "date": "2026-04-16",
-          "dateLabel": "April 16, 2026",
-          "session": "Destruction of Jerusalem — Zedekiah, False Prophets, the Yoke of Babylon",
-          "topic": "God as main character; cyclical warnings; partial truth as lie; two masters",
-          "duration": "1h 54m (114 minutes)",
-          "attendees": 7,
-          "newcomers": 0,
-          "score": 70.66,
-          "base": 70.66,
-          "newcomerBonus": 0,
-          "sizeBonus": 0,
-          "status": "On Target",
-          "statusEmoji": "🟡",
-          "clusters": [
-            {
-              "name": "Teaching Craft",
-              "weight": 33,
-              "scorePct": 72,
-              "contribution": 23.76
-            },
-            {
-              "name": "Building Ministry",
-              "weight": 31,
-              "scorePct": 70,
-              "contribution": 21.7
-            },
-            {
-              "name": "Engaging People",
-              "weight": 18,
-              "scorePct": 60,
-              "contribution": 10.8
-            },
-            {
-              "name": "Being Real",
-              "weight": 18,
-              "scorePct": 80,
-              "contribution": 14.4
-            }
-          ],
-          "dimensions": [
-            {
-              "n": 1,
-              "name": "Session Structure & Flow",
-              "score": 4,
-              "note": "Clean arc; opens with retrieval; closes with Big Ideas but apologetic"
-            },
-            {
-              "n": 2,
-              "name": "Newcomer Welcome",
-              "score": null,
-              "note": "No newcomers present"
-            },
-            {
-              "n": 3,
-              "name": "Scripture Engagement",
-              "score": 5,
-              "note": "7 books triangulated on one narrative; 85% verse-grounded"
-            },
-            {
-              "n": 4,
-              "name": "Facilitation vs. Lecture",
-              "score": 2,
-              "note": "52% leader talk — 22 points above 30% target"
-            },
-            {
-              "n": 5,
-              "name": "Application Questions",
-              "score": 3,
-              "note": "6 Big Ideas at 83% DOK 3-4, but clustered late"
-            },
-            {
-              "n": 6,
-              "name": "Participant Engagement",
-              "score": 4,
-              "note": "83% read aloud; 50% discuss; named call-outs used well"
-            },
-            {
-              "n": 7,
-              "name": "Visual Aids",
-              "score": 1,
-              "note": "None observed — audio-plus-Bible only on dense parallel-passage session"
-            },
-            {
-              "n": 8,
-              "name": "Vulnerability / Authenticity",
-              "score": 4,
-              "note": "3 moments, 1 reciprocity peak; moderate depth overall"
-            },
-            {
-              "n": 9,
-              "name": "Memory Reinforcement",
-              "score": 5,
-              "note": "Retrieval-first opening — pedagogically strongest position"
-            },
-            {
-              "n": 10,
-              "name": "Homework References",
-              "score": 4,
-              "note": "Regular workbook references; lesson built on homework questions"
-            },
-            {
-              "n": 11,
-              "name": "Prayer",
-              "score": 4,
-              "note": "Opening delegated to Frank; closing delegated to John Relic (different member)"
-            },
-            {
-              "n": 12,
-              "name": "Leader Development",
-              "score": 3,
-              "note": "Solo leader (no co-teacher or mentor); no apprentice visible"
-            }
-          ],
-          "bigIdeas": [],
-          "feedback": {
-            "headline": "An on target session — strongest in Scripture Engagement and Memory Reinforcement, with the clearest next step in Visual Aids.",
-            "strengths": [
-              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-              "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
-              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place."
-            ],
-            "improvements": [
-              "The session leaned audio-only; a visual anchor would aid retention.",
-              "Leader talk crowded out discussion; the balance leaned toward lecture.",
-              "Questions stayed heady; few moved the group to first-person, personal application."
-            ],
-            "recommendations": [
-              "Next time, put one word-study lookup or a simple table on screen during the key term.",
-              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-              "Next time, pre-write 3 \"what does this look like for you this week?\" probes."
-            ],
-            "overview": [
-              "An on target session — strongest in Scripture Engagement and Memory Reinforcement, with the clearest next step in Visual Aids. It scored 70.66/100 under the v3 weighted model.",
-              "The session played to its strengths in Scripture Engagement and Memory Reinforcement; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
-            ],
-            "strengthsProse": [
-              {
-                "title": "Scripture Engagement anchored the session (5/5)",
-                "paragraphs": [
-                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 7 books triangulated on one narrative; 85% verse-grounded"
-                ]
-              },
-              {
-                "title": "Memory Reinforcement anchored the session (5/5)",
-                "paragraphs": [
-                  "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Retrieval-first opening — pedagogically strongest position"
-                ]
-              },
-              {
-                "title": "Session Structure & Flow anchored the session (4/5)",
-                "paragraphs": [
-                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: Clean arc; opens with retrieval; closes with Big Ideas but apologetic"
-                ]
-              },
-              {
-                "title": "Participant Engagement anchored the session (4/5)",
-                "paragraphs": [
-                  "A high share of the room contributed substantively, called on by name.",
-                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
-                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 83% read aloud; 50% discuss; named call-outs used well"
-                ]
-              },
-              {
-                "title": "Vulnerability / Authenticity anchored the session (4/5)",
-                "paragraphs": [
-                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
-                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
-                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
-                  "From the session: 3 moments, 1 reciprocity peak; moderate depth overall"
-                ]
-              }
-            ],
-            "improvementsProse": [
-              {
-                "title": "Visual Aids is a growth area (1/5)",
-                "paragraphs": [
-                  "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: None observed — audio-plus-Bible only on dense parallel-passage session"
-                ]
-              },
-              {
-                "title": "Facilitation vs. Lecture is a growth area (2/5)",
-                "paragraphs": [
-                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: 52% leader talk — 22 points above 30% target"
-                ]
-              },
-              {
-                "title": "Application Questions is a growth area (3/5)",
-                "paragraphs": [
-                  "Questions stayed heady; few moved the group to first-person, personal application.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: 6 Big Ideas at 83% DOK 3-4, but clustered late"
-                ]
-              },
-              {
-                "title": "Leader Development is a growth area (3/5)",
-                "paragraphs": [
-                  "No in-session development of another leader was observable this week.",
-                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Solo leader (no co-teacher or mentor); no apprentice visible"
-                ]
-              },
-              {
-                "title": "Homework References is a growth area (4/5)",
-                "paragraphs": [
-                  "Homework went unmentioned, reducing its pull on the group.",
-                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
-                  "From the session: Regular workbook references; lesson built on homework questions"
-                ]
-              }
-            ],
-            "recommendationsProse": [
-              {
-                "title": "Next session — Visual Aids",
-                "paragraphs": [
-                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              },
-              {
-                "title": "Next session — Facilitation vs. Lecture",
-                "paragraphs": [
-                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              },
-              {
-                "title": "Next session — Application Questions",
-                "paragraphs": [
-                  "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              },
-              {
-                "title": "Next session — Leader Development",
-                "paragraphs": [
-                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              },
-              {
-                "title": "Next session — Homework References",
-                "paragraphs": [
-                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              }
-            ]
-          },
-          "sections": [
-            {
-              "title": "Score composition",
-              "paragraphs": [
-                "How the four weighted clusters and any session bonuses combined into the composite score."
-              ],
-              "bullets": [
-                "Teaching Craft: 72% × weight 33 → 23.76 pts",
-                "Building Ministry: 70% × weight 31 → 21.70 pts",
-                "Engaging People: 60% × weight 18 → 10.80 pts",
-                "Being Real: 80% × weight 18 → 14.40 pts",
-                "Base (sum of cluster contributions): 70.66 / 100",
-                "Session score: 70.66 / 100"
-              ]
-            },
-            {
-              "title": "Coaching notes by dimension",
-              "paragraphs": [
-                "The per-dimension rationale behind each score on the 12-dimension scorecard."
-              ],
-              "bullets": [
-                "Session Structure & Flow (4/5): Clean arc; opens with retrieval; closes with Big Ideas but apologetic",
-                "Newcomer Welcome (N/A): No newcomers present",
-                "Scripture Engagement (5/5): 7 books triangulated on one narrative; 85% verse-grounded",
-                "Facilitation vs. Lecture (2/5): 52% leader talk — 22 points above 30% target",
-                "Application Questions (3/5): 6 Big Ideas at 83% DOK 3-4, but clustered late",
-                "Participant Engagement (4/5): 83% read aloud; 50% discuss; named call-outs used well",
-                "Visual Aids (1/5): None observed — audio-plus-Bible only on dense parallel-passage session",
-                "Vulnerability / Authenticity (4/5): 3 moments, 1 reciprocity peak; moderate depth overall",
-                "Memory Reinforcement (5/5): Retrieval-first opening — pedagogically strongest position",
-                "Homework References (4/5): Regular workbook references; lesson built on homework questions",
-                "Prayer (4/5): Opening delegated to Frank; closing delegated to John Relic (different member)",
-                "Leader Development (3/5): Solo leader (no co-teacher or mentor); no apprentice visible"
-              ]
-            }
-          ],
-          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
-          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
-        }
-      ]
-    },
-    {
       "id": "brendan-elizabeth",
       "name": "Brendan & Elizabeth",
-      "email": "brendan-elizabeth@needs-real-email.invalid",
+      "email": "bocojoywed@gmail.com",
       "group": "Couples Precept Study",
       "coachName": "Bryan Bailey",
       "isCoach": true,
@@ -17851,7 +17214,7 @@
     {
       "id": "jt-dettman",
       "name": "JT Dettman",
-      "email": "jt-dettman@needs-real-email.invalid",
+      "email": "jt.dettman@austinstone.org",
       "group": "Revelation Study",
       "coachName": "Bryan Bailey",
       "isCoach": true,
@@ -18430,7 +17793,7 @@
     {
       "id": "josh-samuels",
       "name": "Josh Samuels",
-      "email": "josh-samuels@needs-real-email.invalid",
+      "email": "jdub.samuels@gmail.com",
       "group": "James Study",
       "coachName": "Bryan Bailey",
       "isCoach": true,
@@ -18743,6 +18106,643 @@
                 "Homework References (3/5): Building Ministry",
                 "Prayer (4/5): Being Real",
                 "Leader Development (5/5): Building Ministry"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        }
+      ]
+    },
+    {
+      "id": "cameron-relic",
+      "name": "Cameron Relic",
+      "email": "cameron-relic@needs-real-email.invalid",
+      "group": "James Study",
+      "coachName": "Bryan Bailey",
+      "isCoach": true,
+      "zoomLink": "",
+      "reports": [
+        {
+          "id": "cameron-relic-2026-05-28-james-lesson-1-faith2see-group-c",
+          "date": "2026-05-28",
+          "dateLabel": "May 28, 2026",
+          "session": "James, Lesson 1 (faith2see group) — Crown of Life, Temptation, Doers of the Word, True Religion (Jas 1:12–27)",
+          "topic": "Trials vs. temptation; sin progression (lust→carried away→death); doers vs. hearers; bridling the tongue; pure religion",
+          "duration": "~2h 3m (6:00 PM – 8:03 PM CT; ended 5 min over target)",
+          "attendees": 15,
+          "newcomers": 0,
+          "score": 73.3,
+          "base": 73.3,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 80,
+              "contribution": 26.4
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 70,
+              "contribution": 21.7
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": "Strong blueprint adherence; dual-leader handoff smooth; both prayers captured; homework anchored"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": "No newcomers — Building Ministry max reduced proportionally"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "14 cross-references; Cameron's arc high; Isaiah 1 cross-ref at close exceptional"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "~30–35% leader talk; Cameron's best facilitation ratio in tracked arc; productive struggle honored"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "10 Big Idea questions; 40% DOK 4; distributed throughout; productive struggle defended"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "~13 members called by name; 12 distinct voices in discussion; strong go-around even if brief"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 3,
+              "note": "Russell's sin-progression diagram (Cameron invited it); no BLB on-screen; no leader-prepared visual"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 3,
+              "note": "Cameron: 3 mild disclosures; no high-cost personal moment; member vulnerability (Uri, Andy) present but not fully honored"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 4,
+              "note": "Russell's 14-min review of James 1:1–11 + Cameron's Big Ideas opening; strong closing synthesis 'three things that cost you'"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 5,
+              "note": "Explicit page references (pg 25, 27, 28); homework structure spine of lesson; Cameron's arc high on this dimension"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": "Opening prayer by Cameron (Russell's invitation, on-topic); closing prayer delegated to Andy (substantive, applied lesson themes); prayer chain awareness implied"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 2,
+              "note": "No visible apprentice or facilitation-window assignment; Russell is peer co-leader not Cameron's coachee; no 2:2 signal visible"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Scripture Engagement and Homework References, with the clearest next step in Leader Development.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Homework was referenced and rewarded, differentiating the members who prepared.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place."
+            ],
+            "improvements": [
+              "No in-session development of another leader was observable this week.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "The session leaned audio-only; a visual anchor would aid retention."
+            ],
+            "recommendations": [
+              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term."
+            ],
+            "overview": [
+              "A strong session — strongest in Scripture Engagement and Homework References, with the clearest next step in Leader Development. It scored 73.3/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Homework References; the recommendations below turn Leader Development into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 14 cross-references; Cameron's arc high; Isaiah 1 cross-ref at close exceptional"
+                ]
+              },
+              {
+                "title": "Homework References anchored the session (5/5)",
+                "paragraphs": [
+                  "Homework was referenced and rewarded, differentiating the members who prepared.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Explicit page references (pg 25, 27, 28); homework structure spine of lesson; Cameron's arc high on this dimension"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Strong blueprint adherence; dual-leader handoff smooth; both prayers captured; homework anchored"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 10 Big Idea questions; 40% DOK 4; distributed throughout; productive struggle defended"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: ~13 members called by name; 12 distinct voices in discussion; strong go-around even if brief"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Leader Development is a growth area (2/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: No visible apprentice or facilitation-window assignment; Russell is peer co-leader not Cameron's coachee; no 2:2 signal visible"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: ~30–35% leader talk; Cameron's best facilitation ratio in tracked arc; productive struggle honored"
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (3/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Russell's sin-progression diagram (Cameron invited it); no BLB on-screen; no leader-prepared visual"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Cameron: 3 mild disclosures; no high-cost personal moment; member vulnerability (Uri, Andy) present but not fully honored"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (4/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Russell's 14-min review of James 1:1–11 + Cameron's Big Ideas opening; strong closing synthesis 'three things that cost you'"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 80% × weight 33 → 26.40 pts",
+                "Building Ministry: 70% × weight 31 → 21.70 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 70% × weight 18 → 12.60 pts",
+                "Base (sum of cluster contributions): 73.30 / 100",
+                "Session score: 73.3 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Strong blueprint adherence; dual-leader handoff smooth; both prayers captured; homework anchored",
+                "Newcomer Welcome (N/A): No newcomers — Building Ministry max reduced proportionally",
+                "Scripture Engagement (5/5): 14 cross-references; Cameron's arc high; Isaiah 1 cross-ref at close exceptional",
+                "Facilitation vs. Lecture (3/5): ~30–35% leader talk; Cameron's best facilitation ratio in tracked arc; productive struggle honored",
+                "Application Questions (4/5): 10 Big Idea questions; 40% DOK 4; distributed throughout; productive struggle defended",
+                "Participant Engagement (4/5): ~13 members called by name; 12 distinct voices in discussion; strong go-around even if brief",
+                "Visual Aids (3/5): Russell's sin-progression diagram (Cameron invited it); no BLB on-screen; no leader-prepared visual",
+                "Vulnerability / Authenticity (3/5): Cameron: 3 mild disclosures; no high-cost personal moment; member vulnerability (Uri, Andy) present but not fully honored",
+                "Memory Reinforcement (4/5): Russell's 14-min review of James 1:1–11 + Cameron's Big Ideas opening; strong closing synthesis 'three things that cost you'",
+                "Homework References (5/5): Explicit page references (pg 25, 27, 28); homework structure spine of lesson; Cameron's arc high on this dimension",
+                "Prayer (4/5): Opening prayer by Cameron (Russell's invitation, on-topic); closing prayer delegated to Andy (substantive, applied lesson themes); prayer chain awareness implied",
+                "Leader Development (2/5): No visible apprentice or facilitation-window assignment; Russell is peer co-leader not Cameron's coachee; no 2:2 signal visible"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "cameron-relic-2026-04-16-destruction-of-jerusalem-zedekia",
+          "date": "2026-04-16",
+          "dateLabel": "April 16, 2026",
+          "session": "Destruction of Jerusalem — Zedekiah, False Prophets, the Yoke of Babylon",
+          "topic": "God as main character; cyclical warnings; partial truth as lie; two masters",
+          "duration": "1h 54m (114 minutes)",
+          "attendees": 7,
+          "newcomers": 0,
+          "score": 70.66,
+          "base": 70.66,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "On Target",
+          "statusEmoji": "🟡",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 72,
+              "contribution": 23.76
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 70,
+              "contribution": 21.7
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 60,
+              "contribution": 10.8
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": "Clean arc; opens with retrieval; closes with Big Ideas but apologetic"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": "No newcomers present"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "7 books triangulated on one narrative; 85% verse-grounded"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 2,
+              "note": "52% leader talk — 22 points above 30% target"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 3,
+              "note": "6 Big Ideas at 83% DOK 3-4, but clustered late"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "83% read aloud; 50% discuss; named call-outs used well"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 1,
+              "note": "None observed — audio-plus-Bible only on dense parallel-passage session"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": "3 moments, 1 reciprocity peak; moderate depth overall"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 5,
+              "note": "Retrieval-first opening — pedagogically strongest position"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 4,
+              "note": "Regular workbook references; lesson built on homework questions"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": "Opening delegated to Frank; closing delegated to John Relic (different member)"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 3,
+              "note": "Solo leader (no co-teacher or mentor); no apprentice visible"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "An on target session — strongest in Scripture Engagement and Memory Reinforcement, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "Questions stayed heady; few moved the group to first-person, personal application."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, pre-write 3 \"what does this look like for you this week?\" probes."
+            ],
+            "overview": [
+              "An on target session — strongest in Scripture Engagement and Memory Reinforcement, with the clearest next step in Visual Aids. It scored 70.66/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Memory Reinforcement; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 7 books triangulated on one narrative; 85% verse-grounded"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement anchored the session (5/5)",
+                "paragraphs": [
+                  "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Retrieval-first opening — pedagogically strongest position"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Clean arc; opens with retrieval; closes with Big Ideas but apologetic"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 83% read aloud; 50% discuss; named call-outs used well"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity anchored the session (4/5)",
+                "paragraphs": [
+                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 3 moments, 1 reciprocity peak; moderate depth overall"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (1/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: None observed — audio-plus-Bible only on dense parallel-passage session"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (2/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 52% leader talk — 22 points above 30% target"
+                ]
+              },
+              {
+                "title": "Application Questions is a growth area (3/5)",
+                "paragraphs": [
+                  "Questions stayed heady; few moved the group to first-person, personal application.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 6 Big Ideas at 83% DOK 3-4, but clustered late"
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (3/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Solo leader (no co-teacher or mentor); no apprentice visible"
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (4/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Regular workbook references; lesson built on homework questions"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Application Questions",
+                "paragraphs": [
+                  "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 72% × weight 33 → 23.76 pts",
+                "Building Ministry: 70% × weight 31 → 21.70 pts",
+                "Engaging People: 60% × weight 18 → 10.80 pts",
+                "Being Real: 80% × weight 18 → 14.40 pts",
+                "Base (sum of cluster contributions): 70.66 / 100",
+                "Session score: 70.66 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Clean arc; opens with retrieval; closes with Big Ideas but apologetic",
+                "Newcomer Welcome (N/A): No newcomers present",
+                "Scripture Engagement (5/5): 7 books triangulated on one narrative; 85% verse-grounded",
+                "Facilitation vs. Lecture (2/5): 52% leader talk — 22 points above 30% target",
+                "Application Questions (3/5): 6 Big Ideas at 83% DOK 3-4, but clustered late",
+                "Participant Engagement (4/5): 83% read aloud; 50% discuss; named call-outs used well",
+                "Visual Aids (1/5): None observed — audio-plus-Bible only on dense parallel-passage session",
+                "Vulnerability / Authenticity (4/5): 3 moments, 1 reciprocity peak; moderate depth overall",
+                "Memory Reinforcement (5/5): Retrieval-first opening — pedagogically strongest position",
+                "Homework References (4/5): Regular workbook references; lesson built on homework questions",
+                "Prayer (4/5): Opening delegated to Frank; closing delegated to John Relic (different member)",
+                "Leader Development (3/5): Solo leader (no co-teacher or mentor); no apprentice visible"
               ]
             }
           ],

--- a/packages/backend-base/src/coach/coach.data.json
+++ b/packages/backend-base/src/coach/coach.data.json
@@ -2,9 +2,7 @@
   "schemaVersion": 2,
   "generatedAt": "2026-07-21",
   "model": "v3-weighted-100",
-  "admins": [
-    "andytryba@gmail.com"
-  ],
+  "admins": ["andytryba@gmail.com"],
   "clusters": [
     {
       "name": "Teaching Craft",

--- a/packages/backend-base/src/coach/coach.data.json
+++ b/packages/backend-base/src/coach/coach.data.json
@@ -2,7 +2,9 @@
   "schemaVersion": 2,
   "generatedAt": "2026-07-21",
   "model": "v3-weighted-100",
-  "admins": ["andytryba@gmail.com"],
+  "admins": [
+    "andytryba@gmail.com"
+  ],
   "clusters": [
     {
       "name": "Teaching Craft",
@@ -2652,6 +2654,25 @@
               "paragraphs": [
                 "These are the disproportionate moments in this session — the exchanges that shaped what this group will remember, believe, and do. Aggregated scores average these away; Key Moments names each one explicitly so Bryan can rewatch with intent."
               ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "What do we know about the author, background, and recipients — tell Cole what he needs to know? — Level 2 — Compare/analyze",
+                "What's the summary of trials — what are we supposed to understand and do with them? — Level 3 — Reason/justify",
+                "What does the prayer of a doubting man sound like — pray it for us? — Level 3 — Reason/justify",
+                "Where is the source of temptation located, according to this passage? — Level 2 — Compare/analyze",
+                "What is at the heart of every sin? — Level 4 — Apply to life",
+                "Why is the temptation passage the next topic after trials? What connects them? — Level 4 — Apply to life",
+                "What's the big idea of James 1:17–18 — every good thing is from above — and how does it connect to lust/sin/death? — Level 3 — Reason/justify",
+                "What does it mean to 'delude yourself' as a hearer only? — Level 3 — Reason/justify",
+                "Contrast: Tristan is stained by the world. What does that look like? Pocan is not stained. What does that look like? — Level 4 — Apply to life",
+                "Who are the orphans and widows in your life? What does your tongue reveal about what you actually believe? — Level 4 — Apply to life",
+                "What's your practical takeaway — rubber meets the road — from James 1:12–27? — Level 4 — Apply to life"
+              ],
+              "paragraphs": [
+                "Big-Idea questions from the session, scored by Webb’s Depth-of-Knowledge (DOK) level. Reading/navigation prompts are excluded."
+              ]
             }
           ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
@@ -3021,6 +3042,23 @@
               "paragraphs": [
                 "These are the 5 disproportionate moments in the session — exchanges that shaped what this group will remember, believe, and carry out. Ordered by impact."
               ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "What does your faith do? (overarching Big Idea for the book of James) — Level 4 — Apply to life",
+                "If you're God, what's the first message you give to persecuted Christians on the run? — Level 4 — Apply to life",
+                "Joy as happiness vs. joy as verdict — what's the difference? — Level 3 — Reason/justify",
+                "What does it mean to 'remain under' the weight of a trial? — Level 3 — Reason/justify",
+                "What would be a barrier to receiving this teaching? — Level 3 — Reason/justify",
+                "What's the difference between praying in faith vs. praying without faith? — Level 3 — Reason/justify",
+                "Is there a parenting technique in this passage? — Level 4 — Apply to life",
+                "What's the advantage of being rich in this world? What's the disadvantage? — Level 3 — Reason/justify",
+                "What are the Big Ideas we're taking from James 1:1–11 today? — Level 4 — Apply to life"
+              ],
+              "paragraphs": [
+                "Big-Idea questions from the session, scored by Webb’s Depth-of-Knowledge (DOK) level. Reading/navigation prompts are excluded."
+              ]
             }
           ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
@@ -3384,6 +3422,20 @@
               "paragraphs": [
                 "These are the 5 disproportionate moments in the session — the exchanges that shaped what this group will remember, believe, and do. Aggregated scores average these away; Key Moments name each one explicitly so Bryan can rewatch with intent."
               ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "If you were God writing the first message to people fleeing persecution, what kind of message would you convey? — Level 4 — Apply to life",
+                "What would be a barrier to receiving this teaching — something that makes it impossible to accept? — Level 3 — Reason/justify",
+                "How do you know if you've gotten God's wisdom? — Level 4 — Apply to life",
+                "Rich and poor face completely different challenges. What is the same solution they both need? — Level 3 — Reason/justify",
+                "What would you go home and tell your wife, girlfriend, daughter, or call your mama about from tonight? — Level 4 — Apply to life",
+                "Why does James say 'when' you encounter trials — not 'if'? — Level 3 — Reason/justify"
+              ],
+              "paragraphs": [
+                "Big-Idea questions from the session, scored by Webb’s Depth-of-Knowledge (DOK) level. Reading/navigation prompts are excluded."
+              ]
             }
           ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
@@ -3730,6 +3782,23 @@
                 "Bumper sticker method explained + executed: Yes — modeled then applied throughout  (Target: Key technique for Lesson 1)  → STRONG",
                 "Big Ideas accumulated at close: Yes — Russ reviewed all bumper stickers [01:56:47]  (Target: 1–2 takeaways reinforced)  → STRONG",
                 "Rabbinical structure / chiasm taught: Yes — chiasm explained, center verse identified [01:23:50]  (Target: Advanced hermeneutic)  → STRONG"
+              ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "Consider it all joy when you meet trials — what’s actually being said? What’s the message? (James 1:2–4) — Level 3 — Reason/justify",
+                "What is wisdom? What’s the difference between earthly wisdom and applied knowledge? And why do you need God’s viewpoint? (James 1:5–8) — Level 2 — Compare/analyze",
+                "What is the test of wholehearted faith here — about your view of your status, your position? (James 1:9–11) — Level 3 — Reason/justify",
+                "What is the source of your sin? Who’s responsible? (James 1:12–18) — Level 3 — Reason/justify",
+                "You say you believe — but what do you actually do? How do you reconcile belief that isn’t reflected in behavior? (James 1:19–25) — Level 4 — Apply to life",
+                "How does James define worthless religion? How does he define pure and undefiled religion? What’s the test? (James 1:26–27) — Level 4 — Apply to life",
+                "If faith has no works, what does James say? What’s the new idea being introduced? (James 2:14–17) — Level 3 — Reason/justify",
+                "If you’re driven by friendship with the world — what does that make you in relation to God? (James 4:4) — Level 3 — Reason/justify",
+                "What makes prayer effective? What does Elijah’s example teach us about how to pray? (James 5:13–18) — Level 4 — Apply to life"
+              ],
+              "paragraphs": [
+                "Big-Idea questions from the session, scored by Webb’s Depth-of-Knowledge (DOK) level. Reading/navigation prompts are excluded."
               ]
             }
           ],
@@ -4081,6 +4150,32 @@
                 "Topic drift: 3% (Joe Rogan/Logan Paul, kids' homework, Bible filter)  (Target: <10%)  → STRONG",
                 "Periodic summaries: Yes — true/false prophet dual-column synthesis  (Target: At key points)  → STRONG",
                 "Big Ideas at close: Cited not recited (4 named, group did not speak)  (Target: 1–2 takeaways actively reinforced)  → NEEDS WORK"
+              ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "What are you learning about God here? (Jer 22:24-30, Coniah) — Level 3 — Reason/justify",
+                "Is that [warning-then-judgment pattern] going to be true for us one day? — Level 4 — Apply to life",
+                "What's the connection between pride, that viewpoint, and repentance? (Big Idea bumper-sticker moment) — Level 4 — Apply to life",
+                "You can get to a point with God where there's no remedy. What would that mean? (2 Chron 36:16) — Level 4 — Apply to life",
+                "God has other people on His payroll. How is that informed — how you pray? (Jer 27:5-7) — Level 4 — Apply to life",
+                "A true prophet calls for submission. A false prophet — what do they call for? — Level 3 — Reason/justify",
+                "Zedekiah asks for prayer without submitting. What would you call that? (Produced ‘spiritual hypocrisy’) — Level 3 — Reason/justify",
+                "What does it say about a Christian who faces no opposition, no persecution? (Jer 37 → 2 Tim 3) — Level 4 — Apply to life",
+                "What else do you see? — Level 2 — Compare/analyze",
+                "What do we see about what role has God played in this story? — Level 2 — Compare/analyze",
+                "What do we learn about the opponent that's going to administer the consequences from verse 7? — Level 2 — Compare/analyze",
+                "Okay, what do you see about God's judgment? — Level 2 — Compare/analyze",
+                "What are we seeing here? What's God's build up for himself? — Level 2 — Compare/analyze",
+                "What do we really get behind the curtain now? What do you see in verses 8-10? — Level 2 — Compare/analyze",
+                "Now we've changed target audience. Jeremiah's now speaking to whom? — Level 2 — Compare/analyze",
+                "Based on how this ends, what appears to be the purpose of the Babylonian act here? — Level 2 — Compare/analyze",
+                "Now you're going — who's right, who's wrong, you think? — Level 2 — Compare/analyze",
+                "What did you just have? You have a repeated theme — which slogan does this fit nicely into? — Level 2 — Compare/analyze"
+              ],
+              "paragraphs": [
+                "Big-Idea questions from the session, scored by Webb’s Depth-of-Knowledge (DOK) level. Reading/navigation prompts are excluded."
               ]
             }
           ],
@@ -4447,6 +4542,44 @@
                 "Discussion / Application time: 12%  (Target: 24%)  → ↑↑ Major Gain",
                 "Overall Score: 52/60 (L1)  (Target: 49/55 (A-))  → → Stable"
               ]
+            },
+            {
+              "title": "Application Questions",
+              "bullets": [
+                "Why does he get angry? — Level 3 — Reason/justify",
+                "Why does he get angry about us? — Level 3 — Reason/justify",
+                "Can God abandon you? — Level 4 — Apply to life",
+                "What does it mean that God doesn't support your flesh? — Level 3 — Reason/justify",
+                "What is a prayer of a believer seeking to have his flesh affirmed? — Level 4 — Apply to life",
+                "What's a better prayer? — Level 3 — Reason/justify",
+                "What's God telling the people in exile? — Level 3 — Reason/justify",
+                "Why is this new covenant? What's the motive? — Level 4 — Apply to life",
+                "Is salvation about you or about him? — Level 4 — Apply to life",
+                "True obedience requires what? — Level 3 — Reason/justify",
+                "What defines the kings being red, being evil? What defines being not good? — Level 2 — Compare/analyze",
+                "What about the southern kingdom, Judah? What do you notice? — Level 2 — Compare/analyze",
+                "What else? What's another big idea? — Level 1 — Simple recall",
+                "What do you see about the political situation? — Level 2 — Compare/analyze",
+                "What do you see going on down? What's happening? — Level 2 — Compare/analyze",
+                "What do you see that was added in Chronicles? — Level 2 — Compare/analyze",
+                "What is the meaning behind discipline from God? — Level 3 — Reason/justify",
+                "Who are the people that are the good figs? — Level 2 — Compare/analyze",
+                "What does that sound like? A new covenant? — Level 2 — Compare/analyze",
+                "What's happening to the ones that stay behind? — Level 2 — Compare/analyze",
+                "You're seeing God's kingdom upside down — what's happening here? — Level 3 — Reason/justify",
+                "What does it mean to be blessed? — Level 3 — Reason/justify",
+                "What are the prophets saying in this time of captivity? — Level 2 — Compare/analyze",
+                "What would be the opposite of what God said in verse 4 through 7? — Level 3 — Reason/justify",
+                "What are the features of this new covenant? — Level 2 — Compare/analyze",
+                "What does that mean — they will know me? — Level 3 — Reason/justify",
+                "What are the promises from Ezekiel 36? — Level 2 — Compare/analyze",
+                "What does it mean — new heart, new spirit? — Level 3 — Reason/justify",
+                "What's next on the list? — Level 1 — Simple recall",
+                "What's the last promise? — Level 1 — Simple recall"
+              ],
+              "paragraphs": [
+                "Big-Idea questions from the session, scored by Webb’s Depth-of-Knowledge (DOK) level. Reading/navigation prompts are excluded."
+              ]
             }
           ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
@@ -4457,24 +4590,24 @@
     {
       "id": "jeff-ward",
       "name": "Jeff Ward",
-      "email": "jeff.ward@example.com",
+      "email": "jeff@simpledonation.com",
       "group": "Colossians (Precept)",
       "coachName": "Bryan Bailey",
       "isCoach": true,
       "zoomLink": "",
       "reports": [
         {
-          "id": "jeff-ward-2026-04-08-colossians-ch-4-precept",
-          "date": "2026-04-08",
-          "dateLabel": "April 8, 2026",
-          "session": "Colossians Ch. 4 (Precept)",
-          "topic": "Colossians 4 — Devote Yourselves to Prayer",
-          "duration": "~1 hr 32 min",
-          "attendees": 11,
-          "newcomers": 0,
-          "score": 69.34,
-          "base": 69.34,
-          "newcomerBonus": 0,
+          "id": "jeff-ward-2026-05-27-james-1-1-12-session-2-of-the-pr",
+          "date": "2026-05-27",
+          "dateLabel": "May 27, 2026",
+          "session": "James 1:1–12 — Session 2 of the Precept James study",
+          "topic": "Trials, testing, steadfastness, wisdom — James 1:2–12",
+          "duration": "~1h 44m",
+          "attendees": 9,
+          "newcomers": 1,
+          "score": 64.1,
+          "base": 63.1,
+          "newcomerBonus": 1,
           "sizeBonus": 0,
           "status": "On Target",
           "statusEmoji": "🟡",
@@ -4482,8 +4615,8 @@
             {
               "name": "Teaching Craft",
               "weight": 33,
-              "scorePct": 68,
-              "contribution": 22.44
+              "scorePct": 60,
+              "contribution": 19.8
             },
             {
               "name": "Building Ministry",
@@ -4500,124 +4633,132 @@
             {
               "name": "Being Real",
               "weight": 18,
-              "scorePct": 70,
-              "contribution": 12.6
+              "scorePct": 50,
+              "contribution": 9
             }
           ],
           "dimensions": [
             {
               "n": 1,
               "name": "Session Structure & Flow",
-              "score": 4,
-              "note": ""
+              "score": 3,
+              "note": "Review present; opening prayer not delegated; newcomer welcome minimal"
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
-              "score": null,
-              "note": ""
+              "score": 2,
+              "note": "Wilson present; two-line intro only; no member testimonies"
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
-              "score": 4,
-              "note": ""
+              "score": 5,
+              "note": "10 passages across 6 books; Greek word studies; all purposeful"
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
               "score": 3,
-              "note": ""
+              "note": "~35% leader talk in discussion (on-target); one long 5-min monologue"
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 3,
-              "note": ""
+              "score": 4,
+              "note": "10 Big Idea questions; 80% at DOK 3–4"
             },
             {
               "n": 6,
               "name": "Participant Engagement",
               "score": 4,
-              "note": ""
+              "note": "~88% participation; multiple named call-outs; Wilson welcomed"
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 3,
-              "note": ""
+              "score": 1,
+              "note": "None used (fourth consecutive session)"
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
-              "score": 3,
-              "note": ""
+              "score": 2,
+              "note": "2 reflective-level disclosures; no current personal-cost moment"
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
-              "score": 3,
-              "note": ""
+              "score": 2,
+              "note": "Bible memory discussed; no formal Big Ideas recitation"
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 4,
-              "note": ""
+              "score": 5,
+              "note": "9 explicit workbook page/question references; strongest across 4 sessions"
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 4,
-              "note": ""
+              "score": 3,
+              "note": "Opening not delegated; closing delegated effectively to Ron"
             },
             {
               "n": 12,
               "name": "Leader Development",
-              "score": 3,
-              "note": ""
+              "score": null,
+              "note": "Solo-leading; no apprentice or mentor present"
             }
           ],
-          "bigIdeas": [
-            "Devote yourselves to prayer",
-            "Let your speech be seasoned with salt"
-          ],
+          "bigIdeas": [],
           "feedback": {
-            "headline": "An on target session — strongest in Session Structure & Flow and Scripture Engagement, with the clearest next step in Facilitation vs. Lecture.",
+            "headline": "An on target session — strongest in Scripture Engagement and Homework References, with the clearest next step in Visual Aids.",
             "strengths": [
-              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
               "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
-              "A high share of the room contributed substantively, called on by name."
+              "Homework was referenced and rewarded, differentiating the members who prepared.",
+              "Application questions pushed members from concept to life, several at the reason/apply level."
             ],
             "improvements": [
-              "Leader talk crowded out discussion; the balance leaned toward lecture.",
-              "Questions stayed heady; few moved the group to first-person, personal application.",
-              "The session leaned audio-only; a visual anchor would aid retention."
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+              "Teaching stayed at arm’s length; little personal cost was modeled."
             ],
             "recommendations": [
-              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-              "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
-              "Next time, put one word-study lookup or a simple table on screen during the key term."
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+              "Next time, open one teaching point with a first-person example that cost you something."
             ],
             "overview": [
-              "An on target session — strongest in Session Structure & Flow and Scripture Engagement, with the clearest next step in Facilitation vs. Lecture. It scored 69.34/100 under the v3 weighted model.",
-              "The session played to its strengths in Session Structure & Flow and Scripture Engagement; the recommendations below turn Facilitation vs. Lecture into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+              "An on target session — strongest in Scripture Engagement and Homework References, with the clearest next step in Visual Aids. It scored 64.1/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Homework References; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
             ],
             "strengthsProse": [
               {
-                "title": "Session Structure & Flow anchored the session (4/5)",
-                "paragraphs": [
-                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
-                ]
-              },
-              {
-                "title": "Scripture Engagement anchored the session (4/5)",
+                "title": "Scripture Engagement anchored the session (5/5)",
                 "paragraphs": [
                   "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
                   "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 10 passages across 6 books; Greek word studies; all purposeful"
+                ]
+              },
+              {
+                "title": "Homework References anchored the session (5/5)",
+                "paragraphs": [
+                  "Homework was referenced and rewarded, differentiating the members who prepared.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 9 explicit workbook page/question references; strongest across 4 sessions"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 10 Big Idea questions; 80% at DOK 3–4"
                 ]
               },
               {
@@ -4625,91 +4766,82 @@
                 "paragraphs": [
                   "A high share of the room contributed substantively, called on by name.",
                   "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
-                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: ~88% participation; multiple named call-outs; Wilson welcomed"
                 ]
               },
               {
-                "title": "Homework References anchored the session (4/5)",
+                "title": "Session Structure & Flow anchored the session (3/5)",
                 "paragraphs": [
-                  "Homework was referenced and rewarded, differentiating the members who prepared.",
-                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
-                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
-                ]
-              },
-              {
-                "title": "Prayer anchored the session (4/5)",
-                "paragraphs": [
-                  "Prayer was delegated to members, opening and closing the group in shared voice.",
-                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
-                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Review present; opening prayer not delegated; newcomer welcome minimal"
                 ]
               }
             ],
             "improvementsProse": [
               {
+                "title": "Visual Aids is a growth area (1/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: None used (fourth consecutive session)"
+                ]
+              },
+              {
+                "title": "Newcomer Welcome is a growth area (2/5)",
+                "paragraphs": [
+                  "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Wilson present; two-line intro only; no member testimonies"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (2/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 2 reflective-level disclosures; no current personal-cost moment"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (2/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Bible memory discussed; no formal Big Ideas recitation"
+                ]
+              },
+              {
                 "title": "Facilitation vs. Lecture is a growth area (3/5)",
                 "paragraphs": [
                   "Leader talk crowded out discussion; the balance leaned toward lecture.",
                   "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              },
-              {
-                "title": "Application Questions is a growth area (3/5)",
-                "paragraphs": [
-                  "Questions stayed heady; few moved the group to first-person, personal application.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              },
-              {
-                "title": "Visual Aids is a growth area (3/5)",
-                "paragraphs": [
-                  "The session leaned audio-only; a visual anchor would aid retention.",
-                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              },
-              {
-                "title": "Vulnerability / Authenticity is a growth area (3/5)",
-                "paragraphs": [
-                  "Teaching stayed at arm’s length; little personal cost was modeled.",
-                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
-                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              },
-              {
-                "title": "Memory Reinforcement is a growth area (3/5)",
-                "paragraphs": [
-                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
-                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: ~35% leader talk in discussion (on-target); one long 5-min monologue"
                 ]
               }
             ],
             "recommendationsProse": [
-              {
-                "title": "Next session — Facilitation vs. Lecture",
-                "paragraphs": [
-                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              },
-              {
-                "title": "Next session — Application Questions",
-                "paragraphs": [
-                  "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
-                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              },
               {
                 "title": "Next session — Visual Aids",
                 "paragraphs": [
                   "Next time, put one word-study lookup or a simple table on screen during the key term.",
                   "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
                   "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Newcomer Welcome",
+                "paragraphs": [
+                  "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
@@ -4727,6 +4859,14 @@
                   "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
                   "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
               }
             ]
           },
@@ -4737,12 +4877,346 @@
                 "How the four weighted clusters and any session bonuses combined into the composite score."
               ],
               "bullets": [
-                "Teaching Craft: 68% × weight 33 → 22.44 pts",
+                "Teaching Craft: 60% × weight 33 → 19.80 pts",
                 "Building Ministry: 70% × weight 31 → 21.70 pts",
                 "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 50% × weight 18 → 9.00 pts",
+                "Base (sum of cluster contributions): 63.10 / 100",
+                "Session bonuses: newcomer growth +1",
+                "Session score: 64.1 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3/5): Review present; opening prayer not delegated; newcomer welcome minimal",
+                "Newcomer Welcome (2/5): Wilson present; two-line intro only; no member testimonies",
+                "Scripture Engagement (5/5): 10 passages across 6 books; Greek word studies; all purposeful",
+                "Facilitation vs. Lecture (3/5): ~35% leader talk in discussion (on-target); one long 5-min monologue",
+                "Application Questions (4/5): 10 Big Idea questions; 80% at DOK 3–4",
+                "Participant Engagement (4/5): ~88% participation; multiple named call-outs; Wilson welcomed",
+                "Visual Aids (1/5): None used (fourth consecutive session)",
+                "Vulnerability / Authenticity (2/5): 2 reflective-level disclosures; no current personal-cost moment",
+                "Memory Reinforcement (2/5): Bible memory discussed; no formal Big Ideas recitation",
+                "Homework References (5/5): 9 explicit workbook page/question references; strongest across 4 sessions",
+                "Prayer (3/5): Opening not delegated; closing delegated effectively to Ron",
+                "Leader Development (N/A): Solo-leading; no apprentice or mentor present"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "jeff-ward-2026-04-08-precept-colossians-study-chapter",
+          "date": "2026-04-08",
+          "dateLabel": "April 8, 2026",
+          "session": "Precept Colossians Study — Chapter 4 (Final Session)",
+          "topic": "Prayer, Walking in Wisdom Toward Outsiders, Personal Greetings",
+          "duration": "1h 36m 30s (~96.5 minutes)",
+          "attendees": 7,
+          "newcomers": 0,
+          "score": 69,
+          "base": 69,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "On Target",
+          "statusEmoji": "🟡",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 60,
+              "contribution": 19.8
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 60,
+              "contribution": 18.6
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 100,
+              "contribution": 18
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": "Follows Precept workbook structure; good transitions; review section effective"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": "No newcomers present — not scored"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 4,
+              "note": "12 cross-references across 8 books; strong internal Colossians connections"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 5,
+              "note": "32% leader talk in discussion; exceptional for a first evaluation"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "8 Big Idea questions; 87.5% at DOK 3-4; spacing even throughout"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 5,
+              "note": "83% participation; strong peer-to-peer interaction; good wait time"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 1,
+              "note": "No visual aids used; no screen sharing on Zoom"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 3,
+              "note": "4 moments at moderate depth; honest but not deeply costly disclosures"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 2,
+              "note": "Structural review present but no cumulative Big Ideas recall"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 4,
+              "note": "Regular workbook page references; encouraged completion; no 'Guarantee' moment"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": "Opening prayer not delegated; closing prayer effectively delegated"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 2,
+              "note": "No apprentice or co-leader visible; solo leadership model currently"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "An on target session — strongest in Facilitation vs. Lecture and Participant Engagement, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+              "A high share of the room contributed substantively, called on by name.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+              "No in-session development of another leader was observable this week."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\""
+            ],
+            "overview": [
+              "An on target session — strongest in Facilitation vs. Lecture and Participant Engagement, with the clearest next step in Visual Aids. It scored 69/100 under the v3 weighted model.",
+              "The session played to its strengths in Facilitation vs. Lecture and Participant Engagement; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Facilitation vs. Lecture anchored the session (5/5)",
+                "paragraphs": [
+                  "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 32% leader talk in discussion; exceptional for a first evaluation"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 83% participation; strong peer-to-peer interaction; good wait time"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Follows Precept workbook structure; good transitions; review section effective"
+                ]
+              },
+              {
+                "title": "Scripture Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 12 cross-references across 8 books; strong internal Colossians connections"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 8 Big Idea questions; 87.5% at DOK 3-4; spacing even throughout"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (1/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: No visual aids used; no screen sharing on Zoom"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (2/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Structural review present but no cumulative Big Ideas recall"
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (2/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: No apprentice or co-leader visible; solo leadership model currently"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 4 moments at moderate depth; honest but not deeply costly disclosures"
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (4/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Regular workbook page references; encouraged completion; no 'Guarantee' moment"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 60% × weight 33 → 19.80 pts",
+                "Building Ministry: 60% × weight 31 → 18.60 pts",
+                "Engaging People: 100% × weight 18 → 18.00 pts",
                 "Being Real: 70% × weight 18 → 12.60 pts",
-                "Base (sum of cluster contributions): 69.34 / 100",
-                "Session score: 69.34 / 100"
+                "Base (sum of cluster contributions): 69.00 / 100",
+                "Session score: 69 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Follows Precept workbook structure; good transitions; review section effective",
+                "Newcomer Welcome (N/A): No newcomers present — not scored",
+                "Scripture Engagement (4/5): 12 cross-references across 8 books; strong internal Colossians connections",
+                "Facilitation vs. Lecture (5/5): 32% leader talk in discussion; exceptional for a first evaluation",
+                "Application Questions (4/5): 8 Big Idea questions; 87.5% at DOK 3-4; spacing even throughout",
+                "Participant Engagement (5/5): 83% participation; strong peer-to-peer interaction; good wait time",
+                "Visual Aids (1/5): No visual aids used; no screen sharing on Zoom",
+                "Vulnerability / Authenticity (3/5): 4 moments at moderate depth; honest but not deeply costly disclosures",
+                "Memory Reinforcement (2/5): Structural review present but no cumulative Big Ideas recall",
+                "Homework References (4/5): Regular workbook page references; encouraged completion; no 'Guarantee' moment",
+                "Prayer (4/5): Opening prayer not delegated; closing prayer effectively delegated",
+                "Leader Development (2/5): No apprentice or co-leader visible; solo leadership model currently"
               ]
             }
           ],
@@ -5037,16 +5511,16 @@
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         },
         {
-          "id": "jeff-ward-2026-03-18-colossians-3-1-4-precept",
+          "id": "jeff-ward-2026-03-18-precept-colossians-study-colossi",
           "date": "2026-03-18",
           "dateLabel": "March 18, 2026",
-          "session": "Colossians 3:1-4 (Precept)",
-          "topic": "Colossians 3:1-4 — Set Your Minds on Things Above",
-          "duration": "~1 hr 30 min",
-          "attendees": 9,
+          "session": "Precept Colossians Study — Colossians 3:1-4",
+          "topic": "Set Your Mind on Things Above; Grace vs. Legalism; Being Transformed",
+          "duration": "1h 43m (~103 minutes)",
+          "attendees": 8,
           "newcomers": 0,
-          "score": 54.24,
-          "base": 54.24,
+          "score": 56.06,
+          "base": 56.06,
           "newcomerBonus": 0,
           "sizeBonus": 0,
           "status": "Developing",
@@ -5055,26 +5529,26 @@
             {
               "name": "Teaching Craft",
               "weight": 33,
-              "scorePct": 48,
-              "contribution": 15.84
+              "scorePct": 52,
+              "contribution": 17.16
             },
             {
               "name": "Building Ministry",
               "weight": 31,
-              "scorePct": 60,
-              "contribution": 18.6
+              "scorePct": 50,
+              "contribution": 15.5
             },
             {
               "name": "Engaging People",
               "weight": 18,
-              "scorePct": 50,
-              "contribution": 9
+              "scorePct": 80,
+              "contribution": 14.4
             },
             {
               "name": "Being Real",
               "weight": 18,
-              "scorePct": 60,
-              "contribution": 10.8
+              "scorePct": 50,
+              "contribution": 9
             }
           ],
           "dimensions": [
@@ -5082,107 +5556,123 @@
               "n": 1,
               "name": "Session Structure & Flow",
               "score": 3,
-              "note": ""
+              "note": "7 of 10 steps present; pre-session and closing overran; no closing prayer"
             },
             {
               "n": 2,
               "name": "Newcomer Welcome",
               "score": null,
-              "note": ""
+              "note": "No newcomers present"
             },
             {
               "n": 3,
               "name": "Scripture Engagement",
               "score": 3,
-              "note": ""
+              "note": "6 cross-references; good for 4 verses; 2 Cor 3 bridge was strongest"
             },
             {
               "n": 4,
               "name": "Facilitation vs. Lecture",
-              "score": 2,
-              "note": ""
+              "score": 4,
+              "note": "48% leader talk in discussion; collaborative throughout teaching core"
             },
             {
               "n": 5,
               "name": "Application Questions",
-              "score": 2,
-              "note": ""
+              "score": 4,
+              "note": "8 Big Idea questions; 75% at DOK 3-4; excellent quality"
             },
             {
               "n": 6,
               "name": "Participant Engagement",
-              "score": 3,
-              "note": ""
+              "score": 4,
+              "note": "75% of attendees spoke; strong peer-to-peer interaction"
             },
             {
               "n": 7,
               "name": "Visual Aids",
-              "score": 2,
-              "note": ""
+              "score": 1,
+              "note": "Zero visual aids due to internet outage; no backup prepared"
             },
             {
               "n": 8,
               "name": "Vulnerability / Authenticity",
               "score": 3,
-              "note": ""
+              "note": "3 moments; intellectual honesty rather than personal depth"
             },
             {
               "n": 9,
               "name": "Memory Reinforcement",
               "score": 2,
-              "note": ""
+              "note": "Book summary asked; no cumulative Big Ideas review"
             },
             {
               "n": 10,
               "name": "Homework References",
-              "score": 4,
-              "note": ""
+              "score": 3,
+              "note": "Referenced Precept workbook pages; \\\"page 74,\\\" \\\"page 76\\\""
             },
             {
               "n": 11,
               "name": "Prayer",
-              "score": 3,
-              "note": ""
+              "score": 2,
+              "note": "Opening prayer present (Jeff-led); no closing prayer visible"
             },
             {
               "n": 12,
               "name": "Leader Development",
               "score": 2,
-              "note": ""
+              "note": "Solo leader; no apprentice or co-teacher visible"
             }
           ],
-          "bigIdeas": [
-            "You died and your life is hidden with Christ",
-            "Set your mind on things above"
-          ],
+          "bigIdeas": [],
           "feedback": {
-            "headline": "A developing session — strongest in Homework References and Session Structure & Flow, with the clearest next step in Facilitation vs. Lecture.",
+            "headline": "A developing session — strongest in Facilitation vs. Lecture and Application Questions, with the clearest next step in Visual Aids.",
             "strengths": [
-              "Homework was referenced and rewarded, differentiating the members who prepared.",
-              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
-              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse."
+              "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "A high share of the room contributed substantively, called on by name."
             ],
             "improvements": [
-              "Leader talk crowded out discussion; the balance leaned toward lecture.",
-              "Questions stayed heady; few moved the group to first-person, personal application.",
-              "The session leaned audio-only; a visual anchor would aid retention."
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+              "Prayer was leader-only or rushed; the group’s voice was thin."
             ],
             "recommendations": [
-              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
-              "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
-              "Next time, put one word-study lookup or a simple table on screen during the key term."
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+              "Next time, ask one member to open and a different member to close in prayer."
             ],
             "overview": [
-              "A developing session — strongest in Homework References and Session Structure & Flow, with the clearest next step in Facilitation vs. Lecture. It scored 54.24/100 under the v3 weighted model.",
-              "The session played to its strengths in Homework References and Session Structure & Flow; the recommendations below turn Facilitation vs. Lecture into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+              "A developing session — strongest in Facilitation vs. Lecture and Application Questions, with the clearest next step in Visual Aids. It scored 56.06/100 under the v3 weighted model.",
+              "The session played to its strengths in Facilitation vs. Lecture and Application Questions; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
             ],
             "strengthsProse": [
               {
-                "title": "Homework References anchored the session (4/5)",
+                "title": "Facilitation vs. Lecture anchored the session (4/5)",
                 "paragraphs": [
-                  "Homework was referenced and rewarded, differentiating the members who prepared.",
-                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
-                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                  "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 48% leader talk in discussion; collaborative throughout teaching core"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 8 Big Idea questions; 75% at DOK 3-4; excellent quality"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 75% of attendees spoke; strong peer-to-peer interaction"
                 ]
               },
               {
@@ -5190,7 +5680,8 @@
                 "paragraphs": [
                   "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
                   "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 7 of 10 steps present; pre-session and closing overran; no closing prayer"
                 ]
               },
               {
@@ -5198,49 +5689,19 @@
                 "paragraphs": [
                   "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
                   "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
-                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
-                ]
-              },
-              {
-                "title": "Participant Engagement anchored the session (3/5)",
-                "paragraphs": [
-                  "A high share of the room contributed substantively, called on by name.",
-                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
-                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
-                ]
-              },
-              {
-                "title": "Vulnerability / Authenticity anchored the session (3/5)",
-                "paragraphs": [
-                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
-                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
-                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off."
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 6 cross-references; good for 4 verses; 2 Cor 3 bridge was strongest"
                 ]
               }
             ],
             "improvementsProse": [
               {
-                "title": "Facilitation vs. Lecture is a growth area (2/5)",
-                "paragraphs": [
-                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
-                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
-                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              },
-              {
-                "title": "Application Questions is a growth area (2/5)",
-                "paragraphs": [
-                  "Questions stayed heady; few moved the group to first-person, personal application.",
-                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
-                ]
-              },
-              {
-                "title": "Visual Aids is a growth area (2/5)",
+                "title": "Visual Aids is a growth area (1/5)",
                 "paragraphs": [
                   "The session leaned audio-only; a visual anchor would aid retention.",
                   "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Zero visual aids due to internet outage; no backup prepared"
                 ]
               },
               {
@@ -5248,7 +5709,17 @@
                 "paragraphs": [
                   "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
                   "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
-                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Book summary asked; no cumulative Big Ideas review"
+                ]
+              },
+              {
+                "title": "Prayer is a growth area (2/5)",
+                "paragraphs": [
+                  "Prayer was leader-only or rushed; the group’s voice was thin.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Opening prayer present (Jeff-led); no closing prayer visible"
                 ]
               },
               {
@@ -5256,7 +5727,341 @@
                 "paragraphs": [
                   "No in-session development of another leader was observable this week.",
                   "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Solo leader; no apprentice or co-teacher visible"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 3 moments; intellectual honesty rather than personal depth"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Prayer",
+                "paragraphs": [
+                  "Next time, ask one member to open and a different member to close in prayer.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
                   "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 52% × weight 33 → 17.16 pts",
+                "Building Ministry: 50% × weight 31 → 15.50 pts",
+                "Engaging People: 80% × weight 18 → 14.40 pts",
+                "Being Real: 50% × weight 18 → 9.00 pts",
+                "Base (sum of cluster contributions): 56.06 / 100",
+                "Session score: 56.06 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3/5): 7 of 10 steps present; pre-session and closing overran; no closing prayer",
+                "Newcomer Welcome (N/A): No newcomers present",
+                "Scripture Engagement (3/5): 6 cross-references; good for 4 verses; 2 Cor 3 bridge was strongest",
+                "Facilitation vs. Lecture (4/5): 48% leader talk in discussion; collaborative throughout teaching core",
+                "Application Questions (4/5): 8 Big Idea questions; 75% at DOK 3-4; excellent quality",
+                "Participant Engagement (4/5): 75% of attendees spoke; strong peer-to-peer interaction",
+                "Visual Aids (1/5): Zero visual aids due to internet outage; no backup prepared",
+                "Vulnerability / Authenticity (3/5): 3 moments; intellectual honesty rather than personal depth",
+                "Memory Reinforcement (2/5): Book summary asked; no cumulative Big Ideas review",
+                "Homework References (3/5): Referenced Precept workbook pages; \\\"page 74,\\\" \\\"page 76\\\"",
+                "Prayer (2/5): Opening prayer present (Jeff-led); no closing prayer visible",
+                "Leader Development (2/5): Solo leader; no apprentice or co-teacher visible"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        }
+      ]
+    },
+    {
+      "id": "joel-hurt",
+      "name": "Joel Hurt",
+      "email": "joelhhurt@yahoo.com",
+      "group": "Thursday Men’s Study",
+      "coachName": "Bryan Bailey",
+      "isCoach": true,
+      "zoomLink": "",
+      "reports": [
+        {
+          "id": "joel-hurt-2026-06-06-revelation-week-5-church-of-smyr",
+          "date": "2026-06-06",
+          "dateLabel": "June 6, 2026",
+          "session": "Revelation Week 5 — Church of Smyrna: Suffering as Normative in the Christian Life",
+          "topic": "Rev 2:8–11; principles of suffering from James, 1 Pet, 2 Tim, Heb, 1 Cor 15",
+          "duration": "~2h 11m",
+          "attendees": 12,
+          "newcomers": 1,
+          "score": 83.64,
+          "base": 82.64,
+          "newcomerBonus": 1,
+          "sizeBonus": 0,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 88,
+              "contribution": 29.04
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 80,
+              "contribution": 24.8
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": "Strong opening, review, scripture, breakouts, delegated prayers. Teaching section slightly lecture-heavy. No formal pre-session prayer/roll call observed."
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 4,
+              "note": "Solomon Moon well introduced. Two members shared testimonies. Multiplication vision cast immediately. Slightly abbreviated (7 min). Testimonies were warm and relevant."
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "20+ cross-references across 10+ books. Blue Letter Bible word study. Among the most cross-reference-dense sessions in the Revelation series."
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "Joel only: ~38–42% (ON TARGET). Combined w/Bruce: ~50–55% (above benchmark). Revelation context requires more framing. Incremental improvement needed on wait time."
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 5,
+              "note": "14 Big Idea questions, all DOK 3–4. Series high. Zero recall-only questions. One DOK 2 question only (opportunity to add on-ramps for newer members)."
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 5,
+              "note": "12+ distinct voices. Named calling-on throughout. Solomon (newcomer) engaged. Keith (online) contributed. Breakouts expanded participation further."
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 4,
+              "note": "Blue Letter Bible word study on screen. Map of 7 churches referenced. Suffering principles whiteboard. Would benefit from one more screen-based visual (historical Smyrna image or crown diagram)."
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": "Three Joel disclosures (aging, wife’s surgeries, evangelistic discomfort). All with real cost. Bruce Hurt’s near-faith-abandonment story was highest-stakes; missed retrieval. Dim 8 = 5/5 potential unreached."
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 4,
+              "note": "Strong interactive review (13 min, popcorn style, ch.1–2 outline, Ephesus summary). Recovered from 2/5 series low (Week 4). Not yet full cumulative verbatim recitation."
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 4,
+              "note": "Day 4 and Day 5 explicitly named. Question numbers called out (‘question 4’). Homework framed as foundation for discussion. Slightly lighter accountability than early series sessions."
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": "Opening prayer delegated; closing prayer delegated to Howard. Brief prayer request mentioned (friend with prostate cancer). Both clear, warm, well-timed."
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 4,
+              "note": "Bruce Hurt (father) actively co-leading. Solomon Moon targeted for future leadership. Chris and Austin led breakout groups. Strong. Follow-up with Solomon needed this week to sustain."
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Facilitation vs. Lecture.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "A high share of the room contributed substantively, called on by name."
+            ],
+            "improvements": [
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+              "The newcomer welcome was brief, missing a chance to enfold guests into the room."
+            ],
+            "recommendations": [
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+              "Next time, open by inviting two regulars to give a 60-second testimony before introductions."
+            ],
+            "overview": [
+              "A strong session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Facilitation vs. Lecture. It scored 83.64/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Application Questions; the recommendations below turn Facilitation vs. Lecture into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 20+ cross-references across 10+ books. Blue Letter Bible word study. Among the most cross-reference-dense sessions in the Revelation series."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (5/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 14 Big Idea questions, all DOK 3–4. Series high. Zero recall-only questions. One DOK 2 question only (opportunity to add on-ramps for newer members)."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 12+ distinct voices. Named calling-on throughout. Solomon (newcomer) engaged. Keith (online) contributed. Breakouts expanded participation further."
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Strong opening, review, scripture, breakouts, delegated prayers. Teaching section slightly lecture-heavy. No formal pre-session prayer/roll call observed."
+                ]
+              },
+              {
+                "title": "Newcomer Welcome anchored the session (4/5)",
+                "paragraphs": [
+                  "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Solomon Moon well introduced. Two members shared testimonies. Multiplication vision cast immediately. Slightly abbreviated (7 min). Testimonies were warm and relevant."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Joel only: ~38–42% (ON TARGET). Combined w/Bruce: ~50–55% (above benchmark). Revelation context requires more framing. Incremental improvement needed on wait time."
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (4/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Blue Letter Bible word study on screen. Map of 7 churches referenced. Suffering principles whiteboard. Would benefit from one more screen-based visual (historical Smyrna image or crown diagram)."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (4/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Three Joel disclosures (aging, wife’s surgeries, evangelistic discomfort). All with real cost. Bruce Hurt’s near-faith-abandonment story was highest-stakes; missed retrieval. Dim 8 = 5/5 potential unreached."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (4/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Strong interactive review (13 min, popcorn style, ch.1–2 outline, Ephesus summary). Recovered from 2/5 series low (Week 4). Not yet full cumulative verbatim recitation."
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (4/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Day 4 and Day 5 explicitly named. Question numbers called out (‘question 4’). Homework framed as foundation for discussion. Slightly lighter accountability than early series sessions."
                 ]
               }
             ],
@@ -5270,11 +6075,639 @@
                 ]
               },
               {
-                "title": "Next session — Application Questions",
+                "title": "Next session — Visual Aids",
                 "paragraphs": [
-                  "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
                   "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
                   "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 88% × weight 33 → 29.04 pts",
+                "Building Ministry: 80% × weight 31 → 24.80 pts",
+                "Engaging People: 80% × weight 18 → 14.40 pts",
+                "Being Real: 80% × weight 18 → 14.40 pts",
+                "Base (sum of cluster contributions): 82.64 / 100",
+                "Session bonuses: newcomer growth +1",
+                "Session score: 83.64 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Strong opening, review, scripture, breakouts, delegated prayers. Teaching section slightly lecture-heavy. No formal pre-session prayer/roll call observed.",
+                "Newcomer Welcome (4/5): Solomon Moon well introduced. Two members shared testimonies. Multiplication vision cast immediately. Slightly abbreviated (7 min). Testimonies were warm and relevant.",
+                "Scripture Engagement (5/5): 20+ cross-references across 10+ books. Blue Letter Bible word study. Among the most cross-reference-dense sessions in the Revelation series.",
+                "Facilitation vs. Lecture (3/5): Joel only: ~38–42% (ON TARGET). Combined w/Bruce: ~50–55% (above benchmark). Revelation context requires more framing. Incremental improvement needed on wait time.",
+                "Application Questions (5/5): 14 Big Idea questions, all DOK 3–4. Series high. Zero recall-only questions. One DOK 2 question only (opportunity to add on-ramps for newer members).",
+                "Participant Engagement (5/5): 12+ distinct voices. Named calling-on throughout. Solomon (newcomer) engaged. Keith (online) contributed. Breakouts expanded participation further.",
+                "Visual Aids (4/5): Blue Letter Bible word study on screen. Map of 7 churches referenced. Suffering principles whiteboard. Would benefit from one more screen-based visual (historical Smyrna image or crown diagram).",
+                "Vulnerability / Authenticity (4/5): Three Joel disclosures (aging, wife’s surgeries, evangelistic discomfort). All with real cost. Bruce Hurt’s near-faith-abandonment story was highest-stakes; missed retrieval. Dim 8 = 5/5 potential unreached.",
+                "Memory Reinforcement (4/5): Strong interactive review (13 min, popcorn style, ch.1–2 outline, Ephesus summary). Recovered from 2/5 series low (Week 4). Not yet full cumulative verbatim recitation.",
+                "Homework References (4/5): Day 4 and Day 5 explicitly named. Question numbers called out (‘question 4’). Homework framed as foundation for discussion. Slightly lighter accountability than early series sessions.",
+                "Prayer (4/5): Opening prayer delegated; closing prayer delegated to Howard. Brief prayer request mentioned (friend with prostate cancer). Both clear, warm, well-timed.",
+                "Leader Development (4/5): Bruce Hurt (father) actively co-leading. Solomon Moon targeted for future leadership. Chris and Austin led breakout groups. Strong. Follow-up with Solomon needed this week to sustain."
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "joel-hurt-2026-06-01-revelation-week-4-letters-to-the",
+          "date": "2026-06-01",
+          "dateLabel": "June 1, 2026",
+          "session": "Revelation Week 4 — Letters to the Seven Churches: Ephesus (Rev 2:1–7)",
+          "topic": "Testing false teachers, losing first love, the lampstand warning",
+          "duration": "~2 hr 3 min",
+          "attendees": 27,
+          "newcomers": 0,
+          "score": 81.02,
+          "base": 78.02,
+          "newcomerBonus": 0,
+          "sizeBonus": 3,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 74,
+              "contribution": 24.42
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 80,
+              "contribution": 24.8
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 90,
+              "contribution": 16.2
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3.5,
+              "note": "Blueprint mostly followed; Big Ideas review ~30 sec (far below 5–15 min target); no close-of-session Big Ideas capture; small-group format is intentional design."
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": "No newcomers this session. Building Ministry max reduces to 10 (from 15); scored against reduced max."
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "14+ cross-references across OT and NT; multiple member-generated; Acts 17:11 Berean model applied live. Exceptional."
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 4,
+              "note": "Joel discussion-only ratio: ~28% (below 30% target). With Bruce: ~36% combined. Strong Socratic facilitation throughout; Ephesus context segment appropriately lecture-heavy."
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "7 Big Idea questions; DOK 3–4 only (no DOK 1 or 2); wait time consistent 3–5 sec. Zero DOK 2 questions — small gap."
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 5,
+              "note": "15+ named contributors; ~90% participation rate; remote members (Aaron, Keith, Bruce) all contributing substantively. Exceptional."
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 4,
+              "note": "Map of Asia Minor, Artemis temple image, 25k-seat theater image shown on screen during Ephesus context. Greek terms referenced verbally but not displayed on Blue Letter Bible."
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 3,
+              "note": "1 mild Joel disclosure (analogy-framed); 5+ member vulnerabilities including Keith’s high-depth Braille Bible confession. Improvement from Week 3 (2/5) but still below 4/5 potential."
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 2,
+              "note": "~30 sec Big Ideas review at open (1 idea recovered). No close-of-session Big Ideas capture. Lowest scoring dimension in the Revelation series."
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 3,
+              "note": "Referenced twice (‘if you guys did the homework,’ ‘one of our homework questions’) but not treated as required input before Joel teaches. Precept model requires homework as discussion foundation."
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": "Closing prayer delegated to Brandon (thematic); live real-time prayer for Spencer (Jeff’s Mormon neighbor) mid-session — the session’s best pastoral moment. Opening prayer unclear (pre-recording or Zoom startup)."
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 5,
+              "note": "Chris, JT, Danny running 3 parallel groups independently; Bruce Hurt as senior mentor contributing 2 Thess 3:5 challenge. Sub-leader check-in at session end (‘Chris, any big thoughts from your group?’). Four visible development tiers."
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Scripture Engagement and Participant Engagement, with the clearest next step in Memory Reinforcement.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "A high share of the room contributed substantively, called on by name.",
+              "An apprentice was visibly developed in-session — a clear multiplication signal."
+            ],
+            "improvements": [
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+              "Teaching stayed at arm’s length; little personal cost was modeled.",
+              "Homework went unmentioned, reducing its pull on the group."
+            ],
+            "recommendations": [
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+              "Next time, open one teaching point with a first-person example that cost you something.",
+              "Next time, ask two members to share one thing from their homework in the first 10 minutes."
+            ],
+            "overview": [
+              "A strong session — strongest in Scripture Engagement and Participant Engagement, with the clearest next step in Memory Reinforcement. It scored 81.02/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Participant Engagement; the recommendations below turn Memory Reinforcement into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 14+ cross-references across OT and NT; multiple member-generated; Acts 17:11 Berean model applied live. Exceptional."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 15+ named contributors; ~90% participation rate; remote members (Aaron, Keith, Bruce) all contributing substantively. Exceptional."
+                ]
+              },
+              {
+                "title": "Leader Development anchored the session (5/5)",
+                "paragraphs": [
+                  "An apprentice was visibly developed in-session — a clear multiplication signal.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Chris, JT, Danny running 3 parallel groups independently; Bruce Hurt as senior mentor contributing 2 Thess 3:5 challenge. Sub-leader check-in at session end (‘Chris, any big thoughts from your group?’). Four visible development tiers."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture anchored the session (4/5)",
+                "paragraphs": [
+                  "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Joel discussion-only ratio: ~28% (below 30% target). With Bruce: ~36% combined. Strong Socratic facilitation throughout; Ephesus context segment appropriately lecture-heavy."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 7 Big Idea questions; DOK 3–4 only (no DOK 1 or 2); wait time consistent 3–5 sec. Zero DOK 2 questions — small gap."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Memory Reinforcement is a growth area (2/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: ~30 sec Big Ideas review at open (1 idea recovered). No close-of-session Big Ideas capture. Lowest scoring dimension in the Revelation series."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 1 mild Joel disclosure (analogy-framed); 5+ member vulnerabilities including Keith’s high-depth Braille Bible confession. Improvement from Week 3 (2/5) but still below 4/5 potential."
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (3/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Referenced twice (‘if you guys did the homework,’ ‘one of our homework questions’) but not treated as required input before Joel teaches. Precept model requires homework as discussion foundation."
+                ]
+              },
+              {
+                "title": "Session Structure & Flow is a growth area (3.5/5)",
+                "paragraphs": [
+                  "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Blueprint mostly followed; Big Ideas review ~30 sec (far below 5–15 min target); no close-of-session Big Ideas capture; small-group format is intentional design."
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (4/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Map of Asia Minor, Artemis temple image, 25k-seat theater image shown on screen during Ephesus context. Greek terms referenced verbally but not displayed on Blue Letter Bible."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Session Structure & Flow",
+                "paragraphs": [
+                  "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 74% × weight 33 → 24.42 pts",
+                "Building Ministry: 80% × weight 31 → 24.80 pts",
+                "Engaging People: 90% × weight 18 → 16.20 pts",
+                "Being Real: 70% × weight 18 → 12.60 pts",
+                "Base (sum of cluster contributions): 78.02 / 100",
+                "Session bonuses: group-size +3",
+                "Session score: 81.02 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3.5/5): Blueprint mostly followed; Big Ideas review ~30 sec (far below 5–15 min target); no close-of-session Big Ideas capture; small-group format is intentional design.",
+                "Newcomer Welcome (N/A): No newcomers this session. Building Ministry max reduces to 10 (from 15); scored against reduced max.",
+                "Scripture Engagement (5/5): 14+ cross-references across OT and NT; multiple member-generated; Acts 17:11 Berean model applied live. Exceptional.",
+                "Facilitation vs. Lecture (4/5): Joel discussion-only ratio: ~28% (below 30% target). With Bruce: ~36% combined. Strong Socratic facilitation throughout; Ephesus context segment appropriately lecture-heavy.",
+                "Application Questions (4/5): 7 Big Idea questions; DOK 3–4 only (no DOK 1 or 2); wait time consistent 3–5 sec. Zero DOK 2 questions — small gap.",
+                "Participant Engagement (5/5): 15+ named contributors; ~90% participation rate; remote members (Aaron, Keith, Bruce) all contributing substantively. Exceptional.",
+                "Visual Aids (4/5): Map of Asia Minor, Artemis temple image, 25k-seat theater image shown on screen during Ephesus context. Greek terms referenced verbally but not displayed on Blue Letter Bible.",
+                "Vulnerability / Authenticity (3/5): 1 mild Joel disclosure (analogy-framed); 5+ member vulnerabilities including Keith’s high-depth Braille Bible confession. Improvement from Week 3 (2/5) but still below 4/5 potential.",
+                "Memory Reinforcement (2/5): ~30 sec Big Ideas review at open (1 idea recovered). No close-of-session Big Ideas capture. Lowest scoring dimension in the Revelation series.",
+                "Homework References (3/5): Referenced twice (‘if you guys did the homework,’ ‘one of our homework questions’) but not treated as required input before Joel teaches. Precept model requires homework as discussion foundation.",
+                "Prayer (4/5): Closing prayer delegated to Brandon (thematic); live real-time prayer for Spencer (Jeff’s Mormon neighbor) mid-session — the session’s best pastoral moment. Opening prayer unclear (pre-recording or Zoom startup).",
+                "Leader Development (5/5): Chris, JT, Danny running 3 parallel groups independently; Bruce Hurt as senior mentor contributing 2 Thess 3:5 challenge. Sub-leader check-in at session end (‘Chris, any big thoughts from your group?’). Four visible development tiers."
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "joel-hurt-2026-05-23-revelation-week-3-chapter-1-vers",
+          "date": "2026-05-23",
+          "dateLabel": "May 23, 2026",
+          "session": "Revelation Week 3 — Chapter 1 Verse-by-Verse (Rev 1:1–20)",
+          "topic": "Apocalypsis, the seven churches, glorified Christ, keys of death and Hades",
+          "duration": "~2h 08m",
+          "attendees": 30,
+          "newcomers": 2,
+          "score": 79.15,
+          "base": 74.15,
+          "newcomerBonus": 2,
+          "sizeBonus": 3,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 74,
+              "contribution": 24.42
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 73.3,
+              "contribution": 22.73
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 90,
+              "contribution": 16.2
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 60,
+              "contribution": 10.8
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3.5,
+              "note": "Blueprint mostly followed; abbreviated Big Ideas review (1 idea, 2 min); small-group format is intentional design, not deviation."
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 3,
+              "note": "2 newcomers present (Luke Bugbee, Kyle); member testimony from Nick; ~6 min total. Under BSF 7–25 min benchmark. Luke’s Israel context not leveraged."
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "25+ cross-references across both testaments; 2 structured blitz sequences; Amos 3:7 member-generated unprompted. Exceptional."
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 4,
+              "note": "Joel’s discussion-only ratio: ~28% (below 30% target). Bruce’s Hades/Sheol segment pushes combined leader ratio to ~40% including all teaching. Overall facilitation is strong."
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "8 Big Idea questions; DOK 2–4 distribution; no DOK 1; wait time consistent at 3–5 sec. No formal close-of-session Big Ideas capture."
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 5,
+              "note": "16+ named contributors; ~90% participation rate; Caesar contributing substantively from Branson; multiple extended member responses. Exceptional."
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 3,
+              "note": "Map of Asia Minor shared on screen [00:52:55]; verbal Greek word studies (tachos, Hades vs. Gehenna). Blue Letter Bible not shown on screen for word studies."
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 2,
+              "note": "0 personal disclosures with real cost from Joel. Intellectual humility modeled (admits gaps). Victor’s confession not followed up with leader vulnerability."
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 3,
+              "note": "One Big Idea recalled at session open (‘God wants to reveal’ [00:17:30]). Not a full cumulative review. No formal close-of-session Big Ideas capture."
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 3,
+              "note": "Direct reference to tachos word study homework [‘Anybody do that this week?’]; simile/metaphor as homework assignment. Study guide mentioned. Not Precept workbook model but equivalent."
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": "Delegated opening prayer (member, [00:12:27]); delegated closing prayer (JT, [02:05:40]) — thematic and on-text (“let our eyes be fixated on your glory”). No formal prayer request collection."
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 5,
+              "note": "Bruce Hurt as senior mentor (present + teaching); Danny, JT, Chris as 3 active sub-group leaders; sons Miles and Stone in active participation. Four visible tiers of development."
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Scripture Engagement and Participant Engagement, with the clearest next step in Vulnerability / Authenticity.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "A high share of the room contributed substantively, called on by name.",
+              "An apprentice was visibly developed in-session — a clear multiplication signal."
+            ],
+            "improvements": [
+              "Teaching stayed at arm’s length; little personal cost was modeled.",
+              "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+              "The session leaned audio-only; a visual anchor would aid retention."
+            ],
+            "recommendations": [
+              "Next time, open one teaching point with a first-person example that cost you something.",
+              "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term."
+            ],
+            "overview": [
+              "A strong session — strongest in Scripture Engagement and Participant Engagement, with the clearest next step in Vulnerability / Authenticity. It scored 79.15/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Participant Engagement; the recommendations below turn Vulnerability / Authenticity into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 25+ cross-references across both testaments; 2 structured blitz sequences; Amos 3:7 member-generated unprompted. Exceptional."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 16+ named contributors; ~90% participation rate; Caesar contributing substantively from Branson; multiple extended member responses. Exceptional."
+                ]
+              },
+              {
+                "title": "Leader Development anchored the session (5/5)",
+                "paragraphs": [
+                  "An apprentice was visibly developed in-session — a clear multiplication signal.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Bruce Hurt as senior mentor (present + teaching); Danny, JT, Chris as 3 active sub-group leaders; sons Miles and Stone in active participation. Four visible tiers of development."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture anchored the session (4/5)",
+                "paragraphs": [
+                  "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Joel’s discussion-only ratio: ~28% (below 30% target). Bruce’s Hades/Sheol segment pushes combined leader ratio to ~40% including all teaching. Overall facilitation is strong."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 8 Big Idea questions; DOK 2–4 distribution; no DOK 1; wait time consistent at 3–5 sec. No formal close-of-session Big Ideas capture."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Vulnerability / Authenticity is a growth area (2/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 0 personal disclosures with real cost from Joel. Intellectual humility modeled (admits gaps). Victor’s confession not followed up with leader vulnerability."
+                ]
+              },
+              {
+                "title": "Newcomer Welcome is a growth area (3/5)",
+                "paragraphs": [
+                  "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 2 newcomers present (Luke Bugbee, Kyle); member testimony from Nick; ~6 min total. Under BSF 7–25 min benchmark. Luke’s Israel context not leveraged."
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (3/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Map of Asia Minor shared on screen [00:52:55]; verbal Greek word studies (tachos, Hades vs. Gehenna). Blue Letter Bible not shown on screen for word studies."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: One Big Idea recalled at session open (‘God wants to reveal’ [00:17:30]). Not a full cumulative review. No formal close-of-session Big Ideas capture."
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (3/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Direct reference to tachos word study homework [‘Anybody do that this week?’]; simile/metaphor as homework assignment. Study guide mentioned. Not Precept workbook model but equivalent."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Newcomer Welcome",
+                "paragraphs": [
+                  "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
               },
               {
@@ -5294,9 +6727,9 @@
                 ]
               },
               {
-                "title": "Next session — Leader Development",
+                "title": "Next session — Homework References",
                 "paragraphs": [
-                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
                   "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
                   "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
                 ]
@@ -5310,29 +6743,981 @@
                 "How the four weighted clusters and any session bonuses combined into the composite score."
               ],
               "bullets": [
-                "Teaching Craft: 48% × weight 33 → 15.84 pts",
-                "Building Ministry: 60% × weight 31 → 18.60 pts",
-                "Engaging People: 50% × weight 18 → 9.00 pts",
+                "Teaching Craft: 74% × weight 33 → 24.42 pts",
+                "Building Ministry: 73.3% × weight 31 → 22.73 pts",
+                "Engaging People: 90% × weight 18 → 16.20 pts",
                 "Being Real: 60% × weight 18 → 10.80 pts",
-                "Base (sum of cluster contributions): 54.24 / 100",
-                "Session score: 54.24 / 100"
+                "Base (sum of cluster contributions): 74.15 / 100",
+                "Session bonuses: newcomer growth +2, group-size +3",
+                "Session score: 79.15 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3.5/5): Blueprint mostly followed; abbreviated Big Ideas review (1 idea, 2 min); small-group format is intentional design, not deviation.",
+                "Newcomer Welcome (3/5): 2 newcomers present (Luke Bugbee, Kyle); member testimony from Nick; ~6 min total. Under BSF 7–25 min benchmark. Luke’s Israel context not leveraged.",
+                "Scripture Engagement (5/5): 25+ cross-references across both testaments; 2 structured blitz sequences; Amos 3:7 member-generated unprompted. Exceptional.",
+                "Facilitation vs. Lecture (4/5): Joel’s discussion-only ratio: ~28% (below 30% target). Bruce’s Hades/Sheol segment pushes combined leader ratio to ~40% including all teaching. Overall facilitation is strong.",
+                "Application Questions (4/5): 8 Big Idea questions; DOK 2–4 distribution; no DOK 1; wait time consistent at 3–5 sec. No formal close-of-session Big Ideas capture.",
+                "Participant Engagement (5/5): 16+ named contributors; ~90% participation rate; Caesar contributing substantively from Branson; multiple extended member responses. Exceptional.",
+                "Visual Aids (3/5): Map of Asia Minor shared on screen [00:52:55]; verbal Greek word studies (tachos, Hades vs. Gehenna). Blue Letter Bible not shown on screen for word studies.",
+                "Vulnerability / Authenticity (2/5): 0 personal disclosures with real cost from Joel. Intellectual humility modeled (admits gaps). Victor’s confession not followed up with leader vulnerability.",
+                "Memory Reinforcement (3/5): One Big Idea recalled at session open (‘God wants to reveal’ [00:17:30]). Not a full cumulative review. No formal close-of-session Big Ideas capture.",
+                "Homework References (3/5): Direct reference to tachos word study homework [‘Anybody do that this week?’]; simile/metaphor as homework assignment. Study guide mentioned. Not Precept workbook model but equivalent.",
+                "Prayer (4/5): Delegated opening prayer (member, [00:12:27]); delegated closing prayer (JT, [02:05:40]) — thematic and on-text (“let our eyes be fixated on your glory”). No formal prayer request collection.",
+                "Leader Development (5/5): Bruce Hurt as senior mentor (present + teaching); Danny, JT, Chris as 3 active sub-group leaders; sons Miles and Stone in active participation. Four visible tiers of development."
               ]
             }
           ],
           "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
-        }
-      ]
-    },
-    {
-      "id": "joel-hurt",
-      "name": "Joel Hurt",
-      "email": "joel.hurt@example.com",
-      "group": "Thursday Men’s Study",
-      "coachName": "Bryan Bailey",
-      "isCoach": true,
-      "zoomLink": "",
-      "reports": [
+        },
+        {
+          "id": "joel-hurt-2026-05-16-revelation-week-2-50-000-foot-ov",
+          "date": "2026-05-16",
+          "dateLabel": "May 16, 2026",
+          "session": "Revelation Week 2 — 50,000-Foot Overview of Chapters 1–5",
+          "topic": "Chapter titles; what we learn about Jesus; common elements of the seven letters",
+          "duration": "~2h 3m (123 minutes)",
+          "attendees": 33,
+          "newcomers": 1,
+          "score": 82.95,
+          "base": 78.95,
+          "newcomerBonus": 1,
+          "sizeBonus": 3,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 76,
+              "contribution": 25.08
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 86.7,
+              "contribution": 26.87
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": "Clean plenary open; prayer delegated; Big Ideas review; sub-group launch; Bruce Q&A close; closing prayer self-led"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 4,
+              "note": "1 newcomer (Michael); existing member testimony first; standard protocol followed; no extended welcome circle"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 4,
+              "note": "Rev 1-5 covered; 6+ cross-references; strong text-grounding; chapter 4-5 compressed at end"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "Joel's small group ~33% discussion-only (STRONG); combined with Bruce Q&A raises leadership side to ~40%"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "7 Big Idea questions; 100% DOK 2-4; well-spaced; DOK 4 lower than Joel's peak (format constraint)"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 5,
+              "note": "10+ named voices; participant-generated cross-refs; scribe activity; distributed reading; 70%+ participation"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 3,
+              "note": "Physical paper list (scribe); purple marker; no screen share; no digital maps or Blue Letter Bible visible"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": "2 leader moments (medium depth); Bruce HIGH-depth disclosure; participant vulnerability moments present"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 4,
+              "note": "Prior Big Ideas reviewed at open (strong); 5 new Big Ideas coined; no written artifact yet (third reminder)"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 4,
+              "note": "FOTO method reinforced; 'bring your questions next week'; spend time in the word daily; not as strong as Week 1's Guarantee"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 3,
+              "note": "Opening delegated (good); closing self-led by Joel (third consecutive session; same note)"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 5,
+              "note": "Bruce co-teaching; 3 sub-leaders (Danny, JT, Patron) running independent groups; 2 Tim 2:2 model live"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Participant Engagement and Leader Development, with the clearest next step in Facilitation vs. Lecture.",
+            "strengths": [
+              "A high share of the room contributed substantively, called on by name.",
+              "An apprentice was visibly developed in-session — a clear multiplication signal.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place."
+            ],
+            "improvements": [
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Prayer was leader-only or rushed; the group’s voice was thin."
+            ],
+            "recommendations": [
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, ask one member to open and a different member to close in prayer."
+            ],
+            "overview": [
+              "A strong session — strongest in Participant Engagement and Leader Development, with the clearest next step in Facilitation vs. Lecture. It scored 82.95/100 under the v3 weighted model.",
+              "The session played to its strengths in Participant Engagement and Leader Development; the recommendations below turn Facilitation vs. Lecture into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Participant Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 10+ named voices; participant-generated cross-refs; scribe activity; distributed reading; 70%+ participation"
+                ]
+              },
+              {
+                "title": "Leader Development anchored the session (5/5)",
+                "paragraphs": [
+                  "An apprentice was visibly developed in-session — a clear multiplication signal.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Bruce co-teaching; 3 sub-leaders (Danny, JT, Patron) running independent groups; 2 Tim 2:2 model live"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Clean plenary open; prayer delegated; Big Ideas review; sub-group launch; Bruce Q&A close; closing prayer self-led"
+                ]
+              },
+              {
+                "title": "Newcomer Welcome anchored the session (4/5)",
+                "paragraphs": [
+                  "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 1 newcomer (Michael); existing member testimony first; standard protocol followed; no extended welcome circle"
+                ]
+              },
+              {
+                "title": "Scripture Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Rev 1-5 covered; 6+ cross-references; strong text-grounding; chapter 4-5 compressed at end"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Joel's small group ~33% discussion-only (STRONG); combined with Bruce Q&A raises leadership side to ~40%"
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (3/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Physical paper list (scribe); purple marker; no screen share; no digital maps or Blue Letter Bible visible"
+                ]
+              },
+              {
+                "title": "Prayer is a growth area (3/5)",
+                "paragraphs": [
+                  "Prayer was leader-only or rushed; the group’s voice was thin.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Opening delegated (good); closing self-led by Joel (third consecutive session; same note)"
+                ]
+              },
+              {
+                "title": "Application Questions is a growth area (4/5)",
+                "paragraphs": [
+                  "Questions stayed heady; few moved the group to first-person, personal application.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 7 Big Idea questions; 100% DOK 2-4; well-spaced; DOK 4 lower than Joel's peak (format constraint)"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (4/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 2 leader moments (medium depth); Bruce HIGH-depth disclosure; participant vulnerability moments present"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Prayer",
+                "paragraphs": [
+                  "Next time, ask one member to open and a different member to close in prayer.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Application Questions",
+                "paragraphs": [
+                  "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 76% × weight 33 → 25.08 pts",
+                "Building Ministry: 86.7% × weight 31 → 26.87 pts",
+                "Engaging People: 80% × weight 18 → 14.40 pts",
+                "Being Real: 70% × weight 18 → 12.60 pts",
+                "Base (sum of cluster contributions): 78.95 / 100",
+                "Session bonuses: newcomer growth +1, group-size +3",
+                "Session score: 82.95 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Clean plenary open; prayer delegated; Big Ideas review; sub-group launch; Bruce Q&A close; closing prayer self-led",
+                "Newcomer Welcome (4/5): 1 newcomer (Michael); existing member testimony first; standard protocol followed; no extended welcome circle",
+                "Scripture Engagement (4/5): Rev 1-5 covered; 6+ cross-references; strong text-grounding; chapter 4-5 compressed at end",
+                "Facilitation vs. Lecture (3/5): Joel's small group ~33% discussion-only (STRONG); combined with Bruce Q&A raises leadership side to ~40%",
+                "Application Questions (4/5): 7 Big Idea questions; 100% DOK 2-4; well-spaced; DOK 4 lower than Joel's peak (format constraint)",
+                "Participant Engagement (5/5): 10+ named voices; participant-generated cross-refs; scribe activity; distributed reading; 70%+ participation",
+                "Visual Aids (3/5): Physical paper list (scribe); purple marker; no screen share; no digital maps or Blue Letter Bible visible",
+                "Vulnerability / Authenticity (4/5): 2 leader moments (medium depth); Bruce HIGH-depth disclosure; participant vulnerability moments present",
+                "Memory Reinforcement (4/5): Prior Big Ideas reviewed at open (strong); 5 new Big Ideas coined; no written artifact yet (third reminder)",
+                "Homework References (4/5): FOTO method reinforced; 'bring your questions next week'; spend time in the word daily; not as strong as Week 1's Guarantee",
+                "Prayer (3/5): Opening delegated (good); closing self-led by Joel (third consecutive session; same note)",
+                "Leader Development (5/5): Bruce co-teaching; 3 sub-leaders (Danny, JT, Patron) running independent groups; 2 Tim 2:2 model live"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "joel-hurt-2026-05-09-revelation-week-1-orientation-pu",
+          "date": "2026-05-09",
+          "dateLabel": "May 9, 2026",
+          "session": "Revelation Week 1 — Orientation: Purpose, Method & Revelation 1 Observation",
+          "topic": "Why study prophecy; hermeneutical method (observe-interpret-apply); Rev 1:1-9 deep-dive",
+          "duration": "~2h 0m (120 minutes)",
+          "attendees": 24,
+          "newcomers": 4,
+          "score": 89.33,
+          "base": 82.33,
+          "newcomerBonus": 4,
+          "sizeBonus": 3,
+          "status": "Exceptional",
+          "statusEmoji": "🔷",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 80,
+              "contribution": 26.4
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 93.3,
+              "contribution": 28.93
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": "10-step blueprint adapted for Week 1; no Big Ideas review (appropriate); closing prayer not delegated"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 5,
+              "note": "4 newcomers; member-testimony-first model; opening prayer delegated to newcomer; online welcomed"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "15+ cross-references across both Testaments; well above 6+ research benchmark"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "Combined Joel+Bruce ~40% discussion-only; above 30-35% target; appropriate for Week 1 orientation"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "10 Big Idea questions; 100% DOK 3-4; well-spaced; strong for intro session"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 5,
+              "note": "15+ named voices; participant-generated cross-refs; 100% silent-observation participation"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 4,
+              "note": "Blue Letter Bible; Patmos photo; JV + Varsity observation worksheets; Rev 1 handouts"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": "2 leader moments (mortality + Word testimony); 1 high-depth member disclosure; medium overall depth"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 3,
+              "note": "Week 1 — no prior Big Ideas to review; 5 new bumper-stickers coined; no written artifact yet"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 5,
+              "note": "Daily-relational framing; ‘The Guarantee’; 10-week structure explained; workbook download offered"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 3,
+              "note": "Opening delegated to newcomer (excellent); closing self-led (opportunity to delegate)"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 4,
+              "note": "Bruce Hurt co-teaching (multiplication); Thursday parallel class (French/Griswold) mentioned"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "An exceptional session — strongest in Newcomer Welcome and Scripture Engagement, with the clearest next step in Facilitation vs. Lecture.",
+            "strengths": [
+              "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "A high share of the room contributed substantively, called on by name."
+            ],
+            "improvements": [
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+              "Prayer was leader-only or rushed; the group’s voice was thin."
+            ],
+            "recommendations": [
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+              "Next time, ask one member to open and a different member to close in prayer."
+            ],
+            "overview": [
+              "An exceptional session — strongest in Newcomer Welcome and Scripture Engagement, with the clearest next step in Facilitation vs. Lecture. It scored 89.33/100 under the v3 weighted model.",
+              "The session played to its strengths in Newcomer Welcome and Scripture Engagement; the recommendations below turn Facilitation vs. Lecture into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Newcomer Welcome anchored the session (5/5)",
+                "paragraphs": [
+                  "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 4 newcomers; member-testimony-first model; opening prayer delegated to newcomer; online welcomed"
+                ]
+              },
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 15+ cross-references across both Testaments; well above 6+ research benchmark"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 15+ named voices; participant-generated cross-refs; 100% silent-observation participation"
+                ]
+              },
+              {
+                "title": "Homework References anchored the session (5/5)",
+                "paragraphs": [
+                  "Homework was referenced and rewarded, differentiating the members who prepared.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Daily-relational framing; ‘The Guarantee’; 10-week structure explained; workbook download offered"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 10-step blueprint adapted for Week 1; no Big Ideas review (appropriate); closing prayer not delegated"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Combined Joel+Bruce ~40% discussion-only; above 30-35% target; appropriate for Week 1 orientation"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Week 1 — no prior Big Ideas to review; 5 new bumper-stickers coined; no written artifact yet"
+                ]
+              },
+              {
+                "title": "Prayer is a growth area (3/5)",
+                "paragraphs": [
+                  "Prayer was leader-only or rushed; the group’s voice was thin.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Opening delegated to newcomer (excellent); closing self-led (opportunity to delegate)"
+                ]
+              },
+              {
+                "title": "Application Questions is a growth area (4/5)",
+                "paragraphs": [
+                  "Questions stayed heady; few moved the group to first-person, personal application.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 10 Big Idea questions; 100% DOK 3-4; well-spaced; strong for intro session"
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (4/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Blue Letter Bible; Patmos photo; JV + Varsity observation worksheets; Rev 1 handouts"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Prayer",
+                "paragraphs": [
+                  "Next time, ask one member to open and a different member to close in prayer.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Application Questions",
+                "paragraphs": [
+                  "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 80% × weight 33 → 26.40 pts",
+                "Building Ministry: 93.3% × weight 31 → 28.93 pts",
+                "Engaging People: 80% × weight 18 → 14.40 pts",
+                "Being Real: 70% × weight 18 → 12.60 pts",
+                "Base (sum of cluster contributions): 82.33 / 100",
+                "Session bonuses: newcomer growth +4, group-size +3",
+                "Session score: 89.33 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): 10-step blueprint adapted for Week 1; no Big Ideas review (appropriate); closing prayer not delegated",
+                "Newcomer Welcome (5/5): 4 newcomers; member-testimony-first model; opening prayer delegated to newcomer; online welcomed",
+                "Scripture Engagement (5/5): 15+ cross-references across both Testaments; well above 6+ research benchmark",
+                "Facilitation vs. Lecture (3/5): Combined Joel+Bruce ~40% discussion-only; above 30-35% target; appropriate for Week 1 orientation",
+                "Application Questions (4/5): 10 Big Idea questions; 100% DOK 3-4; well-spaced; strong for intro session",
+                "Participant Engagement (5/5): 15+ named voices; participant-generated cross-refs; 100% silent-observation participation",
+                "Visual Aids (4/5): Blue Letter Bible; Patmos photo; JV + Varsity observation worksheets; Rev 1 handouts",
+                "Vulnerability / Authenticity (4/5): 2 leader moments (mortality + Word testimony); 1 high-depth member disclosure; medium overall depth",
+                "Memory Reinforcement (3/5): Week 1 — no prior Big Ideas to review; 5 new bumper-stickers coined; no written artifact yet",
+                "Homework References (5/5): Daily-relational framing; ‘The Guarantee’; 10-week structure explained; workbook download offered",
+                "Prayer (3/5): Opening delegated to newcomer (excellent); closing self-led (opportunity to delegate)",
+                "Leader Development (4/5): Bruce Hurt co-teaching (multiplication); Thursday parallel class (French/Griswold) mentioned"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "joel-hurt-2026-04-18-kings-week-6-the-fall-of-judah-j",
+          "date": "2026-04-18",
+          "dateLabel": "April 18, 2026",
+          "session": "Kings Week 6 — The Fall of Judah: Jehoahaz, Jehoiakim, Jehoiachin / Jeconiah, and Zedekiah",
+          "topic": "The three Babylonian deportations; false prophets; Jeremiah 22, 27-28; Ezekiel 17",
+          "duration": "2h 7m (127 minutes)",
+          "attendees": 14,
+          "newcomers": 2,
+          "score": 90.86,
+          "base": 88.86,
+          "newcomerBonus": 2,
+          "sizeBonus": 0,
+          "status": "Exceptional",
+          "statusEmoji": "🔷",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 92,
+              "contribution": 30.36
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 90,
+              "contribution": 27.9
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 90,
+              "contribution": 16.2
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 5,
+              "note": "Clean blueprint; delegated open; Socratic teaching; extended cumulative review; different closer and opener"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": "No newcomers present"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "11 distinct passages; parallel-text across 4 books on the same event"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "~58% combined Joel + Bruce (mentor) leader talk; 28 points above 30% target; framework-heavy context applies"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 5,
+              "note": "12 Big Ideas; 92% at DOK 3-4; woven every 10-15 min"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 5,
+              "note": "11+ distinct member voices; 20+ named call-outs; deliberate inclusion of remote"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 3,
+              "note": "Kings chart strong in-room; not screen-shared for remote attendees"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 5,
+              "note": "Two HIGH leader disclosures (addicted brother + past relationship); three unprompted member disclosures"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 5,
+              "note": "Extended cumulative Big Ideas review at open; new Big Idea coined and field-tested in-session"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 4,
+              "note": "Referenced assigned reading (Jer 22:24-30); no Precept workbook-specific callouts"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": "Delegated open (David) and different closer (Joel); no prayer-requests round-up visible"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 5,
+              "note": "Bruce co-teach on Jeconiah curse; Danny and Christian given breakout-group lead assignments"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "An exceptional session — strongest in Session Structure & Flow and Scripture Engagement, with the clearest next step in Facilitation vs. Lecture.",
+            "strengths": [
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level."
+            ],
+            "improvements": [
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Homework went unmentioned, reducing its pull on the group."
+            ],
+            "recommendations": [
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, ask two members to share one thing from their homework in the first 10 minutes."
+            ],
+            "overview": [
+              "An exceptional session — strongest in Session Structure & Flow and Scripture Engagement, with the clearest next step in Facilitation vs. Lecture. It scored 90.86/100 under the v3 weighted model.",
+              "The session played to its strengths in Session Structure & Flow and Scripture Engagement; the recommendations below turn Facilitation vs. Lecture into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Session Structure & Flow anchored the session (5/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Clean blueprint; delegated open; Socratic teaching; extended cumulative review; different closer and opener"
+                ]
+              },
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 11 distinct passages; parallel-text across 4 books on the same event"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (5/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 12 Big Ideas; 92% at DOK 3-4; woven every 10-15 min"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 11+ distinct member voices; 20+ named call-outs; deliberate inclusion of remote"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity anchored the session (5/5)",
+                "paragraphs": [
+                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Two HIGH leader disclosures (addicted brother + past relationship); three unprompted member disclosures"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: ~58% combined Joel + Bruce (mentor) leader talk; 28 points above 30% target; framework-heavy context applies"
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (3/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Kings chart strong in-room; not screen-shared for remote attendees"
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (4/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Referenced assigned reading (Jer 22:24-30); no Precept workbook-specific callouts"
+                ]
+              },
+              {
+                "title": "Prayer is a growth area (4/5)",
+                "paragraphs": [
+                  "Prayer was leader-only or rushed; the group’s voice was thin.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Delegated open (David) and different closer (Joel); no prayer-requests round-up visible"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (5/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Extended cumulative Big Ideas review at open; new Big Idea coined and field-tested in-session"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Prayer",
+                "paragraphs": [
+                  "Next time, ask one member to open and a different member to close in prayer.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 92% × weight 33 → 30.36 pts",
+                "Building Ministry: 90% × weight 31 → 27.90 pts",
+                "Engaging People: 80% × weight 18 → 14.40 pts",
+                "Being Real: 90% × weight 18 → 16.20 pts",
+                "Base (sum of cluster contributions): 88.86 / 100",
+                "Session bonuses: newcomer growth +2",
+                "Session score: 90.86 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (5/5): Clean blueprint; delegated open; Socratic teaching; extended cumulative review; different closer and opener",
+                "Newcomer Welcome (N/A): No newcomers present",
+                "Scripture Engagement (5/5): 11 distinct passages; parallel-text across 4 books on the same event",
+                "Facilitation vs. Lecture (3/5): ~58% combined Joel + Bruce (mentor) leader talk; 28 points above 30% target; framework-heavy context applies",
+                "Application Questions (5/5): 12 Big Ideas; 92% at DOK 3-4; woven every 10-15 min",
+                "Participant Engagement (5/5): 11+ distinct member voices; 20+ named call-outs; deliberate inclusion of remote",
+                "Visual Aids (3/5): Kings chart strong in-room; not screen-shared for remote attendees",
+                "Vulnerability / Authenticity (5/5): Two HIGH leader disclosures (addicted brother + past relationship); three unprompted member disclosures",
+                "Memory Reinforcement (5/5): Extended cumulative Big Ideas review at open; new Big Idea coined and field-tested in-session",
+                "Homework References (4/5): Referenced assigned reading (Jer 22:24-30); no Precept workbook-specific callouts",
+                "Prayer (4/5): Delegated open (David) and different closer (Joel); no prayer-requests round-up visible",
+                "Leader Development (5/5): Bruce co-teach on Jeconiah curse; Danny and Christian given breakout-group lead assignments"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
         {
           "id": "joel-hurt-2026-03-14-zephaniah-1-3",
           "date": "2026-03-14",
@@ -5626,7 +8011,7 @@
     {
       "id": "russell-reed",
       "name": "Russell Reed",
-      "email": "russell.reed@example.com",
+      "email": "vilitefilms@gmail.com",
       "group": "Kings Study",
       "coachName": "Bryan Bailey",
       "isCoach": true,
@@ -5924,12 +8309,1579 @@
     {
       "id": "cole-strong",
       "name": "Cole Strong",
-      "email": "cole.strong@example.com",
+      "email": "cstrong@squarecowmoovers.com",
       "group": "Kings Study",
       "coachName": "Bryan Bailey",
       "isCoach": true,
       "zoomLink": "",
       "reports": [
+        {
+          "id": "cole-strong-2026-06-06-james-2-1-13-no-partiality-royal",
+          "date": "2026-06-06",
+          "dateLabel": "June 6, 2026",
+          "session": "James 2:1–13 — No Partiality, Royal Law, Mercy Triumphs Over Judgment (Lesson 4)",
+          "topic": "Partiality exposes dead faith; royal law fulfills the law; mercy triumphs over judgment",
+          "duration": "~1h 54m",
+          "attendees": 9,
+          "newcomers": 1,
+          "score": 74.78,
+          "base": 73.78,
+          "newcomerBonus": 1,
+          "sizeBonus": 0,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 76,
+              "contribution": 25.08
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 70,
+              "contribution": 21.7
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": "Retrieval-first open, delegated prayers, clear arc; closing bumper sticker exercise slightly brief"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 3,
+              "note": "Skade welcomed with member testimonies and Cole's personal story; 9 min duration; protocol present but compressed"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "20+ cross-references, 11 books, James 1–2 + full OT/NT theology of law and mercy; session-series high"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "Strong Socratic frame; leader talk est. 40–45% (excl. reading); improved from 2/5 in May 23/30"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "4–5 DOK 3–4 questions woven throughout; 'How much mercy?' is strongest; slightly below 5–7 target"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "7–8 of 8 members active; 6 distinct scripture readers; Skade (newcomer) not drawn into lesson"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 2,
+              "note": "Slide deck submitted but noted as 'out' mid-session; no consistent visual anchor in transcript; 3rd consecutive low score"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 3,
+              "note": "Lupus/faith journey in welcome; fishing/sufficiency reflection; both genuine but resolved quickly; no major depth moment"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 4,
+              "note": "Explicit James 1 Big Ideas review at open; True Faith Test running list; closing bumper sticker consolidation; strong rebound from 2/5"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 4,
+              "note": "Newcomer orientation to 5-day homework; 'do the homework and get plugged in'; workbook page references throughout"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 5,
+              "note": "Opening delegated to Kurt; closing delegated to Lucas — different members, both prayers synthesized session themes"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": null,
+              "note": "Solo leading — third consecutive solo session; no mentor or apprentice present"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Scripture Engagement and Prayer, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Prayer was delegated to members, opening and closing the group in shared voice.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds."
+            ],
+            "overview": [
+              "A strong session — strongest in Scripture Engagement and Prayer, with the clearest next step in Visual Aids. It scored 74.78/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Prayer; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 20+ cross-references, 11 books, James 1–2 + full OT/NT theology of law and mercy; session-series high"
+                ]
+              },
+              {
+                "title": "Prayer anchored the session (5/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Opening delegated to Kurt; closing delegated to Lucas — different members, both prayers synthesized session themes"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Retrieval-first open, delegated prayers, clear arc; closing bumper sticker exercise slightly brief"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 4–5 DOK 3–4 questions woven throughout; 'How much mercy?' is strongest; slightly below 5–7 target"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 7–8 of 8 members active; 6 distinct scripture readers; Skade (newcomer) not drawn into lesson"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (2/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Slide deck submitted but noted as 'out' mid-session; no consistent visual anchor in transcript; 3rd consecutive low score"
+                ]
+              },
+              {
+                "title": "Newcomer Welcome is a growth area (3/5)",
+                "paragraphs": [
+                  "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Skade welcomed with member testimonies and Cole's personal story; 9 min duration; protocol present but compressed"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Strong Socratic frame; leader talk est. 40–45% (excl. reading); improved from 2/5 in May 23/30"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Lupus/faith journey in welcome; fishing/sufficiency reflection; both genuine but resolved quickly; no major depth moment"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (4/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Explicit James 1 Big Ideas review at open; True Faith Test running list; closing bumper sticker consolidation; strong rebound from 2/5"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Newcomer Welcome",
+                "paragraphs": [
+                  "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 76% × weight 33 → 25.08 pts",
+                "Building Ministry: 70% × weight 31 → 21.70 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 80% × weight 18 → 14.40 pts",
+                "Base (sum of cluster contributions): 73.78 / 100",
+                "Session bonuses: newcomer growth +1",
+                "Session score: 74.78 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Retrieval-first open, delegated prayers, clear arc; closing bumper sticker exercise slightly brief",
+                "Newcomer Welcome (3/5): Skade welcomed with member testimonies and Cole's personal story; 9 min duration; protocol present but compressed",
+                "Scripture Engagement (5/5): 20+ cross-references, 11 books, James 1–2 + full OT/NT theology of law and mercy; session-series high",
+                "Facilitation vs. Lecture (3/5): Strong Socratic frame; leader talk est. 40–45% (excl. reading); improved from 2/5 in May 23/30",
+                "Application Questions (4/5): 4–5 DOK 3–4 questions woven throughout; 'How much mercy?' is strongest; slightly below 5–7 target",
+                "Participant Engagement (4/5): 7–8 of 8 members active; 6 distinct scripture readers; Skade (newcomer) not drawn into lesson",
+                "Visual Aids (2/5): Slide deck submitted but noted as 'out' mid-session; no consistent visual anchor in transcript; 3rd consecutive low score",
+                "Vulnerability / Authenticity (3/5): Lupus/faith journey in welcome; fishing/sufficiency reflection; both genuine but resolved quickly; no major depth moment",
+                "Memory Reinforcement (4/5): Explicit James 1 Big Ideas review at open; True Faith Test running list; closing bumper sticker consolidation; strong rebound from 2/5",
+                "Homework References (4/5): Newcomer orientation to 5-day homework; 'do the homework and get plugged in'; workbook page references throughout",
+                "Prayer (5/5): Opening delegated to Kurt; closing delegated to Lucas — different members, both prayers synthesized session themes",
+                "Leader Development (N/A): Solo leading — third consecutive solo session; no mentor or apprentice present"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "cole-strong-2026-05-30-james-1-12-27-crown-of-life-temp",
+          "date": "2026-05-30",
+          "dateLabel": "May 30, 2026",
+          "session": "James 1:12–27 — Crown of Life, Temptation Progression & Doers vs. Hearers (Week 4)",
+          "topic": "Perseverance under trial; temptation→lust→sin→death; good gifts from above; pure religion",
+          "duration": "~1h 51m",
+          "attendees": 6,
+          "newcomers": 2,
+          "score": 60.72,
+          "base": 58.72,
+          "newcomerBonus": 2,
+          "sizeBonus": 0,
+          "status": "On Target",
+          "statusEmoji": "🟡",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 64,
+              "contribution": 21.12
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 40,
+              "contribution": 12.4
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 60,
+              "contribution": 10.8
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": "Opening prayer delegated; prior Big Ideas reviewed; OIA consistent; closing prayer NOT delegated (self-led). Structure solid except for closing."
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 2,
+              "note": "Thomas acknowledged (“thanks for coming back”) but no full welcome protocol — no member testimonies, no extended introduction. Thomas is a returning visitor, not a first-timer."
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 4,
+              "note": "9 cross-references across 7 NT books + 14 word studies. Exceeds 6+ benchmark (Precept). Minor reduction from May 23 (12 cross-refs → 9)."
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 2,
+              "note": "Leader talk ~60% (with reading), ~50% (discussion only). Target ≤35%. Extended adoption story (~12 min) and sin-progression teaching (~4 min) are primary drivers. Post-question follow-up tends toward explanation rather than holding silence."
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "5–6 Big Idea questions, majority DOK 4. Well-spaced across the session. One question (“Tuesday”) is among the strongest of the James series for precision and accountability."
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "All ~6 members contributed. 10+ name-calls. Will, Mike, Marshall, Thomas, Lucas all had substantive contributions. Bidirectional discussion observed (members responding to each other)."
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 2,
+              "note": "Some slides visible (sin-progression diagram referenced [00:47:39]). Minimal visual presence. Multiple chartable opportunities in the passage were not visualized."
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 5,
+              "note": "Adoption story (10+ min, high personal cost, current stakes named) is the highest-depth vulnerability disclosure of the James series. Marshall’s faith-uncertainty disclosure was also capitalized. Ashley moment (James 1:26 teaching) was missed."
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 3,
+              "note": "Prior bumper stickers reviewed at open (James 1:1–12); new bumper stickers generated at close. Not a full cumulative recitation of all Big Ideas from prior weeks."
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 2,
+              "note": "2 explicit references (Cole’s own homework [00:39:12]; encouragement to Thomas). No “The Guarantee”. No explicit Precept workbook references."
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 3,
+              "note": "Opening prayer delegated to Mike (appropriately). Closing prayer led by Cole himself. Both open and close delegated in May 23 (5/5). Self-led closing is the primary regression vs. prior session."
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": null,
+              "note": "Solo-led session. No mentor present, no apprentice in active development noted. N/A — does not penalize the cluster score."
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "An on target session — strongest in Vulnerability / Authenticity and Scripture Engagement, with the clearest next step in Newcomer Welcome.",
+            "strengths": [
+              "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level."
+            ],
+            "improvements": [
+              "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "The session leaned audio-only; a visual anchor would aid retention."
+            ],
+            "recommendations": [
+              "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term."
+            ],
+            "overview": [
+              "An on target session — strongest in Vulnerability / Authenticity and Scripture Engagement, with the clearest next step in Newcomer Welcome. It scored 60.72/100 under the v3 weighted model.",
+              "The session played to its strengths in Vulnerability / Authenticity and Scripture Engagement; the recommendations below turn Newcomer Welcome into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Vulnerability / Authenticity anchored the session (5/5)",
+                "paragraphs": [
+                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Adoption story (10+ min, high personal cost, current stakes named) is the highest-depth vulnerability disclosure of the James series. Marshall’s faith-uncertainty disclosure was also capitalized. Ashley moment (James 1:26 teaching) was missed."
+                ]
+              },
+              {
+                "title": "Scripture Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 9 cross-references across 7 NT books + 14 word studies. Exceeds 6+ benchmark (Precept). Minor reduction from May 23 (12 cross-refs → 9)."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 5–6 Big Idea questions, majority DOK 4. Well-spaced across the session. One question (“Tuesday”) is among the strongest of the James series for precision and accountability."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: All ~6 members contributed. 10+ name-calls. Will, Mike, Marshall, Thomas, Lucas all had substantive contributions. Bidirectional discussion observed (members responding to each other)."
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (3/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Opening prayer delegated; prior Big Ideas reviewed; OIA consistent; closing prayer NOT delegated (self-led). Structure solid except for closing."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Newcomer Welcome is a growth area (2/5)",
+                "paragraphs": [
+                  "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Thomas acknowledged (“thanks for coming back”) but no full welcome protocol — no member testimonies, no extended introduction. Thomas is a returning visitor, not a first-timer."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (2/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Leader talk ~60% (with reading), ~50% (discussion only). Target ≤35%. Extended adoption story (~12 min) and sin-progression teaching (~4 min) are primary drivers. Post-question follow-up tends toward explanation rather than holding silence."
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (2/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Some slides visible (sin-progression diagram referenced [00:47:39]). Minimal visual presence. Multiple chartable opportunities in the passage were not visualized."
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (2/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 2 explicit references (Cole’s own homework [00:39:12]; encouragement to Thomas). No “The Guarantee”. No explicit Precept workbook references."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Prior bumper stickers reviewed at open (James 1:1–12); new bumper stickers generated at close. Not a full cumulative recitation of all Big Ideas from prior weeks."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Newcomer Welcome",
+                "paragraphs": [
+                  "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 64% × weight 33 → 21.12 pts",
+                "Building Ministry: 40% × weight 31 → 12.40 pts",
+                "Engaging People: 60% × weight 18 → 10.80 pts",
+                "Being Real: 80% × weight 18 → 14.40 pts",
+                "Base (sum of cluster contributions): 58.72 / 100",
+                "Session bonuses: newcomer growth +2",
+                "Session score: 60.72 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3/5): Opening prayer delegated; prior Big Ideas reviewed; OIA consistent; closing prayer NOT delegated (self-led). Structure solid except for closing.",
+                "Newcomer Welcome (2/5): Thomas acknowledged (“thanks for coming back”) but no full welcome protocol — no member testimonies, no extended introduction. Thomas is a returning visitor, not a first-timer.",
+                "Scripture Engagement (4/5): 9 cross-references across 7 NT books + 14 word studies. Exceeds 6+ benchmark (Precept). Minor reduction from May 23 (12 cross-refs → 9).",
+                "Facilitation vs. Lecture (2/5): Leader talk ~60% (with reading), ~50% (discussion only). Target ≤35%. Extended adoption story (~12 min) and sin-progression teaching (~4 min) are primary drivers. Post-question follow-up tends toward explanation rather than holding silence.",
+                "Application Questions (4/5): 5–6 Big Idea questions, majority DOK 4. Well-spaced across the session. One question (“Tuesday”) is among the strongest of the James series for precision and accountability.",
+                "Participant Engagement (4/5): All ~6 members contributed. 10+ name-calls. Will, Mike, Marshall, Thomas, Lucas all had substantive contributions. Bidirectional discussion observed (members responding to each other).",
+                "Visual Aids (2/5): Some slides visible (sin-progression diagram referenced [00:47:39]). Minimal visual presence. Multiple chartable opportunities in the passage were not visualized.",
+                "Vulnerability / Authenticity (5/5): Adoption story (10+ min, high personal cost, current stakes named) is the highest-depth vulnerability disclosure of the James series. Marshall’s faith-uncertainty disclosure was also capitalized. Ashley moment (James 1:26 teaching) was missed.",
+                "Memory Reinforcement (3/5): Prior bumper stickers reviewed at open (James 1:1–12); new bumper stickers generated at close. Not a full cumulative recitation of all Big Ideas from prior weeks.",
+                "Homework References (2/5): 2 explicit references (Cole’s own homework [00:39:12]; encouragement to Thomas). No “The Guarantee”. No explicit Precept workbook references.",
+                "Prayer (3/5): Opening prayer delegated to Mike (appropriately). Closing prayer led by Cole himself. Both open and close delegated in May 23 (5/5). Self-led closing is the primary regression vs. prior session.",
+                "Leader Development (N/A): Solo-led session. No mentor present, no apprentice in active development noted. N/A — does not penalize the cluster score."
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "cole-strong-2026-05-23-james-1-2-12-trials-endurance-wi",
+          "date": "2026-05-23",
+          "dateLabel": "May 23, 2026",
+          "session": "James 1:2–12 — Trials, Endurance, Wisdom & Double-Mindedness (Week 3 Deep-Dive)",
+          "topic": "Trials → testing of faith → endurance → maturity; wisdom without doubt; humble vs. rich man",
+          "duration": "~1h 48m",
+          "attendees": 9,
+          "newcomers": 0,
+          "score": 63.6,
+          "base": 63.6,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "On Target",
+          "statusEmoji": "🟡",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 60,
+              "contribution": 19.8
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 60,
+              "contribution": 18.6
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 60,
+              "contribution": 10.8
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": "10-step blueprint partial: newcomer welcome ✓, opening prayer ✓, context overview ✓, scripture reading ✓, closing prayer ✓; Big Ideas recitation at open missing (Week 3)"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 3,
+              "note": "Thomas and Bo welcomed with member testimonies; Cole said ‘quick introduction’ and was rushed; Bo got limited direct attention; ~8 min total"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "12 cross-references — Eph 4, Phil 3, Rom 5, 1 Pet 1&4, Mk 11, Dan 2, Job 12, Rom 11, Acts 2&4, 1 Cor 1; exceeds 6+ benchmark 2×"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 2,
+              "note": "~55% leader talk in discussion-only; target ≤35%; extended monologues at 00:36 and 01:35"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "5 Big Idea questions; 3 DOK 4, 2 DOK 3; well distributed; strongest DOK profile of three sessions"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "~88% participation; 10+ name-calls; newcomer Thomas integrated; Bo less visible"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 1,
+              "note": "No visual aids; third consecutive week declining (5 → 3 → 1); significant regression"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 3,
+              "note": "Two hints without landing; personal application at close is strongest moment but lacks specific detail"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 2,
+              "note": "No cumulative Big Ideas review at session open despite Week 3; bumper sticker exercise at close is positive"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 3,
+              "note": "2 explicit references (word study homework, Lucas praised); down from 4 prior sessions"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 5,
+              "note": "Opening (Will) and closing (Mike) both delegated to different members; Mike’s closing prayer was exceptional"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": null,
+              "note": "Solo-led; no mentor present; N/A per rubric (no penalty)"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "An on target session — strongest in Scripture Engagement and Prayer, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Prayer was delegated to members, opening and closing the group in shared voice.",
+              "Application questions pushed members from concept to life, several at the reason/apply level."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas."
+            ],
+            "overview": [
+              "An on target session — strongest in Scripture Engagement and Prayer, with the clearest next step in Visual Aids. It scored 63.6/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Prayer; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 12 cross-references — Eph 4, Phil 3, Rom 5, 1 Pet 1&4, Mk 11, Dan 2, Job 12, Rom 11, Acts 2&4, 1 Cor 1; exceeds 6+ benchmark 2×"
+                ]
+              },
+              {
+                "title": "Prayer anchored the session (5/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Opening (Will) and closing (Mike) both delegated to different members; Mike’s closing prayer was exceptional"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 5 Big Idea questions; 3 DOK 4, 2 DOK 3; well distributed; strongest DOK profile of three sessions"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: ~88% participation; 10+ name-calls; newcomer Thomas integrated; Bo less visible"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (3/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 10-step blueprint partial: newcomer welcome ✓, opening prayer ✓, context overview ✓, scripture reading ✓, closing prayer ✓; Big Ideas recitation at open missing (Week 3)"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (1/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: No visual aids; third consecutive week declining (5 → 3 → 1); significant regression"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (2/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: ~55% leader talk in discussion-only; target ≤35%; extended monologues at 00:36 and 01:35"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (2/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: No cumulative Big Ideas review at session open despite Week 3; bumper sticker exercise at close is positive"
+                ]
+              },
+              {
+                "title": "Newcomer Welcome is a growth area (3/5)",
+                "paragraphs": [
+                  "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Thomas and Bo welcomed with member testimonies; Cole said ‘quick introduction’ and was rushed; Bo got limited direct attention; ~8 min total"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Two hints without landing; personal application at close is strongest moment but lacks specific detail"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Newcomer Welcome",
+                "paragraphs": [
+                  "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 60% × weight 33 → 19.80 pts",
+                "Building Ministry: 60% × weight 31 → 18.60 pts",
+                "Engaging People: 60% × weight 18 → 10.80 pts",
+                "Being Real: 80% × weight 18 → 14.40 pts",
+                "Base (sum of cluster contributions): 63.60 / 100",
+                "Session score: 63.6 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3/5): 10-step blueprint partial: newcomer welcome ✓, opening prayer ✓, context overview ✓, scripture reading ✓, closing prayer ✓; Big Ideas recitation at open missing (Week 3)",
+                "Newcomer Welcome (3/5): Thomas and Bo welcomed with member testimonies; Cole said ‘quick introduction’ and was rushed; Bo got limited direct attention; ~8 min total",
+                "Scripture Engagement (5/5): 12 cross-references — Eph 4, Phil 3, Rom 5, 1 Pet 1&4, Mk 11, Dan 2, Job 12, Rom 11, Acts 2&4, 1 Cor 1; exceeds 6+ benchmark 2×",
+                "Facilitation vs. Lecture (2/5): ~55% leader talk in discussion-only; target ≤35%; extended monologues at 00:36 and 01:35",
+                "Application Questions (4/5): 5 Big Idea questions; 3 DOK 4, 2 DOK 3; well distributed; strongest DOK profile of three sessions",
+                "Participant Engagement (4/5): ~88% participation; 10+ name-calls; newcomer Thomas integrated; Bo less visible",
+                "Visual Aids (1/5): No visual aids; third consecutive week declining (5 → 3 → 1); significant regression",
+                "Vulnerability / Authenticity (3/5): Two hints without landing; personal application at close is strongest moment but lacks specific detail",
+                "Memory Reinforcement (2/5): No cumulative Big Ideas review at session open despite Week 3; bumper sticker exercise at close is positive",
+                "Homework References (3/5): 2 explicit references (word study homework, Lucas praised); down from 4 prior sessions",
+                "Prayer (5/5): Opening (Will) and closing (Mike) both delegated to different members; Mike’s closing prayer was exceptional",
+                "Leader Development (N/A): Solo-led; no mentor present; N/A per rubric (no penalty)"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "cole-strong-2026-05-16-james-book-survey-five-chapter-h",
+          "date": "2026-05-16",
+          "dateLabel": "May 16, 2026",
+          "session": "James Book Survey — Five-Chapter High-Level Overview (Week 2 of James Series)",
+          "topic": "Wisdom, endurance, faith & works, the tongue, humility, patience",
+          "duration": "1h 47m (~107 minutes)",
+          "attendees": 10,
+          "newcomers": 0,
+          "score": 75.29,
+          "base": 75.29,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 72,
+              "contribution": 23.76
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 73.3,
+              "contribution": 22.73
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 90,
+              "contribution": 16.2
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": "10-step blueprint followed well for survey format; Big Ideas recitation N/A (new book)"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 4,
+              "note": "Will Blackman welcomed with full group testimonies + BLB equipping; ~8–10 min"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 4,
+              "note": "7+ cross-references; 90% verse-grounded; all 5 chapters read aloud by group"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "~62% leader talk in discussion; 32 points above 30% target"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "6 Big Idea questions; DOK 2–3; appropriate for survey; no DOK 4 this session"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "~89% substantive participation; newcomer integrated; 15+ name-calls"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 3,
+              "note": "BLB demo only; minimal slides; appropriate for outdoor survey session"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": "Austin-move story at full personal cost; member vulnerability (Mike’s tongue conviction)"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 3,
+              "note": "No prior Big Ideas to recite (new book); end-of-session theme synthesis without bumper stickers"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 4,
+              "note": "Multiple homework encouragements; BLB demo for next week’s word studies; ‘do your homework’ cited 3+ times"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 5,
+              "note": "Opening (Mike) and closing (Marshall) both delegated to different members; excellent"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 3,
+              "note": "Solo-led; no mentor present; appropriate execution under solo config"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Prayer and Session Structure & Flow, with the clearest next step in Facilitation vs. Lecture.",
+            "strengths": [
+              "Prayer was delegated to members, opening and closing the group in shared voice.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+              "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began."
+            ],
+            "improvements": [
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded."
+            ],
+            "recommendations": [
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas."
+            ],
+            "overview": [
+              "A strong session — strongest in Prayer and Session Structure & Flow, with the clearest next step in Facilitation vs. Lecture. It scored 75.29/100 under the v3 weighted model.",
+              "The session played to its strengths in Prayer and Session Structure & Flow; the recommendations below turn Facilitation vs. Lecture into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Prayer anchored the session (5/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Opening (Mike) and closing (Marshall) both delegated to different members; excellent"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 10-step blueprint followed well for survey format; Big Ideas recitation N/A (new book)"
+                ]
+              },
+              {
+                "title": "Newcomer Welcome anchored the session (4/5)",
+                "paragraphs": [
+                  "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Will Blackman welcomed with full group testimonies + BLB equipping; ~8–10 min"
+                ]
+              },
+              {
+                "title": "Scripture Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 7+ cross-references; 90% verse-grounded; all 5 chapters read aloud by group"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 6 Big Idea questions; DOK 2–3; appropriate for survey; no DOK 4 this session"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: ~62% leader talk in discussion; 32 points above 30% target"
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (3/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: BLB demo only; minimal slides; appropriate for outdoor survey session"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: No prior Big Ideas to recite (new book); end-of-session theme synthesis without bumper stickers"
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (3/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Solo-led; no mentor present; appropriate execution under solo config"
+                ]
+              },
+              {
+                "title": "Participant Engagement is a growth area (4/5)",
+                "paragraphs": [
+                  "A few voices carried the discussion; quieter members went unheard.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: ~89% substantive participation; newcomer integrated; 15+ name-calls"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Participant Engagement",
+                "paragraphs": [
+                  "Next time, name one quiet regular early and invite their read on a passage.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 72% × weight 33 → 23.76 pts",
+                "Building Ministry: 73.3% × weight 31 → 22.73 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 90% × weight 18 → 16.20 pts",
+                "Base (sum of cluster contributions): 75.29 / 100",
+                "Session score: 75.29 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): 10-step blueprint followed well for survey format; Big Ideas recitation N/A (new book)",
+                "Newcomer Welcome (4/5): Will Blackman welcomed with full group testimonies + BLB equipping; ~8–10 min",
+                "Scripture Engagement (4/5): 7+ cross-references; 90% verse-grounded; all 5 chapters read aloud by group",
+                "Facilitation vs. Lecture (3/5): ~62% leader talk in discussion; 32 points above 30% target",
+                "Application Questions (4/5): 6 Big Idea questions; DOK 2–3; appropriate for survey; no DOK 4 this session",
+                "Participant Engagement (4/5): ~89% substantive participation; newcomer integrated; 15+ name-calls",
+                "Visual Aids (3/5): BLB demo only; minimal slides; appropriate for outdoor survey session",
+                "Vulnerability / Authenticity (4/5): Austin-move story at full personal cost; member vulnerability (Mike’s tongue conviction)",
+                "Memory Reinforcement (3/5): No prior Big Ideas to recite (new book); end-of-session theme synthesis without bumper stickers",
+                "Homework References (4/5): Multiple homework encouragements; BLB demo for next week’s word studies; ‘do your homework’ cited 3+ times",
+                "Prayer (5/5): Opening (Mike) and closing (Marshall) both delegated to different members; excellent",
+                "Leader Development (3/5): Solo-led; no mentor present; appropriate execution under solo config"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "cole-strong-2026-04-18-listening-to-god-through-the-pro",
+          "date": "2026-04-18",
+          "dateLabel": "April 18, 2026",
+          "session": "Listening to God Through the Prophets — Zedekiah and the Fall of Judah",
+          "topic": "Sovereignty; false prophets; mercy's expiration; listening and obedience",
+          "duration": "1h 52m (112 minutes)",
+          "attendees": 8,
+          "newcomers": 0,
+          "score": 82.64,
+          "base": 82.64,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 88,
+              "contribution": 29.04
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 80,
+              "contribution": 24.8
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 90,
+              "contribution": 16.2
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": "Clean arc; retrieval-first opening; close collapsed to 'Jesus' rather than Big Ideas restated"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": "No newcomers present"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "9+ books triangulated on one narrative; ~95% verse-grounded"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "~55% leader talk in discussion; 25 points above 30% target"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 5,
+              "note": "7 Big Ideas, 100% at DOK 3-4, woven every 10-15 min"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "~75% substantive; reading distribution strong; quiet members under-activated"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 5,
+              "note": "One bold slide per big idea + 2 Kings timeline — Mayer's multimedia principle"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": "Moderate leader depth; high member depth (Mike unprompted)"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 3,
+              "note": "Strong retrieval-first open; Big Ideas not restated at close"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 4,
+              "note": "Regular workbook references; lesson built on homework passages"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 5,
+              "note": "Opening (Jacy) and closing (Mike Rockwell) both delegated; different members"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 4,
+              "note": "Solo-leading (no mentor present this session); strong execution under solo config"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Facilitation vs. Lecture.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "On-screen word study and visuals reinforced the teaching multi-modally."
+            ],
+            "improvements": [
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+              "Transitions between segments lost momentum, so the session’s shape was harder to feel."
+            ],
+            "recommendations": [
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+              "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp."
+            ],
+            "overview": [
+              "A strong session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Facilitation vs. Lecture. It scored 82.64/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Application Questions; the recommendations below turn Facilitation vs. Lecture into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 9+ books triangulated on one narrative; ~95% verse-grounded"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (5/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 7 Big Ideas, 100% at DOK 3-4, woven every 10-15 min"
+                ]
+              },
+              {
+                "title": "Visual Aids anchored the session (5/5)",
+                "paragraphs": [
+                  "On-screen word study and visuals reinforced the teaching multi-modally.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: One bold slide per big idea + 2 Kings timeline — Mayer's multimedia principle"
+                ]
+              },
+              {
+                "title": "Prayer anchored the session (5/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Opening (Jacy) and closing (Mike Rockwell) both delegated; different members"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Clean arc; retrieval-first opening; close collapsed to 'Jesus' rather than Big Ideas restated"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: ~55% leader talk in discussion; 25 points above 30% target"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Strong retrieval-first open; Big Ideas not restated at close"
+                ]
+              },
+              {
+                "title": "Participant Engagement is a growth area (4/5)",
+                "paragraphs": [
+                  "A few voices carried the discussion; quieter members went unheard.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: ~75% substantive; reading distribution strong; quiet members under-activated"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (4/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Moderate leader depth; high member depth (Mike unprompted)"
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (4/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Regular workbook references; lesson built on homework passages"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Participant Engagement",
+                "paragraphs": [
+                  "Next time, name one quiet regular early and invite their read on a passage.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 88% × weight 33 → 29.04 pts",
+                "Building Ministry: 80% × weight 31 → 24.80 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 90% × weight 18 → 16.20 pts",
+                "Base (sum of cluster contributions): 82.64 / 100",
+                "Session score: 82.64 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Clean arc; retrieval-first opening; close collapsed to 'Jesus' rather than Big Ideas restated",
+                "Newcomer Welcome (N/A): No newcomers present",
+                "Scripture Engagement (5/5): 9+ books triangulated on one narrative; ~95% verse-grounded",
+                "Facilitation vs. Lecture (3/5): ~55% leader talk in discussion; 25 points above 30% target",
+                "Application Questions (5/5): 7 Big Ideas, 100% at DOK 3-4, woven every 10-15 min",
+                "Participant Engagement (4/5): ~75% substantive; reading distribution strong; quiet members under-activated",
+                "Visual Aids (5/5): One bold slide per big idea + 2 Kings timeline — Mayer's multimedia principle",
+                "Vulnerability / Authenticity (4/5): Moderate leader depth; high member depth (Mike unprompted)",
+                "Memory Reinforcement (3/5): Strong retrieval-first open; Big Ideas not restated at close",
+                "Homework References (4/5): Regular workbook references; lesson built on homework passages",
+                "Prayer (5/5): Opening (Jacy) and closing (Mike Rockwell) both delegated; different members",
+                "Leader Development (4/5): Solo-leading (no mentor present this session); strong execution under solo config"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
         {
           "id": "cole-strong-2026-03-28-kings-p10-l4-2-kings-23-31-24-9",
           "date": "2026-03-28",
@@ -6223,12 +10175,640 @@
     {
       "id": "ken-ture",
       "name": "Ken Ture",
-      "email": "ken.ture@example.com",
+      "email": "kenture@me.com",
       "group": "Jeremiah Study",
       "coachName": "Bryan Bailey",
       "isCoach": true,
       "zoomLink": "",
       "reports": [
+        {
+          "id": "ken-ture-2026-06-06-james-lesson-4-partiality-rich-v",
+          "date": "2026-06-06",
+          "dateLabel": "June 6, 2026",
+          "session": "James Lesson 4 — Partiality, Rich vs. Poor, and the Law of Liberty",
+          "topic": "James 2:1-13 — God shows no partiality; mercy triumphs over judgment",
+          "duration": "~2h 10m",
+          "attendees": 13,
+          "newcomers": 3,
+          "score": 70.03,
+          "base": 67.03,
+          "newcomerBonus": 3,
+          "sizeBonus": 0,
+          "status": "On Target",
+          "statusEmoji": "🟡",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 72,
+              "contribution": 23.76
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 46.7,
+              "contribution": 14.47
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 90,
+              "contribution": 16.2
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": "10-step blueprint followed well; Big Ideas review present but long (20 min); newcomer welcome absent; delegated open/close prayer."
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 2,
+              "note": "James (3rd week) mentioned casually [00:09:39]; no formal welcome, no member testimonies, no prayer for James by name."
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "10+ cross-references across 7 books; all read aloud by named members; verse-grounded throughout (~85%)."
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 4,
+              "note": "~40% leader / 60% member; strong Socratic facilitation; 2 brief monologues (<90 sec each) in context not discussion."
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 5,
+              "note": "14 Big Idea questions; 0% DOK 1; 50% DOK 3; 36% DOK 4. Best question-quality session in Ken’s record."
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 5,
+              "note": "13 distinct named voices; Ken called members by name throughout; quieter members explicitly invited ('Somebody that hasn’t spoken yet?')."
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 1,
+              "note": "No whiteboard, slides, Blue Letter Bible, or shared screen. Hamartia word study ([01:47:40]) was the perfect BLB moment — missed."
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": "3 leader disclosures at meaningful depth; Ken’s homosexual favoritism confession directly unlocked Jeff’s disclosure. 4 member disclosures."
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 3,
+              "note": "20-min opening Big Ideas review — conversational, not structured recitation from memory. Content was good; form was loose."
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 3,
+              "note": "3 references: Blake’s hamartia homework insight [01:47:40]; Josh Samuel insight from last week referenced; workbook framing implicit."
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 3,
+              "note": "Opening prayer delegated to Eric; closing prayer delegated. No prayer requests taken despite multiple vulnerability disclosures."
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 2,
+              "note": "Tasks distributed (Eric prayed, rotating readers, Stephen managed logistics) but no named apprentice, no multiplication signal in 3 sessions."
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "An on target session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "A high share of the room contributed substantively, called on by name."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+              "No in-session development of another leader was observable this week."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\""
+            ],
+            "overview": [
+              "An on target session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Visual Aids. It scored 70.03/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Application Questions; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 10+ cross-references across 7 books; all read aloud by named members; verse-grounded throughout (~85%)."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (5/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 14 Big Idea questions; 0% DOK 1; 50% DOK 3; 36% DOK 4. Best question-quality session in Ken’s record."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 13 distinct named voices; Ken called members by name throughout; quieter members explicitly invited ('Somebody that hasn’t spoken yet?')."
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 10-step blueprint followed well; Big Ideas review present but long (20 min); newcomer welcome absent; delegated open/close prayer."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture anchored the session (4/5)",
+                "paragraphs": [
+                  "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: ~40% leader / 60% member; strong Socratic facilitation; 2 brief monologues (<90 sec each) in context not discussion."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (1/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: No whiteboard, slides, Blue Letter Bible, or shared screen. Hamartia word study ([01:47:40]) was the perfect BLB moment — missed."
+                ]
+              },
+              {
+                "title": "Newcomer Welcome is a growth area (2/5)",
+                "paragraphs": [
+                  "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: James (3rd week) mentioned casually [00:09:39]; no formal welcome, no member testimonies, no prayer for James by name."
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (2/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Tasks distributed (Eric prayed, rotating readers, Stephen managed logistics) but no named apprentice, no multiplication signal in 3 sessions."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 20-min opening Big Ideas review — conversational, not structured recitation from memory. Content was good; form was loose."
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (3/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 3 references: Blake’s hamartia homework insight [01:47:40]; Josh Samuel insight from last week referenced; workbook framing implicit."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Newcomer Welcome",
+                "paragraphs": [
+                  "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 72% × weight 33 → 23.76 pts",
+                "Building Ministry: 46.7% × weight 31 → 14.47 pts",
+                "Engaging People: 90% × weight 18 → 16.20 pts",
+                "Being Real: 70% × weight 18 → 12.60 pts",
+                "Base (sum of cluster contributions): 67.03 / 100",
+                "Session bonuses: newcomer growth +3",
+                "Session score: 70.03 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): 10-step blueprint followed well; Big Ideas review present but long (20 min); newcomer welcome absent; delegated open/close prayer.",
+                "Newcomer Welcome (2/5): James (3rd week) mentioned casually [00:09:39]; no formal welcome, no member testimonies, no prayer for James by name.",
+                "Scripture Engagement (5/5): 10+ cross-references across 7 books; all read aloud by named members; verse-grounded throughout (~85%).",
+                "Facilitation vs. Lecture (4/5): ~40% leader / 60% member; strong Socratic facilitation; 2 brief monologues (<90 sec each) in context not discussion.",
+                "Application Questions (5/5): 14 Big Idea questions; 0% DOK 1; 50% DOK 3; 36% DOK 4. Best question-quality session in Ken’s record.",
+                "Participant Engagement (5/5): 13 distinct named voices; Ken called members by name throughout; quieter members explicitly invited ('Somebody that hasn’t spoken yet?').",
+                "Visual Aids (1/5): No whiteboard, slides, Blue Letter Bible, or shared screen. Hamartia word study ([01:47:40]) was the perfect BLB moment — missed.",
+                "Vulnerability / Authenticity (4/5): 3 leader disclosures at meaningful depth; Ken’s homosexual favoritism confession directly unlocked Jeff’s disclosure. 4 member disclosures.",
+                "Memory Reinforcement (3/5): 20-min opening Big Ideas review — conversational, not structured recitation from memory. Content was good; form was loose.",
+                "Homework References (3/5): 3 references: Blake’s hamartia homework insight [01:47:40]; Josh Samuel insight from last week referenced; workbook framing implicit.",
+                "Prayer (3/5): Opening prayer delegated to Eric; closing prayer delegated. No prayer requests taken despite multiple vulnerability disclosures.",
+                "Leader Development (2/5): Tasks distributed (Eric prayed, rotating readers, Stephen managed logistics) but no named apprentice, no multiplication signal in 3 sessions."
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "ken-ture-2026-05-16-james-book-overview-james-1-1-11",
+          "date": "2026-05-16",
+          "dateLabel": "May 16, 2026",
+          "session": "James — book overview + James 1:1-11 deep dive",
+          "topic": "Doers of the Word, joy in trials, double-mindedness, identity over behavior",
+          "duration": "2h 15m (135 minutes)",
+          "attendees": 10,
+          "newcomers": 1,
+          "score": 83.85,
+          "base": 82.85,
+          "newcomerBonus": 1,
+          "sizeBonus": 0,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 84,
+              "contribution": 27.72
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 73.3,
+              "contribution": 22.73
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 90,
+              "contribution": 16.2
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 90,
+              "contribution": 16.2
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": "Clean 10-step arc; delegated open and close to different members; two soft spots — long OIA review and ~2 min audio troubleshooting with Jim"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 3,
+              "note": "Jeff introduced; ~3 min total; no member testimonies preceded the intro; Josh’s share at 14:29 was the right material but not framed as a welcome"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "9+ cross-references across both Testaments; Hebrews 4:12 read aloud; ‘each part brings out different aspects of God’ principle named"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 4,
+              "note": "~38% leader-talk in discussion-only; ~42% with reading; prompt-then-yield signature move; 10+ named call-outs"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 5,
+              "note": "8 Big Idea questions; 75% at DOK 3-4; spaced across the full 2 hours; text → meaning → life movement consistent"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 5,
+              "note": "11 distinct named voices; 5+ rotating readers; quiet voices drawn out by name (Caesar); peer-to-peer responses visible"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 2,
+              "note": "Whiteboard only; no slides, no diaspora map, no Blue Letter Bible, no shared screen on Zoom; Mayer’s multimedia principle not engaged"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 5,
+              "note": "Ken’s HIGH-depth disclosure about Cindy unlocked 5+ HIGH-depth member disclosures; Willow Creek force-multiplier effect in operation"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 5,
+              "note": "Group recited OIA + 5 W’s + H from memory; Stephen captured this session’s themes for next-week recall — textbook Ebbinghaus"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 5,
+              "note": "4+ explicit references; defended workbook pedagogy; used as the discussion catalyst for the first 25 min"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": "Both open (Stephen) and close (Josh) delegated to different members; gap is no dedicated prayer-request time and no prayer-chain infrastructure visible"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 3,
+              "note": "Tasks delegated (board, reading, prayer) but no named apprentice being explicitly coached; no real-time coaching language ‘next time, try …’"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "A high share of the room contributed substantively, called on by name."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+              "No in-session development of another leader was observable this week."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\""
+            ],
+            "overview": [
+              "A strong session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Visual Aids. It scored 83.85/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Application Questions; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 9+ cross-references across both Testaments; Hebrews 4:12 read aloud; ‘each part brings out different aspects of God’ principle named"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (5/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 8 Big Idea questions; 75% at DOK 3-4; spaced across the full 2 hours; text → meaning → life movement consistent"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 11 distinct named voices; 5+ rotating readers; quiet voices drawn out by name (Caesar); peer-to-peer responses visible"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity anchored the session (5/5)",
+                "paragraphs": [
+                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Ken’s HIGH-depth disclosure about Cindy unlocked 5+ HIGH-depth member disclosures; Willow Creek force-multiplier effect in operation"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement anchored the session (5/5)",
+                "paragraphs": [
+                  "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Group recited OIA + 5 W’s + H from memory; Stephen captured this session’s themes for next-week recall — textbook Ebbinghaus"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (2/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Whiteboard only; no slides, no diaspora map, no Blue Letter Bible, no shared screen on Zoom; Mayer’s multimedia principle not engaged"
+                ]
+              },
+              {
+                "title": "Newcomer Welcome is a growth area (3/5)",
+                "paragraphs": [
+                  "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Jeff introduced; ~3 min total; no member testimonies preceded the intro; Josh’s share at 14:29 was the right material but not framed as a welcome"
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (3/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Tasks delegated (board, reading, prayer) but no named apprentice being explicitly coached; no real-time coaching language ‘next time, try …’"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow is a growth area (4/5)",
+                "paragraphs": [
+                  "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Clean 10-step arc; delegated open and close to different members; two soft spots — long OIA review and ~2 min audio troubleshooting with Jim"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (4/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: ~38% leader-talk in discussion-only; ~42% with reading; prompt-then-yield signature move; 10+ named call-outs"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Newcomer Welcome",
+                "paragraphs": [
+                  "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Session Structure & Flow",
+                "paragraphs": [
+                  "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 84% × weight 33 → 27.72 pts",
+                "Building Ministry: 73.3% × weight 31 → 22.73 pts",
+                "Engaging People: 90% × weight 18 → 16.20 pts",
+                "Being Real: 90% × weight 18 → 16.20 pts",
+                "Base (sum of cluster contributions): 82.85 / 100",
+                "Session bonuses: newcomer growth +1",
+                "Session score: 83.85 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Clean 10-step arc; delegated open and close to different members; two soft spots — long OIA review and ~2 min audio troubleshooting with Jim",
+                "Newcomer Welcome (3/5): Jeff introduced; ~3 min total; no member testimonies preceded the intro; Josh’s share at 14:29 was the right material but not framed as a welcome",
+                "Scripture Engagement (5/5): 9+ cross-references across both Testaments; Hebrews 4:12 read aloud; ‘each part brings out different aspects of God’ principle named",
+                "Facilitation vs. Lecture (4/5): ~38% leader-talk in discussion-only; ~42% with reading; prompt-then-yield signature move; 10+ named call-outs",
+                "Application Questions (5/5): 8 Big Idea questions; 75% at DOK 3-4; spaced across the full 2 hours; text → meaning → life movement consistent",
+                "Participant Engagement (5/5): 11 distinct named voices; 5+ rotating readers; quiet voices drawn out by name (Caesar); peer-to-peer responses visible",
+                "Visual Aids (2/5): Whiteboard only; no slides, no diaspora map, no Blue Letter Bible, no shared screen on Zoom; Mayer’s multimedia principle not engaged",
+                "Vulnerability / Authenticity (5/5): Ken’s HIGH-depth disclosure about Cindy unlocked 5+ HIGH-depth member disclosures; Willow Creek force-multiplier effect in operation",
+                "Memory Reinforcement (5/5): Group recited OIA + 5 W’s + H from memory; Stephen captured this session’s themes for next-week recall — textbook Ebbinghaus",
+                "Homework References (5/5): 4+ explicit references; defended workbook pedagogy; used as the discussion catalyst for the first 25 min",
+                "Prayer (4/5): Both open (Stephen) and close (Josh) delegated to different members; gap is no dedicated prayer-request time and no prayer-chain infrastructure visible",
+                "Leader Development (3/5): Tasks delegated (board, reading, prayer) but no named apprentice being explicitly coached; no real-time coaching language ‘next time, try …’"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
         {
           "id": "ken-ture-2026-03-25-jeremiah-lesson-4",
           "date": "2026-03-25",
@@ -6517,6 +11097,5445 @@
           "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
         }
       ]
+    },
+    {
+      "id": "ricky-town",
+      "name": "Ricky Town",
+      "email": "ricky@modhometx.com",
+      "group": "Saturday Men’s Study (1 John / James)",
+      "coachName": "Bryan Bailey",
+      "isCoach": true,
+      "zoomLink": "",
+      "reports": [
+        {
+          "id": "ricky-town-2026-06-07-james-2-1-13-lesson-4-partiality",
+          "date": "2026-06-07",
+          "dateLabel": "June 7, 2026",
+          "session": "James 2:1–13, Lesson 4 — Partiality, the Royal Law, and Mercy",
+          "topic": "Personal favoritism as sin; the royal law; mercy vs. judgment",
+          "duration": "~99 minutes",
+          "attendees": 11,
+          "newcomers": 0,
+          "score": 59.54,
+          "base": 59.54,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "Developing",
+          "statusEmoji": "🟠",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 68,
+              "contribution": 22.44
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 50,
+              "contribution": 15.5
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 50,
+              "contribution": 9
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": "Building Ministry"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 4,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "Engaging People"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "Engaging People"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 2,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 3,
+              "note": "Being Real"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 4,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 2,
+              "note": "Building Ministry"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 2,
+              "note": "Being Real"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 3,
+              "note": "Building Ministry"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A developing session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "A high share of the room contributed substantively, called on by name."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Homework went unmentioned, reducing its pull on the group.",
+              "Prayer was leader-only or rushed; the group’s voice was thin."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+              "Next time, ask one member to open and a different member to close in prayer."
+            ],
+            "overview": [
+              "A developing session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Visual Aids. It scored 59.54/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Application Questions; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Engaging People"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement anchored the session (4/5)",
+                "paragraphs": [
+                  "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (3/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (2/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (2/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Building Ministry"
+                ]
+              },
+              {
+                "title": "Prayer is a growth area (2/5)",
+                "paragraphs": [
+                  "Prayer was leader-only or rushed; the group’s voice was thin.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Being Real"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Engaging People"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Being Real"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Prayer",
+                "paragraphs": [
+                  "Next time, ask one member to open and a different member to close in prayer.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 68% × weight 33 → 22.44 pts",
+                "Building Ministry: 50% × weight 31 → 15.50 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 50% × weight 18 → 9.00 pts",
+                "Base (sum of cluster contributions): 59.54 / 100",
+                "Session score: 59.54 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3/5): Teaching Craft",
+                "Newcomer Welcome (N/A): Building Ministry",
+                "Scripture Engagement (4/5): Teaching Craft",
+                "Facilitation vs. Lecture (3/5): Engaging People",
+                "Application Questions (4/5): Teaching Craft",
+                "Participant Engagement (4/5): Engaging People",
+                "Visual Aids (2/5): Teaching Craft",
+                "Vulnerability / Authenticity (3/5): Being Real",
+                "Memory Reinforcement (4/5): Teaching Craft",
+                "Homework References (2/5): Building Ministry",
+                "Prayer (2/5): Being Real",
+                "Leader Development (3/5): Building Ministry"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "ricky-town-2026-05-30-james-1-12-27-lesson-3-the-crown",
+          "date": "2026-05-30",
+          "dateLabel": "May 30, 2026",
+          "session": "James 1:12–27, Lesson 3 — The Crown of Life, Birth Cycle of Sin & Pure Religion",
+          "topic": "Perseverance under trial; temptation vs. testing; God’s character; hearing vs. doing",
+          "duration": "~1h 46m",
+          "attendees": 12,
+          "newcomers": 2,
+          "score": 64.16,
+          "base": 62.16,
+          "newcomerBonus": 2,
+          "sizeBonus": 0,
+          "status": "On Target",
+          "statusEmoji": "🟡",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 72,
+              "contribution": 23.76
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 60,
+              "contribution": 18.6
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 50,
+              "contribution": 9
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 60,
+              "contribution": 10.8
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": "Building Ministry"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 2,
+              "note": "Building Ministry"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 2,
+              "note": "Engaging People"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 3,
+              "note": "Engaging People"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 3,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 2,
+              "note": "Being Real"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 3,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 3,
+              "note": "Building Ministry"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": "Being Real"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 4,
+              "note": "Building Ministry"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "An on target session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Newcomer Welcome.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "Prayer was delegated to members, opening and closing the group in shared voice."
+            ],
+            "improvements": [
+              "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "Teaching stayed at arm’s length; little personal cost was modeled."
+            ],
+            "recommendations": [
+              "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, open one teaching point with a first-person example that cost you something."
+            ],
+            "overview": [
+              "An on target session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Newcomer Welcome. It scored 64.16/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Application Questions; the recommendations below turn Newcomer Welcome into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Prayer anchored the session (4/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Being Real"
+                ]
+              },
+              {
+                "title": "Leader Development anchored the session (4/5)",
+                "paragraphs": [
+                  "An apprentice was visibly developed in-session — a clear multiplication signal.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Building Ministry"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (3/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Building Ministry"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Newcomer Welcome is a growth area (2/5)",
+                "paragraphs": [
+                  "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Building Ministry"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (2/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Engaging People"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (2/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Being Real"
+                ]
+              },
+              {
+                "title": "Participant Engagement is a growth area (3/5)",
+                "paragraphs": [
+                  "A few voices carried the discussion; quieter members went unheard.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Engaging People"
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (3/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Teaching Craft"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Newcomer Welcome",
+                "paragraphs": [
+                  "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Participant Engagement",
+                "paragraphs": [
+                  "Next time, name one quiet regular early and invite their read on a passage.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 72% × weight 33 → 23.76 pts",
+                "Building Ministry: 60% × weight 31 → 18.60 pts",
+                "Engaging People: 50% × weight 18 → 9.00 pts",
+                "Being Real: 60% × weight 18 → 10.80 pts",
+                "Base (sum of cluster contributions): 62.16 / 100",
+                "Session bonuses: newcomer growth +2",
+                "Session score: 64.16 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3/5): Building Ministry",
+                "Newcomer Welcome (2/5): Building Ministry",
+                "Scripture Engagement (5/5): Teaching Craft",
+                "Facilitation vs. Lecture (2/5): Engaging People",
+                "Application Questions (4/5): Teaching Craft",
+                "Participant Engagement (3/5): Engaging People",
+                "Visual Aids (3/5): Teaching Craft",
+                "Vulnerability / Authenticity (2/5): Being Real",
+                "Memory Reinforcement (3/5): Teaching Craft",
+                "Homework References (3/5): Building Ministry",
+                "Prayer (4/5): Being Real",
+                "Leader Development (4/5): Building Ministry"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "ricky-town-2026-05-17-james-1-1-12-lesson-2-from-doulo",
+          "date": "2026-05-17",
+          "dateLabel": "May 17, 2026",
+          "session": "James 1:1–12, Lesson 2 — From Doulos to Trials: The Bond Servant’s Perspective on Suffering",
+          "topic": "Introduction to James; trials, faith, wisdom, and the priority of Christlikeness over comfort",
+          "duration": "~1h 57m",
+          "attendees": 11,
+          "newcomers": 2,
+          "score": 67.26,
+          "base": 65.26,
+          "newcomerBonus": 2,
+          "sizeBonus": 0,
+          "status": "On Target",
+          "statusEmoji": "🟡",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 72,
+              "contribution": 23.76
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 70,
+              "contribution": 21.7
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 50,
+              "contribution": 9
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 60,
+              "contribution": 10.8
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": "Building Ministry"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": "Building Ministry"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 4,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 2,
+              "note": "Engaging People"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 3,
+              "note": "Engaging People"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 3,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 2,
+              "note": "Being Real"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 3,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 3,
+              "note": "Building Ministry"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": "Being Real"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 4,
+              "note": "Building Ministry"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "An on target session — strongest in Session Structure & Flow and Scripture Engagement, with the clearest next step in Facilitation vs. Lecture.",
+            "strengths": [
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level."
+            ],
+            "improvements": [
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "Teaching stayed at arm’s length; little personal cost was modeled.",
+              "A few voices carried the discussion; quieter members went unheard."
+            ],
+            "recommendations": [
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, open one teaching point with a first-person example that cost you something.",
+              "Next time, name one quiet regular early and invite their read on a passage."
+            ],
+            "overview": [
+              "An on target session — strongest in Session Structure & Flow and Scripture Engagement, with the clearest next step in Facilitation vs. Lecture. It scored 67.26/100 under the v3 weighted model.",
+              "The session played to its strengths in Session Structure & Flow and Scripture Engagement; the recommendations below turn Facilitation vs. Lecture into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Building Ministry"
+                ]
+              },
+              {
+                "title": "Scripture Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Prayer anchored the session (4/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Being Real"
+                ]
+              },
+              {
+                "title": "Leader Development anchored the session (4/5)",
+                "paragraphs": [
+                  "An apprentice was visibly developed in-session — a clear multiplication signal.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Building Ministry"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Facilitation vs. Lecture is a growth area (2/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Engaging People"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (2/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Being Real"
+                ]
+              },
+              {
+                "title": "Participant Engagement is a growth area (3/5)",
+                "paragraphs": [
+                  "A few voices carried the discussion; quieter members went unheard.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Engaging People"
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (3/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Teaching Craft"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Participant Engagement",
+                "paragraphs": [
+                  "Next time, name one quiet regular early and invite their read on a passage.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 72% × weight 33 → 23.76 pts",
+                "Building Ministry: 70% × weight 31 → 21.70 pts",
+                "Engaging People: 50% × weight 18 → 9.00 pts",
+                "Being Real: 60% × weight 18 → 10.80 pts",
+                "Base (sum of cluster contributions): 65.26 / 100",
+                "Session bonuses: newcomer growth +2",
+                "Session score: 67.26 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Building Ministry",
+                "Newcomer Welcome (N/A): Building Ministry",
+                "Scripture Engagement (4/5): Teaching Craft",
+                "Facilitation vs. Lecture (2/5): Engaging People",
+                "Application Questions (4/5): Teaching Craft",
+                "Participant Engagement (3/5): Engaging People",
+                "Visual Aids (3/5): Teaching Craft",
+                "Vulnerability / Authenticity (2/5): Being Real",
+                "Memory Reinforcement (3/5): Teaching Craft",
+                "Homework References (3/5): Building Ministry",
+                "Prayer (4/5): Being Real",
+                "Leader Development (4/5): Building Ministry"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "ricky-town-2026-04-12-1-john-lesson-5",
+          "date": "2026-04-12",
+          "dateLabel": "April 12, 2026",
+          "session": "1 John, Lesson 5",
+          "topic": "1 John 3 — Identity as Children of God, Sanctification, Sin & Love",
+          "duration": "~1h 50m (110 min)",
+          "attendees": 8,
+          "newcomers": 0,
+          "score": 72.5,
+          "base": 72.5,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 80,
+              "contribution": 26.4
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 50,
+              "contribution": 15.5
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 90,
+              "contribution": 16.2
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": "5"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": "—"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "5"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 4,
+              "note": "5"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 5,
+              "note": "5"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "5"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 3,
+              "note": "5"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": "5"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 3,
+              "note": "5"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 2,
+              "note": "5"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 5,
+              "note": "5"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 3,
+              "note": "5"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Homework References.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "Prayer was delegated to members, opening and closing the group in shared voice."
+            ],
+            "improvements": [
+              "Homework went unmentioned, reducing its pull on the group.",
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded."
+            ],
+            "recommendations": [
+              "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas."
+            ],
+            "overview": [
+              "A strong session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Homework References. It scored 72.5/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Application Questions; the recommendations below turn Homework References into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 5"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (5/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 5"
+                ]
+              },
+              {
+                "title": "Prayer anchored the session (5/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 5"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 5"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture anchored the session (4/5)",
+                "paragraphs": [
+                  "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 5"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Homework References is a growth area (2/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 5"
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (3/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 5"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 5"
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (3/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 5"
+                ]
+              },
+              {
+                "title": "Participant Engagement is a growth area (4/5)",
+                "paragraphs": [
+                  "A few voices carried the discussion; quieter members went unheard.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 5"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Participant Engagement",
+                "paragraphs": [
+                  "Next time, name one quiet regular early and invite their read on a passage.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 80% × weight 33 → 26.40 pts",
+                "Building Ministry: 50% × weight 31 → 15.50 pts",
+                "Engaging People: 80% × weight 18 → 14.40 pts",
+                "Being Real: 90% × weight 18 → 16.20 pts",
+                "Base (sum of cluster contributions): 72.50 / 100",
+                "Session score: 72.5 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): 5",
+                "Newcomer Welcome (N/A): —",
+                "Scripture Engagement (5/5): 5",
+                "Facilitation vs. Lecture (4/5): 5",
+                "Application Questions (5/5): 5",
+                "Participant Engagement (4/5): 5",
+                "Visual Aids (3/5): 5",
+                "Vulnerability / Authenticity (4/5): 5",
+                "Memory Reinforcement (3/5): 5",
+                "Homework References (2/5): 5",
+                "Prayer (5/5): 5",
+                "Leader Development (3/5): 5"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        }
+      ]
+    },
+    {
+      "id": "danny-thomas",
+      "name": "Danny Thomas",
+      "email": "dannythomas34@gmail.com",
+      "group": "Men’s Study",
+      "coachName": "Bryan Bailey",
+      "isCoach": true,
+      "zoomLink": "",
+      "reports": [
+        {
+          "id": "danny-thomas-2026-05-23-revelation-1-daniel-7-who-is-jes",
+          "date": "2026-05-23",
+          "dateLabel": "May 23, 2026",
+          "session": "Revelation 1 & Daniel 7 — Who Is Jesus? Titles, Vision, and Priestly Calling",
+          "topic": "Christ as faithful witness, firstborn from the dead, ruler of kings; believers as royal priests",
+          "duration": "~87 min",
+          "attendees": 11,
+          "newcomers": 0,
+          "score": 60.5,
+          "base": 60.5,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "On Target",
+          "statusEmoji": "🟡",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 60,
+              "contribution": 19.8
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 50,
+              "contribution": 15.5
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": "5"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 2,
+              "note": "5"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "5"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "5"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "5"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "5"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 2,
+              "note": "5"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 3,
+              "note": "5"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 1,
+              "note": "5"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 3,
+              "note": "5"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": "5"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": null,
+              "note": "N/A"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "An on target session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Memory Reinforcement.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "A high share of the room contributed substantively, called on by name."
+            ],
+            "improvements": [
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+              "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+              "The session leaned audio-only; a visual anchor would aid retention."
+            ],
+            "recommendations": [
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+              "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term."
+            ],
+            "overview": [
+              "An on target session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Memory Reinforcement. It scored 60.5/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Application Questions; the recommendations below turn Memory Reinforcement into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 5"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 5"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 5"
+                ]
+              },
+              {
+                "title": "Prayer anchored the session (4/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 5"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (3/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 5"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Memory Reinforcement is a growth area (1/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 5"
+                ]
+              },
+              {
+                "title": "Newcomer Welcome is a growth area (2/5)",
+                "paragraphs": [
+                  "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 5"
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (2/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 5"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 5"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 5"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Newcomer Welcome",
+                "paragraphs": [
+                  "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 60% × weight 33 → 19.80 pts",
+                "Building Ministry: 50% × weight 31 → 15.50 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 70% × weight 18 → 12.60 pts",
+                "Base (sum of cluster contributions): 60.50 / 100",
+                "Session score: 60.5 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3/5): 5",
+                "Newcomer Welcome (2/5): 5",
+                "Scripture Engagement (5/5): 5",
+                "Facilitation vs. Lecture (3/5): 5",
+                "Application Questions (4/5): 5",
+                "Participant Engagement (4/5): 5",
+                "Visual Aids (2/5): 5",
+                "Vulnerability / Authenticity (3/5): 5",
+                "Memory Reinforcement (1/5): 5",
+                "Homework References (3/5): 5",
+                "Prayer (4/5): 5",
+                "Leader Development (N/A): N/A"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        }
+      ]
+    },
+    {
+      "id": "russell-davis",
+      "name": "Russell Davis",
+      "email": "faith2see@gmail.com",
+      "group": "Men’s Study",
+      "coachName": "Bryan Bailey",
+      "isCoach": true,
+      "zoomLink": "",
+      "reports": [
+        {
+          "id": "russell-davis-2026-05-21-book-of-james-week-2-first-conte",
+          "date": "2026-05-21",
+          "dateLabel": "May 21, 2026",
+          "session": "Book of James · Week 2 — First Content Lesson (James 1:1–12)",
+          "topic": "Trials, Wisdom, and the Double-Minded Man",
+          "duration": "~2 hr 5 min",
+          "attendees": 17,
+          "newcomers": 2,
+          "score": 73.3,
+          "base": 70.3,
+          "newcomerBonus": 2,
+          "sizeBonus": 1,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 60,
+              "contribution": 19.8
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 70,
+              "contribution": 21.7
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 90,
+              "contribution": 16.2
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": "Opening prayer, scripture reading, multiple cross-refs, closing prayer all present. Missing: formal Big Ideas review at open and Big Ideas synthesis at close. Blueprint partially executed."
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 3,
+              "note": "2 newcomers introduced warmly; both given time. Missing: member testimonies (existing members sharing what the group has meant to them). No “this group changed my life” moments from peers."
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 4,
+              "note": "10+ cross-references; 3 Greek word studies (BLB); 85%+ verse-grounded discussion. Strong breadth. Minor gap: BLB not displayed on screen."
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "~42% with reading, ~35% discussion-only — both above Lifeway 30% target. Self-aware about it; execution needs tightening. Question/statement ratio ~45/55 (target: 60/40+)."
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "12–15 Big Idea questions, mostly DOK 3–4, woven throughout. Strong volume. Some clustering in the first half of the session."
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "82% contribution rate; 8+ named call-outs; productive struggle used at [00:26:35]. Near or at Gini benchmark for 17-person group."
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 1,
+              "note": "No visual aids displayed on screen. Blue Letter Bible referenced verbally only. Lowest-scoring dimension; highest addressable gap."
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": "4 leader vulnerability moments (MODERATE depth); group vulnerability HIGH (John Sermon cancer, Jay daily distraction, Ron family struggles). Culture is strong. Prison-ministry moment underutilized."
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 3,
+              "note": "Verse memorization of James 1:1–8 noted (members had it); no formal Big Ideas cumulative review. Partial execution of the Ebbinghaus retrieval cycle."
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 4,
+              "note": "Explicit page-by-page Precept workbook integration; members came with BLB lookups, concordance work, and commentary notes. Strong homework culture."
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 5,
+              "note": "Opening prayer delegated to Jay; closing prayer delegated to John (substantive, multi-threaded). Prayer requests gathered (John Sermon, Renly, nation). Weekly prayer pairs system described in detail."
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": null,
+              "note": "Solo lead; Barry on sabbatical; no mentor or apprentice present in session. Andy manages the prayer letter (some delegation). N/A reduces Building Ministry max proportionally per v3 spec."
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Prayer and Scripture Engagement, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Prayer was delegated to members, opening and closing the group in shared voice.",
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+              "The newcomer welcome was brief, missing a chance to enfold guests into the room."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+              "Next time, open by inviting two regulars to give a 60-second testimony before introductions."
+            ],
+            "overview": [
+              "A strong session — strongest in Prayer and Scripture Engagement, with the clearest next step in Visual Aids. It scored 73.3/100 under the v3 weighted model.",
+              "The session played to its strengths in Prayer and Scripture Engagement; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Prayer anchored the session (5/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Opening prayer delegated to Jay; closing prayer delegated to John (substantive, multi-threaded). Prayer requests gathered (John Sermon, Renly, nation). Weekly prayer pairs system described in detail."
+                ]
+              },
+              {
+                "title": "Scripture Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 10+ cross-references; 3 Greek word studies (BLB); 85%+ verse-grounded discussion. Strong breadth. Minor gap: BLB not displayed on screen."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 12–15 Big Idea questions, mostly DOK 3–4, woven throughout. Strong volume. Some clustering in the first half of the session."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 82% contribution rate; 8+ named call-outs; productive struggle used at [00:26:35]. Near or at Gini benchmark for 17-person group."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity anchored the session (4/5)",
+                "paragraphs": [
+                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 4 leader vulnerability moments (MODERATE depth); group vulnerability HIGH (John Sermon cancer, Jay daily distraction, Ron family struggles). Culture is strong. Prison-ministry moment underutilized."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (1/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: No visual aids displayed on screen. Blue Letter Bible referenced verbally only. Lowest-scoring dimension; highest addressable gap."
+                ]
+              },
+              {
+                "title": "Session Structure & Flow is a growth area (3/5)",
+                "paragraphs": [
+                  "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Opening prayer, scripture reading, multiple cross-refs, closing prayer all present. Missing: formal Big Ideas review at open and Big Ideas synthesis at close. Blueprint partially executed."
+                ]
+              },
+              {
+                "title": "Newcomer Welcome is a growth area (3/5)",
+                "paragraphs": [
+                  "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 2 newcomers introduced warmly; both given time. Missing: member testimonies (existing members sharing what the group has meant to them). No “this group changed my life” moments from peers."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: ~42% with reading, ~35% discussion-only — both above Lifeway 30% target. Self-aware about it; execution needs tightening. Question/statement ratio ~45/55 (target: 60/40+)."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Verse memorization of James 1:1–8 noted (members had it); no formal Big Ideas cumulative review. Partial execution of the Ebbinghaus retrieval cycle."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Session Structure & Flow",
+                "paragraphs": [
+                  "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Newcomer Welcome",
+                "paragraphs": [
+                  "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 60% × weight 33 → 19.80 pts",
+                "Building Ministry: 70% × weight 31 → 21.70 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 90% × weight 18 → 16.20 pts",
+                "Base (sum of cluster contributions): 70.30 / 100",
+                "Session bonuses: newcomer growth +2, group-size +1",
+                "Session score: 73.3 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3/5): Opening prayer, scripture reading, multiple cross-refs, closing prayer all present. Missing: formal Big Ideas review at open and Big Ideas synthesis at close. Blueprint partially executed.",
+                "Newcomer Welcome (3/5): 2 newcomers introduced warmly; both given time. Missing: member testimonies (existing members sharing what the group has meant to them). No “this group changed my life” moments from peers.",
+                "Scripture Engagement (4/5): 10+ cross-references; 3 Greek word studies (BLB); 85%+ verse-grounded discussion. Strong breadth. Minor gap: BLB not displayed on screen.",
+                "Facilitation vs. Lecture (3/5): ~42% with reading, ~35% discussion-only — both above Lifeway 30% target. Self-aware about it; execution needs tightening. Question/statement ratio ~45/55 (target: 60/40+).",
+                "Application Questions (4/5): 12–15 Big Idea questions, mostly DOK 3–4, woven throughout. Strong volume. Some clustering in the first half of the session.",
+                "Participant Engagement (4/5): 82% contribution rate; 8+ named call-outs; productive struggle used at [00:26:35]. Near or at Gini benchmark for 17-person group.",
+                "Visual Aids (1/5): No visual aids displayed on screen. Blue Letter Bible referenced verbally only. Lowest-scoring dimension; highest addressable gap.",
+                "Vulnerability / Authenticity (4/5): 4 leader vulnerability moments (MODERATE depth); group vulnerability HIGH (John Sermon cancer, Jay daily distraction, Ron family struggles). Culture is strong. Prison-ministry moment underutilized.",
+                "Memory Reinforcement (3/5): Verse memorization of James 1:1–8 noted (members had it); no formal Big Ideas cumulative review. Partial execution of the Ebbinghaus retrieval cycle.",
+                "Homework References (4/5): Explicit page-by-page Precept workbook integration; members came with BLB lookups, concordance work, and commentary notes. Strong homework culture.",
+                "Prayer (5/5): Opening prayer delegated to Jay; closing prayer delegated to John (substantive, multi-threaded). Prayer requests gathered (John Sermon, Renly, nation). Weekly prayer pairs system described in detail.",
+                "Leader Development (N/A): Solo lead; Barry on sabbatical; no mentor or apprentice present in session. Andy manages the prayer letter (some delegation). N/A reduces Building Ministry max proportionally per v3 spec."
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        }
+      ]
+    },
+    {
+      "id": "james-davis",
+      "name": "James Davis",
+      "email": "james-davis@needs-real-email.invalid",
+      "group": "James D’Apolito’s Group",
+      "coachName": "Bryan Bailey",
+      "isCoach": true,
+      "zoomLink": "",
+      "reports": [
+        {
+          "id": "james-davis-2026-05-30-james-ch-1-complete-blessed-man-",
+          "date": "2026-05-30",
+          "dateLabel": "May 30, 2026",
+          "session": "James Ch. 1 (Complete) — Blessed Man through Pure Religion",
+          "topic": "Crown of Life · Trials vs. Temptation · Desire Redirected · Word as Mirror",
+          "duration": "~2 hr 9 min",
+          "attendees": 12,
+          "newcomers": 1,
+          "score": 65.44,
+          "base": 64.44,
+          "newcomerBonus": 1,
+          "sizeBonus": 0,
+          "status": "On Target",
+          "statusEmoji": "🟡",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 68,
+              "contribution": 22.44
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 60,
+              "contribution": 18.6
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 60,
+              "contribution": 10.8
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": "Building on 10-step blueprint; newcomer welcome skipped; opening review strong"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 2,
+              "note": "30-second name exchange; no member testimonies; immediately read scripture"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "17+ cross-references; James 1, Rev 2-3, Matt 5, Luke 6, 1 Cor 3, Ps 23, 1 Pet 5, 1 Thes 2, 2 Tim 4, 1 John"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "~58% leader talk; strong Socratic method; explain-after-response pattern still dominant"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "10 Big Idea questions; DOK 2=4, DOK 3=4, DOK 4=2; well-distributed"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "8+ named contributors; ~67% participation rate; wait time honored"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 2,
+              "note": "Sin-progression diagram shown briefly; 5-crowns list; no sustained visual use"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 3,
+              "note": "Leader conviction depth 2/5; 2 high-cost member disclosures (Celebrate Recovery + Chris)"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 3,
+              "note": "Opening review covers James 1:1-11; brief closing member synthesis; no bumper-sticker capsule"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 4,
+              "note": "6+ specific references: blessed, approved, enticed, crown of life, 1 John 3, five crowns"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 3,
+              "note": "Opening prayer not in recording; closing delegated to Chris; genuinely specific prayer"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": null,
+              "note": "Solo session; no mentor or apprentice present"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "An on target session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Newcomer Welcome.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "A high share of the room contributed substantively, called on by name."
+            ],
+            "improvements": [
+              "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Transitions between segments lost momentum, so the session’s shape was harder to feel."
+            ],
+            "recommendations": [
+              "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp."
+            ],
+            "overview": [
+              "An on target session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Newcomer Welcome. It scored 65.44/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Application Questions; the recommendations below turn Newcomer Welcome into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 17+ cross-references; James 1, Rev 2-3, Matt 5, Luke 6, 1 Cor 3, Ps 23, 1 Pet 5, 1 Thes 2, 2 Tim 4, 1 John"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 10 Big Idea questions; DOK 2=4, DOK 3=4, DOK 4=2; well-distributed"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 8+ named contributors; ~67% participation rate; wait time honored"
+                ]
+              },
+              {
+                "title": "Homework References anchored the session (4/5)",
+                "paragraphs": [
+                  "Homework was referenced and rewarded, differentiating the members who prepared.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 6+ specific references: blessed, approved, enticed, crown of life, 1 John 3, five crowns"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (3/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Building on 10-step blueprint; newcomer welcome skipped; opening review strong"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Newcomer Welcome is a growth area (2/5)",
+                "paragraphs": [
+                  "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 30-second name exchange; no member testimonies; immediately read scripture"
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (2/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Sin-progression diagram shown briefly; 5-crowns list; no sustained visual use"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: ~58% leader talk; strong Socratic method; explain-after-response pattern still dominant"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Leader conviction depth 2/5; 2 high-cost member disclosures (Celebrate Recovery + Chris)"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Opening review covers James 1:1-11; brief closing member synthesis; no bumper-sticker capsule"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Newcomer Welcome",
+                "paragraphs": [
+                  "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 68% × weight 33 → 22.44 pts",
+                "Building Ministry: 60% × weight 31 → 18.60 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 60% × weight 18 → 10.80 pts",
+                "Base (sum of cluster contributions): 64.44 / 100",
+                "Session bonuses: newcomer growth +1",
+                "Session score: 65.44 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3/5): Building on 10-step blueprint; newcomer welcome skipped; opening review strong",
+                "Newcomer Welcome (2/5): 30-second name exchange; no member testimonies; immediately read scripture",
+                "Scripture Engagement (5/5): 17+ cross-references; James 1, Rev 2-3, Matt 5, Luke 6, 1 Cor 3, Ps 23, 1 Pet 5, 1 Thes 2, 2 Tim 4, 1 John",
+                "Facilitation vs. Lecture (3/5): ~58% leader talk; strong Socratic method; explain-after-response pattern still dominant",
+                "Application Questions (4/5): 10 Big Idea questions; DOK 2=4, DOK 3=4, DOK 4=2; well-distributed",
+                "Participant Engagement (4/5): 8+ named contributors; ~67% participation rate; wait time honored",
+                "Visual Aids (2/5): Sin-progression diagram shown briefly; 5-crowns list; no sustained visual use",
+                "Vulnerability / Authenticity (3/5): Leader conviction depth 2/5; 2 high-cost member disclosures (Celebrate Recovery + Chris)",
+                "Memory Reinforcement (3/5): Opening review covers James 1:1-11; brief closing member synthesis; no bumper-sticker capsule",
+                "Homework References (4/5): 6+ specific references: blessed, approved, enticed, crown of life, 1 John 3, five crowns",
+                "Prayer (3/5): Opening prayer not in recording; closing delegated to Chris; genuinely specific prayer",
+                "Leader Development (N/A): Solo session; no mentor or apprentice present"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "james-davis-2026-05-23-james-ch-1-trials-wisdom-the-cro",
+          "date": "2026-05-23",
+          "dateLabel": "May 23, 2026",
+          "session": "James Ch. 1 — Trials, Wisdom & the Crown of Life (Part 2)",
+          "topic": "Count it all joy · Ask for wisdom in faith · The blessed man who perseveres",
+          "duration": "~2h 18 min",
+          "attendees": 11,
+          "newcomers": 2,
+          "score": 76.24,
+          "base": 74.24,
+          "newcomerBonus": 2,
+          "sizeBonus": 0,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 68,
+              "contribution": 22.44
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 80,
+              "contribution": 24.8
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": "60%"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": "N/A"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "100%"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "60%"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "80%"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "80%"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 2,
+              "note": "40%"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 5,
+              "note": "100%"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 3,
+              "note": "60%"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 4,
+              "note": "80%"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 3,
+              "note": "60%"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": null,
+              "note": "N/A"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Scripture Engagement and Vulnerability / Authenticity, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+              "Application questions pushed members from concept to life, several at the reason/apply level."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds."
+            ],
+            "overview": [
+              "A strong session — strongest in Scripture Engagement and Vulnerability / Authenticity, with the clearest next step in Visual Aids. It scored 76.24/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Vulnerability / Authenticity; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 100%"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity anchored the session (5/5)",
+                "paragraphs": [
+                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 100%"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 80%"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 80%"
+                ]
+              },
+              {
+                "title": "Homework References anchored the session (4/5)",
+                "paragraphs": [
+                  "Homework was referenced and rewarded, differentiating the members who prepared.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 80%"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (2/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 40%"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow is a growth area (3/5)",
+                "paragraphs": [
+                  "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 60%"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 60%"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 60%"
+                ]
+              },
+              {
+                "title": "Prayer is a growth area (3/5)",
+                "paragraphs": [
+                  "Prayer was leader-only or rushed; the group’s voice was thin.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 60%"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Session Structure & Flow",
+                "paragraphs": [
+                  "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Prayer",
+                "paragraphs": [
+                  "Next time, ask one member to open and a different member to close in prayer.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 68% × weight 33 → 22.44 pts",
+                "Building Ministry: 80% × weight 31 → 24.80 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 80% × weight 18 → 14.40 pts",
+                "Base (sum of cluster contributions): 74.24 / 100",
+                "Session bonuses: newcomer growth +2",
+                "Session score: 76.24 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3/5): 60%",
+                "Newcomer Welcome (N/A): N/A",
+                "Scripture Engagement (5/5): 100%",
+                "Facilitation vs. Lecture (3/5): 60%",
+                "Application Questions (4/5): 80%",
+                "Participant Engagement (4/5): 80%",
+                "Visual Aids (2/5): 40%",
+                "Vulnerability / Authenticity (5/5): 100%",
+                "Memory Reinforcement (3/5): 60%",
+                "Homework References (4/5): 80%",
+                "Prayer (3/5): 60%",
+                "Leader Development (N/A): N/A"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "james-davis-2026-05-16-book-of-james-full-read-through-",
+          "date": "2026-05-16",
+          "dateLabel": "May 16, 2026",
+          "session": "Book of James — Full Read-Through (Observation Phase, Session 2)",
+          "topic": "Trials & faith · Partiality & works · Tongue & wisdom · Earthly vs. godly wisdom",
+          "duration": "~2h 15 min",
+          "attendees": 11,
+          "newcomers": 2,
+          "score": 62.94,
+          "base": 60.94,
+          "newcomerBonus": 2,
+          "sizeBonus": 0,
+          "status": "On Target",
+          "statusEmoji": "🟡",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 48,
+              "contribution": 15.84
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 70,
+              "contribution": 21.7
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 60,
+              "contribution": 10.8
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": "60%"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 5,
+              "note": "100%"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 3,
+              "note": "60%"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "60%"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 2,
+              "note": "40%"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 3,
+              "note": "60%"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 2,
+              "note": "40%"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 2,
+              "note": "40%"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 2,
+              "note": "40%"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 2,
+              "note": "40%"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 5,
+              "note": "100%"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": null,
+              "note": "N/A"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "An on target session — strongest in Newcomer Welcome and Prayer, with the clearest next step in Application Questions.",
+            "strengths": [
+              "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
+              "Prayer was delegated to members, opening and closing the group in shared voice.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place."
+            ],
+            "improvements": [
+              "Questions stayed heady; few moved the group to first-person, personal application.",
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Teaching stayed at arm’s length; little personal cost was modeled."
+            ],
+            "recommendations": [
+              "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, open one teaching point with a first-person example that cost you something."
+            ],
+            "overview": [
+              "An on target session — strongest in Newcomer Welcome and Prayer, with the clearest next step in Application Questions. It scored 62.94/100 under the v3 weighted model.",
+              "The session played to its strengths in Newcomer Welcome and Prayer; the recommendations below turn Application Questions into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Newcomer Welcome anchored the session (5/5)",
+                "paragraphs": [
+                  "Newcomers were welcomed warmly, with members sharing testimonies before the lesson began.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 100%"
+                ]
+              },
+              {
+                "title": "Prayer anchored the session (5/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 100%"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (3/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 60%"
+                ]
+              },
+              {
+                "title": "Scripture Engagement anchored the session (3/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 60%"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture anchored the session (3/5)",
+                "paragraphs": [
+                  "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 60%"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Application Questions is a growth area (2/5)",
+                "paragraphs": [
+                  "Questions stayed heady; few moved the group to first-person, personal application.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 40%"
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (2/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 40%"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (2/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 40%"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (2/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 40%"
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (2/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 40%"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Application Questions",
+                "paragraphs": [
+                  "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 48% × weight 33 → 15.84 pts",
+                "Building Ministry: 70% × weight 31 → 21.70 pts",
+                "Engaging People: 60% × weight 18 → 10.80 pts",
+                "Being Real: 70% × weight 18 → 12.60 pts",
+                "Base (sum of cluster contributions): 60.94 / 100",
+                "Session bonuses: newcomer growth +2",
+                "Session score: 62.94 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3/5): 60%",
+                "Newcomer Welcome (5/5): 100%",
+                "Scripture Engagement (3/5): 60%",
+                "Facilitation vs. Lecture (3/5): 60%",
+                "Application Questions (2/5): 40%",
+                "Participant Engagement (3/5): 60%",
+                "Visual Aids (2/5): 40%",
+                "Vulnerability / Authenticity (2/5): 40%",
+                "Memory Reinforcement (2/5): 40%",
+                "Homework References (2/5): 40%",
+                "Prayer (5/5): 100%",
+                "Leader Development (N/A): N/A"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "james-davis-2026-01-17-2-kings-8-10-god-s-sovereignty-c",
+          "date": "2026-01-17",
+          "dateLabel": "January 17, 2026",
+          "session": "2 Kings 8–10 — God's Sovereignty, Covenant Judgment & Generational Faithfulness",
+          "topic": "Shunammite's restoration, Hazael's anointing, Jehu's purge, Rechabite legacy",
+          "duration": "~2h 20m",
+          "attendees": 8,
+          "newcomers": 2,
+          "score": 63.32,
+          "base": 61.32,
+          "newcomerBonus": 2,
+          "sizeBonus": 0,
+          "status": "On Target",
+          "statusEmoji": "🟡",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 64,
+              "contribution": 21.12
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 60,
+              "contribution": 18.6
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 60,
+              "contribution": 10.8
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 60,
+              "contribution": 10.8
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": "60%"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": "N/A"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "100%"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "60%"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "80%"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 3,
+              "note": "60%"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 2,
+              "note": "40%"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": "80%"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 2,
+              "note": "40%"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 3,
+              "note": "60%"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 2,
+              "note": "40%"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": null,
+              "note": "N/A"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "An on target session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "Costly personal honesty set a tone of safety, and members disclosed in turn."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+              "Prayer was leader-only or rushed; the group’s voice was thin."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+              "Next time, ask one member to open and a different member to close in prayer."
+            ],
+            "overview": [
+              "An on target session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Visual Aids. It scored 63.32/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Application Questions; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 100%"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 80%"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity anchored the session (4/5)",
+                "paragraphs": [
+                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 80%"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (3/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 60%"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture anchored the session (3/5)",
+                "paragraphs": [
+                  "Discussion outweighed lecture — the room did the thinking, not just the leader.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 60%"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (2/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 40%"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (2/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 40%"
+                ]
+              },
+              {
+                "title": "Prayer is a growth area (2/5)",
+                "paragraphs": [
+                  "Prayer was leader-only or rushed; the group’s voice was thin.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 40%"
+                ]
+              },
+              {
+                "title": "Participant Engagement is a growth area (3/5)",
+                "paragraphs": [
+                  "A few voices carried the discussion; quieter members went unheard.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 60%"
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (3/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 60%"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Prayer",
+                "paragraphs": [
+                  "Next time, ask one member to open and a different member to close in prayer.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Participant Engagement",
+                "paragraphs": [
+                  "Next time, name one quiet regular early and invite their read on a passage.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 64% × weight 33 → 21.12 pts",
+                "Building Ministry: 60% × weight 31 → 18.60 pts",
+                "Engaging People: 60% × weight 18 → 10.80 pts",
+                "Being Real: 60% × weight 18 → 10.80 pts",
+                "Base (sum of cluster contributions): 61.32 / 100",
+                "Session bonuses: newcomer growth +2",
+                "Session score: 63.32 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3/5): 60%",
+                "Newcomer Welcome (N/A): N/A",
+                "Scripture Engagement (5/5): 100%",
+                "Facilitation vs. Lecture (3/5): 60%",
+                "Application Questions (4/5): 80%",
+                "Participant Engagement (3/5): 60%",
+                "Visual Aids (2/5): 40%",
+                "Vulnerability / Authenticity (4/5): 80%",
+                "Memory Reinforcement (2/5): 40%",
+                "Homework References (3/5): 60%",
+                "Prayer (2/5): 40%",
+                "Leader Development (N/A): N/A"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        }
+      ]
+    },
+    {
+      "id": "cameron-relic",
+      "name": "Cameron Relic",
+      "email": "cameron-relic@needs-real-email.invalid",
+      "group": "James Study",
+      "coachName": "Bryan Bailey",
+      "isCoach": true,
+      "zoomLink": "",
+      "reports": [
+        {
+          "id": "cameron-relic-2026-05-28-james-lesson-1-faith2see-group-c",
+          "date": "2026-05-28",
+          "dateLabel": "May 28, 2026",
+          "session": "James, Lesson 1 (faith2see group) — Crown of Life, Temptation, Doers of the Word, True Religion (Jas 1:12–27)",
+          "topic": "Trials vs. temptation; sin progression (lust→carried away→death); doers vs. hearers; bridling the tongue; pure religion",
+          "duration": "~2h 3m (6:00 PM – 8:03 PM CT; ended 5 min over target)",
+          "attendees": 15,
+          "newcomers": 0,
+          "score": 73.3,
+          "base": 73.3,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 80,
+              "contribution": 26.4
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 70,
+              "contribution": 21.7
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": "Strong blueprint adherence; dual-leader handoff smooth; both prayers captured; homework anchored"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": "No newcomers — Building Ministry max reduced proportionally"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "14 cross-references; Cameron's arc high; Isaiah 1 cross-ref at close exceptional"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "~30–35% leader talk; Cameron's best facilitation ratio in tracked arc; productive struggle honored"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "10 Big Idea questions; 40% DOK 4; distributed throughout; productive struggle defended"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "~13 members called by name; 12 distinct voices in discussion; strong go-around even if brief"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 3,
+              "note": "Russell's sin-progression diagram (Cameron invited it); no BLB on-screen; no leader-prepared visual"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 3,
+              "note": "Cameron: 3 mild disclosures; no high-cost personal moment; member vulnerability (Uri, Andy) present but not fully honored"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 4,
+              "note": "Russell's 14-min review of James 1:1–11 + Cameron's Big Ideas opening; strong closing synthesis 'three things that cost you'"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 5,
+              "note": "Explicit page references (pg 25, 27, 28); homework structure spine of lesson; Cameron's arc high on this dimension"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": "Opening prayer by Cameron (Russell's invitation, on-topic); closing prayer delegated to Andy (substantive, applied lesson themes); prayer chain awareness implied"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 2,
+              "note": "No visible apprentice or facilitation-window assignment; Russell is peer co-leader not Cameron's coachee; no 2:2 signal visible"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Scripture Engagement and Homework References, with the clearest next step in Leader Development.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Homework was referenced and rewarded, differentiating the members who prepared.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place."
+            ],
+            "improvements": [
+              "No in-session development of another leader was observable this week.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "The session leaned audio-only; a visual anchor would aid retention."
+            ],
+            "recommendations": [
+              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, put one word-study lookup or a simple table on screen during the key term."
+            ],
+            "overview": [
+              "A strong session — strongest in Scripture Engagement and Homework References, with the clearest next step in Leader Development. It scored 73.3/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Homework References; the recommendations below turn Leader Development into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 14 cross-references; Cameron's arc high; Isaiah 1 cross-ref at close exceptional"
+                ]
+              },
+              {
+                "title": "Homework References anchored the session (5/5)",
+                "paragraphs": [
+                  "Homework was referenced and rewarded, differentiating the members who prepared.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Explicit page references (pg 25, 27, 28); homework structure spine of lesson; Cameron's arc high on this dimension"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Strong blueprint adherence; dual-leader handoff smooth; both prayers captured; homework anchored"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 10 Big Idea questions; 40% DOK 4; distributed throughout; productive struggle defended"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: ~13 members called by name; 12 distinct voices in discussion; strong go-around even if brief"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Leader Development is a growth area (2/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: No visible apprentice or facilitation-window assignment; Russell is peer co-leader not Cameron's coachee; no 2:2 signal visible"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: ~30–35% leader talk; Cameron's best facilitation ratio in tracked arc; productive struggle honored"
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (3/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Russell's sin-progression diagram (Cameron invited it); no BLB on-screen; no leader-prepared visual"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Cameron: 3 mild disclosures; no high-cost personal moment; member vulnerability (Uri, Andy) present but not fully honored"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (4/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Russell's 14-min review of James 1:1–11 + Cameron's Big Ideas opening; strong closing synthesis 'three things that cost you'"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 80% × weight 33 → 26.40 pts",
+                "Building Ministry: 70% × weight 31 → 21.70 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 70% × weight 18 → 12.60 pts",
+                "Base (sum of cluster contributions): 73.30 / 100",
+                "Session score: 73.3 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Strong blueprint adherence; dual-leader handoff smooth; both prayers captured; homework anchored",
+                "Newcomer Welcome (N/A): No newcomers — Building Ministry max reduced proportionally",
+                "Scripture Engagement (5/5): 14 cross-references; Cameron's arc high; Isaiah 1 cross-ref at close exceptional",
+                "Facilitation vs. Lecture (3/5): ~30–35% leader talk; Cameron's best facilitation ratio in tracked arc; productive struggle honored",
+                "Application Questions (4/5): 10 Big Idea questions; 40% DOK 4; distributed throughout; productive struggle defended",
+                "Participant Engagement (4/5): ~13 members called by name; 12 distinct voices in discussion; strong go-around even if brief",
+                "Visual Aids (3/5): Russell's sin-progression diagram (Cameron invited it); no BLB on-screen; no leader-prepared visual",
+                "Vulnerability / Authenticity (3/5): Cameron: 3 mild disclosures; no high-cost personal moment; member vulnerability (Uri, Andy) present but not fully honored",
+                "Memory Reinforcement (4/5): Russell's 14-min review of James 1:1–11 + Cameron's Big Ideas opening; strong closing synthesis 'three things that cost you'",
+                "Homework References (5/5): Explicit page references (pg 25, 27, 28); homework structure spine of lesson; Cameron's arc high on this dimension",
+                "Prayer (4/5): Opening prayer by Cameron (Russell's invitation, on-topic); closing prayer delegated to Andy (substantive, applied lesson themes); prayer chain awareness implied",
+                "Leader Development (2/5): No visible apprentice or facilitation-window assignment; Russell is peer co-leader not Cameron's coachee; no 2:2 signal visible"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "cameron-relic-2026-04-16-destruction-of-jerusalem-zedekia",
+          "date": "2026-04-16",
+          "dateLabel": "April 16, 2026",
+          "session": "Destruction of Jerusalem — Zedekiah, False Prophets, the Yoke of Babylon",
+          "topic": "God as main character; cyclical warnings; partial truth as lie; two masters",
+          "duration": "1h 54m (114 minutes)",
+          "attendees": 7,
+          "newcomers": 0,
+          "score": 70.66,
+          "base": 70.66,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "On Target",
+          "statusEmoji": "🟡",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 72,
+              "contribution": 23.76
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 70,
+              "contribution": 21.7
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 60,
+              "contribution": 10.8
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 4,
+              "note": "Clean arc; opens with retrieval; closes with Big Ideas but apologetic"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": "No newcomers present"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "7 books triangulated on one narrative; 85% verse-grounded"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 2,
+              "note": "52% leader talk — 22 points above 30% target"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 3,
+              "note": "6 Big Ideas at 83% DOK 3-4, but clustered late"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "83% read aloud; 50% discuss; named call-outs used well"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 1,
+              "note": "None observed — audio-plus-Bible only on dense parallel-passage session"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": "3 moments, 1 reciprocity peak; moderate depth overall"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 5,
+              "note": "Retrieval-first opening — pedagogically strongest position"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 4,
+              "note": "Regular workbook references; lesson built on homework questions"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": "Opening delegated to Frank; closing delegated to John Relic (different member)"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 3,
+              "note": "Solo leader (no co-teacher or mentor); no apprentice visible"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "An on target session — strongest in Scripture Engagement and Memory Reinforcement, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
+              "The session followed a clear arc — opening, context, reading, discussion, and close each had their place."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "Questions stayed heady; few moved the group to first-person, personal application."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, pre-write 3 \"what does this look like for you this week?\" probes."
+            ],
+            "overview": [
+              "An on target session — strongest in Scripture Engagement and Memory Reinforcement, with the clearest next step in Visual Aids. It scored 70.66/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Memory Reinforcement; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 7 books triangulated on one narrative; 85% verse-grounded"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement anchored the session (5/5)",
+                "paragraphs": [
+                  "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Retrieval-first opening — pedagogically strongest position"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow anchored the session (4/5)",
+                "paragraphs": [
+                  "The session followed a clear arc — opening, context, reading, discussion, and close each had their place.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Clean arc; opens with retrieval; closes with Big Ideas but apologetic"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 83% read aloud; 50% discuss; named call-outs used well"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity anchored the session (4/5)",
+                "paragraphs": [
+                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 3 moments, 1 reciprocity peak; moderate depth overall"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (1/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: None observed — audio-plus-Bible only on dense parallel-passage session"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (2/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 52% leader talk — 22 points above 30% target"
+                ]
+              },
+              {
+                "title": "Application Questions is a growth area (3/5)",
+                "paragraphs": [
+                  "Questions stayed heady; few moved the group to first-person, personal application.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: 6 Big Ideas at 83% DOK 3-4, but clustered late"
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (3/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Solo leader (no co-teacher or mentor); no apprentice visible"
+                ]
+              },
+              {
+                "title": "Homework References is a growth area (4/5)",
+                "paragraphs": [
+                  "Homework went unmentioned, reducing its pull on the group.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Regular workbook references; lesson built on homework questions"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Application Questions",
+                "paragraphs": [
+                  "Next time, pre-write 3 \"what does this look like for you this week?\" probes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Homework References",
+                "paragraphs": [
+                  "Next time, ask two members to share one thing from their homework in the first 10 minutes.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 72% × weight 33 → 23.76 pts",
+                "Building Ministry: 70% × weight 31 → 21.70 pts",
+                "Engaging People: 60% × weight 18 → 10.80 pts",
+                "Being Real: 80% × weight 18 → 14.40 pts",
+                "Base (sum of cluster contributions): 70.66 / 100",
+                "Session score: 70.66 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (4/5): Clean arc; opens with retrieval; closes with Big Ideas but apologetic",
+                "Newcomer Welcome (N/A): No newcomers present",
+                "Scripture Engagement (5/5): 7 books triangulated on one narrative; 85% verse-grounded",
+                "Facilitation vs. Lecture (2/5): 52% leader talk — 22 points above 30% target",
+                "Application Questions (3/5): 6 Big Ideas at 83% DOK 3-4, but clustered late",
+                "Participant Engagement (4/5): 83% read aloud; 50% discuss; named call-outs used well",
+                "Visual Aids (1/5): None observed — audio-plus-Bible only on dense parallel-passage session",
+                "Vulnerability / Authenticity (4/5): 3 moments, 1 reciprocity peak; moderate depth overall",
+                "Memory Reinforcement (5/5): Retrieval-first opening — pedagogically strongest position",
+                "Homework References (4/5): Regular workbook references; lesson built on homework questions",
+                "Prayer (4/5): Opening delegated to Frank; closing delegated to John Relic (different member)",
+                "Leader Development (3/5): Solo leader (no co-teacher or mentor); no apprentice visible"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        }
+      ]
+    },
+    {
+      "id": "brendan-elizabeth",
+      "name": "Brendan & Elizabeth",
+      "email": "brendan-elizabeth@needs-real-email.invalid",
+      "group": "Couples Precept Study",
+      "coachName": "Bryan Bailey",
+      "isCoach": true,
+      "zoomLink": "",
+      "reports": [
+        {
+          "id": "brendan-elizabeth-2026-06-06-james-lesson-3-james-2-1-13",
+          "date": "2026-06-06",
+          "dateLabel": "June 6, 2026",
+          "session": "James — Lesson 3 (James 2:1–13)",
+          "topic": "Partiality, Royal Law, Law of Liberty, Judgment & Mercy",
+          "duration": "~2h 07m",
+          "attendees": 8,
+          "newcomers": 7,
+          "score": 80.63,
+          "base": 75.63,
+          "newcomerBonus": 5,
+          "sizeBonus": 0,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 82,
+              "contribution": 27.06
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 66.7,
+              "contribution": 20.67
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 75,
+              "contribution": 13.5
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3.5,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": 2,
+              "note": "Building Ministry"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "Engaging People"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4.5,
+              "note": "Engaging People"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 4,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 3.5,
+              "note": "Being Real"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 4,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 5,
+              "note": "Building Ministry"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4.5,
+              "note": "Being Real"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 3,
+              "note": "Building Ministry"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Scripture Engagement and Homework References, with the clearest next step in Newcomer Welcome.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Homework was referenced and rewarded, differentiating the members who prepared.",
+              "A high share of the room contributed substantively, called on by name."
+            ],
+            "improvements": [
+              "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "No in-session development of another leader was observable this week."
+            ],
+            "recommendations": [
+              "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\""
+            ],
+            "overview": [
+              "A strong session — strongest in Scripture Engagement and Homework References, with the clearest next step in Newcomer Welcome. It scored 80.63/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Homework References; the recommendations below turn Newcomer Welcome into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Homework References anchored the session (5/5)",
+                "paragraphs": [
+                  "Homework was referenced and rewarded, differentiating the members who prepared.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Building Ministry"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4.5/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Engaging People"
+                ]
+              },
+              {
+                "title": "Prayer anchored the session (4.5/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Being Real"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Newcomer Welcome is a growth area (2/5)",
+                "paragraphs": [
+                  "The newcomer welcome was brief, missing a chance to enfold guests into the room.",
+                  "A 7–25 minute welcome with member testimonies before the lesson is enrollment, not overhead — the apex Building-Ministry signal (Precept, BSF).",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Building Ministry"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Engaging People"
+                ]
+              },
+              {
+                "title": "Leader Development is a growth area (3/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Building Ministry"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow is a growth area (3.5/5)",
+                "paragraphs": [
+                  "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (3.5/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Being Real"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Newcomer Welcome",
+                "paragraphs": [
+                  "Next time, open by inviting two regulars to give a 60-second testimony before introductions.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Session Structure & Flow",
+                "paragraphs": [
+                  "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 82% × weight 33 → 27.06 pts",
+                "Building Ministry: 66.7% × weight 31 → 20.67 pts",
+                "Engaging People: 75% × weight 18 → 13.50 pts",
+                "Being Real: 80% × weight 18 → 14.40 pts",
+                "Base (sum of cluster contributions): 75.63 / 100",
+                "Session bonuses: newcomer growth +5",
+                "Session score: 80.63 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3.5/5): Teaching Craft",
+                "Newcomer Welcome (2/5): Building Ministry",
+                "Scripture Engagement (5/5): Teaching Craft",
+                "Facilitation vs. Lecture (3/5): Engaging People",
+                "Application Questions (4/5): Teaching Craft",
+                "Participant Engagement (4.5/5): Engaging People",
+                "Visual Aids (4/5): Teaching Craft",
+                "Vulnerability / Authenticity (3.5/5): Being Real",
+                "Memory Reinforcement (4/5): Teaching Craft",
+                "Homework References (5/5): Building Ministry",
+                "Prayer (4.5/5): Being Real",
+                "Leader Development (3/5): Building Ministry"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "brendan-elizabeth-2026-05-30-james-lesson-2-james-1-12-27",
+          "date": "2026-05-30",
+          "dateLabel": "May 30, 2026",
+          "session": "James — Lesson 2 (James 1:12–27)",
+          "topic": "Crown of life, sin's cycle, doers vs. hearers, true religion",
+          "duration": "~2h 02m",
+          "attendees": 8,
+          "newcomers": 2,
+          "score": 77.76,
+          "base": 75.76,
+          "newcomerBonus": 2,
+          "sizeBonus": 0,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 82,
+              "contribution": 27.06
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 70,
+              "contribution": 21.7
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3.5,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": "Building Ministry"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "Engaging People"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "Engaging People"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 3.5,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": "Being Real"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 4.5,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 5,
+              "note": "Building Ministry"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": "Being Real"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 2,
+              "note": "Building Ministry"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Scripture Engagement and Homework References, with the clearest next step in Leader Development.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Homework was referenced and rewarded, differentiating the members who prepared.",
+              "The session opened by recalling prior Big Ideas, reinforcing cumulative learning."
+            ],
+            "improvements": [
+              "No in-session development of another leader was observable this week.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture.",
+              "Transitions between segments lost momentum, so the session’s shape was harder to feel."
+            ],
+            "recommendations": [
+              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+              "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp."
+            ],
+            "overview": [
+              "A strong session — strongest in Scripture Engagement and Homework References, with the clearest next step in Leader Development. It scored 77.76/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Homework References; the recommendations below turn Leader Development into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Homework References anchored the session (5/5)",
+                "paragraphs": [
+                  "Homework was referenced and rewarded, differentiating the members who prepared.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Building Ministry"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement anchored the session (4.5/5)",
+                "paragraphs": [
+                  "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Engaging People"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Leader Development is a growth area (2/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Building Ministry"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Engaging People"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow is a growth area (3.5/5)",
+                "paragraphs": [
+                  "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (3.5/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (4/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Being Real"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Session Structure & Flow",
+                "paragraphs": [
+                  "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 82% × weight 33 → 27.06 pts",
+                "Building Ministry: 70% × weight 31 → 21.70 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 80% × weight 18 → 14.40 pts",
+                "Base (sum of cluster contributions): 75.76 / 100",
+                "Session bonuses: newcomer growth +2",
+                "Session score: 77.76 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3.5/5): Teaching Craft",
+                "Newcomer Welcome (N/A): Building Ministry",
+                "Scripture Engagement (5/5): Teaching Craft",
+                "Facilitation vs. Lecture (3/5): Engaging People",
+                "Application Questions (4/5): Teaching Craft",
+                "Participant Engagement (4/5): Engaging People",
+                "Visual Aids (3.5/5): Teaching Craft",
+                "Vulnerability / Authenticity (4/5): Being Real",
+                "Memory Reinforcement (4.5/5): Teaching Craft",
+                "Homework References (5/5): Building Ministry",
+                "Prayer (4/5): Being Real",
+                "Leader Development (2/5): Building Ministry"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        },
+        {
+          "id": "brendan-elizabeth-2026-05-25-james-lesson-1-james-1-1-12",
+          "date": "2026-05-25",
+          "dateLabel": "May 25, 2026",
+          "session": "James — Lesson 1 (James 1:1–12)",
+          "topic": "Trials, endurance, wisdom, faith, and double-mindedness",
+          "duration": "~2h 07m",
+          "attendees": 6,
+          "newcomers": 2,
+          "score": 78.9,
+          "base": 76.9,
+          "newcomerBonus": 2,
+          "sizeBonus": 0,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 80,
+              "contribution": 26.4
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 70,
+              "contribution": 21.7
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 90,
+              "contribution": 16.2
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": "Building Ministry"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "Engaging People"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "Engaging People"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 3,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": "Being Real"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 5,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 5,
+              "note": "Building Ministry"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 5,
+              "note": "Being Real"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 2,
+              "note": "Building Ministry"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Scripture Engagement and Memory Reinforcement, with the clearest next step in Leader Development.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
+              "Homework was referenced and rewarded, differentiating the members who prepared."
+            ],
+            "improvements": [
+              "No in-session development of another leader was observable this week.",
+              "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture."
+            ],
+            "recommendations": [
+              "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+              "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds."
+            ],
+            "overview": [
+              "A strong session — strongest in Scripture Engagement and Memory Reinforcement, with the clearest next step in Leader Development. It scored 78.9/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Memory Reinforcement; the recommendations below turn Leader Development into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement anchored the session (5/5)",
+                "paragraphs": [
+                  "The session opened by recalling prior Big Ideas, reinforcing cumulative learning.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Homework References anchored the session (5/5)",
+                "paragraphs": [
+                  "Homework was referenced and rewarded, differentiating the members who prepared.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Building Ministry"
+                ]
+              },
+              {
+                "title": "Prayer anchored the session (5/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Being Real"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Leader Development is a growth area (2/5)",
+                "paragraphs": [
+                  "No in-session development of another leader was observable this week.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Building Ministry"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow is a growth area (3/5)",
+                "paragraphs": [
+                  "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Engaging People"
+                ]
+              },
+              {
+                "title": "Visual Aids is a growth area (3/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Participant Engagement is a growth area (4/5)",
+                "paragraphs": [
+                  "A few voices carried the discussion; quieter members went unheard.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Engaging People"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Leader Development",
+                "paragraphs": [
+                  "Next time, verbalize one hand-off — e.g., \"Randy is going to open us next week.\"",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Building Ministry cluster (weight 31 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Session Structure & Flow",
+                "paragraphs": [
+                  "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Participant Engagement",
+                "paragraphs": [
+                  "Next time, name one quiet regular early and invite their read on a passage.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 80% × weight 33 → 26.40 pts",
+                "Building Ministry: 70% × weight 31 → 21.70 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 90% × weight 18 → 16.20 pts",
+                "Base (sum of cluster contributions): 76.90 / 100",
+                "Session bonuses: newcomer growth +2",
+                "Session score: 78.9 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3/5): Teaching Craft",
+                "Newcomer Welcome (N/A): Building Ministry",
+                "Scripture Engagement (5/5): Teaching Craft",
+                "Facilitation vs. Lecture (3/5): Engaging People",
+                "Application Questions (4/5): Teaching Craft",
+                "Participant Engagement (4/5): Engaging People",
+                "Visual Aids (3/5): Teaching Craft",
+                "Vulnerability / Authenticity (4/5): Being Real",
+                "Memory Reinforcement (5/5): Teaching Craft",
+                "Homework References (5/5): Building Ministry",
+                "Prayer (5/5): Being Real",
+                "Leader Development (2/5): Building Ministry"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        }
+      ]
+    },
+    {
+      "id": "jt-dettman",
+      "name": "JT Dettman",
+      "email": "jt-dettman@needs-real-email.invalid",
+      "group": "Revelation Study",
+      "coachName": "Bryan Bailey",
+      "isCoach": true,
+      "zoomLink": "",
+      "reports": []
+    },
+    {
+      "id": "josh-samuels",
+      "name": "Josh Samuels",
+      "email": "josh-samuels@needs-real-email.invalid",
+      "group": "James Study",
+      "coachName": "Bryan Bailey",
+      "isCoach": true,
+      "zoomLink": "",
+      "reports": [
+        {
+          "id": "josh-samuels-2026-05-30-james-1-12-27-lesson-3-crown-of-",
+          "date": "2026-05-30",
+          "dateLabel": "May 30, 2026",
+          "session": "James 1:12–27, Lesson 3 — Crown of Life, Birth Cycle of Sin & Pure Religion",
+          "topic": "Perseverance under trial; temptation vs. testing; God's character & goodness; hearers vs. doers",
+          "duration": "~2h 20m",
+          "attendees": 15,
+          "newcomers": 0,
+          "score": 72.44,
+          "base": 72.44,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 68,
+              "contribution": 22.44
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 80,
+              "contribution": 24.8
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": "Building Ministry"
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "Engaging People"
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "Engaging People"
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 2,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 3,
+              "note": "Being Real"
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 3,
+              "note": "Teaching Craft"
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 3,
+              "note": "Building Ministry"
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": "Being Real"
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": 5,
+              "note": "Building Ministry"
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Scripture Engagement and Leader Development, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "An apprentice was visibly developed in-session — a clear multiplication signal.",
+              "Application questions pushed members from concept to life, several at the reason/apply level."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds."
+            ],
+            "overview": [
+              "A strong session — strongest in Scripture Engagement and Leader Development, with the clearest next step in Visual Aids. It scored 72.44/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Leader Development; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Leader Development anchored the session (5/5)",
+                "paragraphs": [
+                  "An apprentice was visibly developed in-session — a clear multiplication signal.",
+                  "2 Timothy 2:2 makes multiplication the apex leadership outcome — a named, in-session hand-off is the observable signal that a leader is being made.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Building Ministry"
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Engaging People"
+                ]
+              },
+              {
+                "title": "Prayer anchored the session (4/5)",
+                "paragraphs": [
+                  "Prayer was delegated to members, opening and closing the group in shared voice.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Being Real"
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (2/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Session Structure & Flow is a growth area (3/5)",
+                "paragraphs": [
+                  "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Teaching Craft"
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Engaging People"
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity is a growth area (3/5)",
+                "paragraphs": [
+                  "Teaching stayed at arm’s length; little personal cost was modeled.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Being Real"
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Teaching Craft"
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Session Structure & Flow",
+                "paragraphs": [
+                  "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Vulnerability / Authenticity",
+                "paragraphs": [
+                  "Next time, open one teaching point with a first-person example that cost you something.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 68% × weight 33 → 22.44 pts",
+                "Building Ministry: 80% × weight 31 → 24.80 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 70% × weight 18 → 12.60 pts",
+                "Base (sum of cluster contributions): 72.44 / 100",
+                "Session score: 72.44 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3/5): Teaching Craft",
+                "Newcomer Welcome (N/A): Building Ministry",
+                "Scripture Engagement (5/5): Teaching Craft",
+                "Facilitation vs. Lecture (3/5): Engaging People",
+                "Application Questions (4/5): Teaching Craft",
+                "Participant Engagement (4/5): Engaging People",
+                "Visual Aids (2/5): Teaching Craft",
+                "Vulnerability / Authenticity (3/5): Being Real",
+                "Memory Reinforcement (3/5): Teaching Craft",
+                "Homework References (3/5): Building Ministry",
+                "Prayer (4/5): Being Real",
+                "Leader Development (5/5): Building Ministry"
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        }
+      ]
+    },
+    {
+      "id": "phil-carlberg",
+      "name": "Phil Carlberg",
+      "email": "phil-carlberg@needs-real-email.invalid",
+      "group": "Men’s Study",
+      "coachName": "Bryan Bailey",
+      "isCoach": true,
+      "zoomLink": "",
+      "reports": [
+        {
+          "id": "phil-carlberg-2026-06-04-book-of-james-lesson-4-partialit",
+          "date": "2026-06-04",
+          "dateLabel": "June 4, 2026",
+          "session": "Book of James · Lesson 4 — Partiality, Wealth & the Royal Law (James 2:1–13)",
+          "topic": "Partiality, Wealth & Possessions, the Royal Law, Mercy Triumphs",
+          "duration": "~1 hr 56 min",
+          "attendees": 15,
+          "newcomers": 0,
+          "score": 74.24,
+          "base": 74.24,
+          "newcomerBonus": 0,
+          "sizeBonus": 0,
+          "status": "Strong",
+          "statusEmoji": "🟢",
+          "clusters": [
+            {
+              "name": "Teaching Craft",
+              "weight": 33,
+              "scorePct": 68,
+              "contribution": 22.44
+            },
+            {
+              "name": "Building Ministry",
+              "weight": 31,
+              "scorePct": 80,
+              "contribution": 24.8
+            },
+            {
+              "name": "Engaging People",
+              "weight": 18,
+              "scorePct": 70,
+              "contribution": 12.6
+            },
+            {
+              "name": "Being Real",
+              "weight": 18,
+              "scorePct": 80,
+              "contribution": 14.4
+            }
+          ],
+          "dimensions": [
+            {
+              "n": 1,
+              "name": "Session Structure & Flow",
+              "score": 3,
+              "note": "Opening prayer delegated, Big Ideas recap (via Cameron), scripture readings, closing prayer delegated. Missing: formal Big Ideas generation at close in bumper-sticker format; whiteboard visual failed. Blueprint partially executed."
+            },
+            {
+              "n": 2,
+              "name": "Newcomer Welcome",
+              "score": null,
+              "note": "No newcomers present. Building Ministry max reduced proportionally; no penalty applied."
+            },
+            {
+              "n": 3,
+              "name": "Scripture Engagement",
+              "score": 5,
+              "note": "13+ cross-references across 8 books; 9 different readers; Greek/Hebrew notes on “listen” and NASB italics; every passage connected back to James 2 theme. Well above 6+ benchmark."
+            },
+            {
+              "n": 4,
+              "name": "Facilitation vs. Lecture",
+              "score": 3,
+              "note": "~38% with scripture reading, ~30–33% discussion-only. At or slightly above Lifeway 30% target. Cross-reference assignment block was leader-heavy. Question/statement ratio ~50/50 (target 60/40+)."
+            },
+            {
+              "n": 5,
+              "name": "Application Questions",
+              "score": 4,
+              "note": "8–10 Big Idea questions, mostly DOK 2–3. DOK 4 life-connection questions under-used (~15% vs. 20–30% target). Strong question design overall."
+            },
+            {
+              "n": 6,
+              "name": "Participant Engagement",
+              "score": 4,
+              "note": "~87% contribution rate; 9 named readers; 15+ named call-outs. Cameron and John Otwell led peer-to-peer synthesis. Strong."
+            },
+            {
+              "n": 7,
+              "name": "Visual Aids",
+              "score": 2,
+              "note": "Whiteboard attempt failed; no screen sharing used; MacArthur Study Bible referenced verbally only. Highest addressable gap."
+            },
+            {
+              "n": 8,
+              "name": "Vulnerability / Authenticity",
+              "score": 4,
+              "note": "3 leader vulnerability moments at progressively deeper levels (partiality, money/idol, double-minded self-indictment). Group vulnerability followed. High-quality modeling."
+            },
+            {
+              "n": 9,
+              "name": "Memory Reinforcement",
+              "score": 3,
+              "note": "Cameron’s 7-point James 1 recap was strong (Ebbinghaus retrieval). Phil’s faith-test summary was good structure but read from notes, not generated from group memory. No bumper-sticker closing ritual yet established."
+            },
+            {
+              "n": 10,
+              "name": "Homework References",
+              "score": 4,
+              "note": "Pages 32–34 explicitly cited throughout; cross-references assigned from homework structure; NASB note taken from workbook. Strong homework integration."
+            },
+            {
+              "n": 11,
+              "name": "Prayer",
+              "score": 4,
+              "note": "Opening prayer delegated to Steve Horn; prayer for John Sermon at open; prayer requests gathered (Ren, John Sermon); closing prayer delegated to John Bradford. All four prayer practices present. Missed: real-time prayer for Ren when Ron shared the update."
+            },
+            {
+              "n": 12,
+              "name": "Leader Development",
+              "score": null,
+              "note": "Solo lead; no mentor or apprentice present. Cameron’s Big Ideas recap role is a natural development pathway (explore deliberately next session). N/A reduces Building Ministry max proportionally per v3 spec."
+            }
+          ],
+          "bigIdeas": [],
+          "feedback": {
+            "headline": "A strong session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Visual Aids.",
+            "strengths": [
+              "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+              "Application questions pushed members from concept to life, several at the reason/apply level.",
+              "A high share of the room contributed substantively, called on by name."
+            ],
+            "improvements": [
+              "The session leaned audio-only; a visual anchor would aid retention.",
+              "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+              "Leader talk crowded out discussion; the balance leaned toward lecture."
+            ],
+            "recommendations": [
+              "Next time, put one word-study lookup or a simple table on screen during the key term.",
+              "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+              "Next time, after each key point hand off with a question and hold silence for a full 5 seconds."
+            ],
+            "overview": [
+              "A strong session — strongest in Scripture Engagement and Application Questions, with the clearest next step in Visual Aids. It scored 74.24/100 under the v3 weighted model.",
+              "The session played to its strengths in Scripture Engagement and Application Questions; the recommendations below turn Visual Aids into transferable technique for the next session, so the momentum carries forward regardless of the passage."
+            ],
+            "strengthsProse": [
+              {
+                "title": "Scripture Engagement anchored the session (5/5)",
+                "paragraphs": [
+                  "Strong cross-referencing anchored the discussion in multiple texts, not a single proof-verse.",
+                  "Willow Creek’s REVEAL study found Scripture engagement the #1 driver of long-term spiritual growth; the research bar is 6+ cross-references a session.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 13+ cross-references across 8 books; 9 different readers; Greek/Hebrew notes on “listen” and NASB italics; every passage connected back to James 2 theme. Well above 6+ benchmark."
+                ]
+              },
+              {
+                "title": "Application Questions anchored the session (4/5)",
+                "paragraphs": [
+                  "Application questions pushed members from concept to life, several at the reason/apply level.",
+                  "Norman Webb’s Depth-of-Knowledge framework asks the majority of Big-Idea questions to land at Level 2–4, moving members from recall toward first-person application.",
+                  "This dimension rolls up into the Teaching Craft cluster (weight 33 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 8–10 Big Idea questions, mostly DOK 2–3. DOK 4 life-connection questions under-used (~15% vs. 20–30% target). Strong question design overall."
+                ]
+              },
+              {
+                "title": "Participant Engagement anchored the session (4/5)",
+                "paragraphs": [
+                  "A high share of the room contributed substantively, called on by name.",
+                  "Healthy participation research (Gini-coefficient approach) looks for 70–80% of attendees contributing substantively, not a few voices carrying the room.",
+                  "This dimension rolls up into the Engaging People cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: ~87% contribution rate; 9 named readers; 15+ named call-outs. Cameron and John Otwell led peer-to-peer synthesis. Strong."
+                ]
+              },
+              {
+                "title": "Vulnerability / Authenticity anchored the session (4/5)",
+                "paragraphs": [
+                  "Costly personal honesty set a tone of safety, and members disclosed in turn.",
+                  "Authenticity modeled at genuine personal cost is what earns a teacher relational authority and gives the room permission to disclose in turn.",
+                  "This dimension rolls up into the Being Real cluster (weight 18 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: 3 leader vulnerability moments at progressively deeper levels (partiality, money/idol, double-minded self-indictment). Group vulnerability followed. High-quality modeling."
+                ]
+              },
+              {
+                "title": "Homework References anchored the session (4/5)",
+                "paragraphs": [
+                  "Homework was referenced and rewarded, differentiating the members who prepared.",
+                  "Homework named and rewarded in-session (the Precept workbook, “The Guarantee”) is what differentiates members who prepared and compounds engagement.",
+                  "This dimension rolls up into the Building Ministry cluster (weight 31 of 100), so keeping it strong protects a large share of the composite — the gain here is banked, not one-off.",
+                  "From the session: Pages 32–34 explicitly cited throughout; cross-references assigned from homework structure; NASB note taken from workbook. Strong homework integration."
+                ]
+              }
+            ],
+            "improvementsProse": [
+              {
+                "title": "Visual Aids is a growth area (2/5)",
+                "paragraphs": [
+                  "The session leaned audio-only; a visual anchor would aid retention.",
+                  "Mayer’s multimedia principle: pairing a word or image on screen with the spoken teaching measurably improves retention.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Whiteboard attempt failed; no screen sharing used; MacArthur Study Bible referenced verbally only. Highest addressable gap."
+                ]
+              },
+              {
+                "title": "Session Structure & Flow is a growth area (3/5)",
+                "paragraphs": [
+                  "Transitions between segments lost momentum, so the session’s shape was harder to feel.",
+                  "A clear arc — open, review, context, reading, discussion, close — is what lets a group feel momentum instead of drift, so hand-offs between segments are worth guarding.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Opening prayer delegated, Big Ideas recap (via Cameron), scripture readings, closing prayer delegated. Missing: formal Big Ideas generation at close in bumper-sticker format; whiteboard visual failed. Blueprint partially executed."
+                ]
+              },
+              {
+                "title": "Facilitation vs. Lecture is a growth area (3/5)",
+                "paragraphs": [
+                  "Leader talk crowded out discussion; the balance leaned toward lecture.",
+                  "The Lifeway 30% Rule (and Flanders Interaction Analysis) puts leader talk at ≤30–35% during discussion — the room should carry most of the thinking.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: ~38% with scripture reading, ~30–33% discussion-only. At or slightly above Lifeway 30% target. Cross-reference assignment block was leader-heavy. Question/statement ratio ~50/50 (target 60/40+)."
+                ]
+              },
+              {
+                "title": "Memory Reinforcement is a growth area (3/5)",
+                "paragraphs": [
+                  "Prior Big Ideas weren’t reviewed, so last week’s themes faded.",
+                  "Ebbinghaus’ forgetting curve is answered by cumulative recall — reciting prior Big Ideas at the open reinforces what would otherwise fade by the next session.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Cameron’s 7-point James 1 recap was strong (Ebbinghaus retrieval). Phil’s faith-test summary was good structure but read from notes, not generated from group memory. No bumper-sticker closing ritual yet established."
+                ]
+              },
+              {
+                "title": "Prayer is a growth area (4/5)",
+                "paragraphs": [
+                  "Prayer was leader-only or rushed; the group’s voice was thin.",
+                  "Delegated opening and closing prayer, plus a living prayer chain, is the relational infrastructure that shepherds a group between meetings.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention.",
+                  "From the session: Opening prayer delegated to Steve Horn; prayer for John Sermon at open; prayer requests gathered (Ren, John Sermon); closing prayer delegated to John Bradford. All four prayer practices present. Missed: real-time prayer for Ren when Ron shared the update."
+                ]
+              }
+            ],
+            "recommendationsProse": [
+              {
+                "title": "Next session — Visual Aids",
+                "paragraphs": [
+                  "Next time, put one word-study lookup or a simple table on screen during the key term.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Session Structure & Flow",
+                "paragraphs": [
+                  "Next time, jot the 5 segment beats on a card and glance at it to keep hand-offs crisp.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Facilitation vs. Lecture",
+                "paragraphs": [
+                  "Next time, after each key point hand off with a question and hold silence for a full 5 seconds.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Engaging People cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Memory Reinforcement",
+                "paragraphs": [
+                  "Next time, start with a 3-minute cold-recall of last session’s Big Ideas.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Teaching Craft cluster (weight 33 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              },
+              {
+                "title": "Next session — Prayer",
+                "paragraphs": [
+                  "Next time, ask one member to open and a different member to close in prayer.",
+                  "This is transferable technique: it carries into next week’s passage rather than re-teaching this one.",
+                  "Because this dimension sits in the Being Real cluster (weight 18 of 100), a one-point move here shifts the composite more than almost anywhere else — which is why it is the highest-leverage place to spend next session's attention."
+                ]
+              }
+            ]
+          },
+          "sections": [
+            {
+              "title": "Score composition",
+              "paragraphs": [
+                "How the four weighted clusters and any session bonuses combined into the composite score."
+              ],
+              "bullets": [
+                "Teaching Craft: 68% × weight 33 → 22.44 pts",
+                "Building Ministry: 80% × weight 31 → 24.80 pts",
+                "Engaging People: 70% × weight 18 → 12.60 pts",
+                "Being Real: 80% × weight 18 → 14.40 pts",
+                "Base (sum of cluster contributions): 74.24 / 100",
+                "Session score: 74.24 / 100"
+              ]
+            },
+            {
+              "title": "Coaching notes by dimension",
+              "paragraphs": [
+                "The per-dimension rationale behind each score on the 12-dimension scorecard."
+              ],
+              "bullets": [
+                "Session Structure & Flow (3/5): Opening prayer delegated, Big Ideas recap (via Cameron), scripture readings, closing prayer delegated. Missing: formal Big Ideas generation at close in bumper-sticker format; whiteboard visual failed. Blueprint partially executed.",
+                "Newcomer Welcome (N/A): No newcomers present. Building Ministry max reduced proportionally; no penalty applied.",
+                "Scripture Engagement (5/5): 13+ cross-references across 8 books; 9 different readers; Greek/Hebrew notes on “listen” and NASB italics; every passage connected back to James 2 theme. Well above 6+ benchmark.",
+                "Facilitation vs. Lecture (3/5): ~38% with scripture reading, ~30–33% discussion-only. At or slightly above Lifeway 30% target. Cross-reference assignment block was leader-heavy. Question/statement ratio ~50/50 (target 60/40+).",
+                "Application Questions (4/5): 8–10 Big Idea questions, mostly DOK 2–3. DOK 4 life-connection questions under-used (~15% vs. 20–30% target). Strong question design overall.",
+                "Participant Engagement (4/5): ~87% contribution rate; 9 named readers; 15+ named call-outs. Cameron and John Otwell led peer-to-peer synthesis. Strong.",
+                "Visual Aids (2/5): Whiteboard attempt failed; no screen sharing used; MacArthur Study Bible referenced verbally only. Highest addressable gap.",
+                "Vulnerability / Authenticity (4/5): 3 leader vulnerability moments at progressively deeper levels (partiality, money/idol, double-minded self-indictment). Group vulnerability followed. High-quality modeling.",
+                "Memory Reinforcement (3/5): Cameron’s 7-point James 1 recap was strong (Ebbinghaus retrieval). Phil’s faith-test summary was good structure but read from notes, not generated from group memory. No bumper-sticker closing ritual yet established.",
+                "Homework References (4/5): Pages 32–34 explicitly cited throughout; cross-references assigned from homework structure; NASB note taken from workbook. Strong homework integration.",
+                "Prayer (4/5): Opening prayer delegated to Steve Horn; prayer for John Sermon at open; prayer requests gathered (Ren, John Sermon); closing prayer delegated to John Bradford. All four prayer practices present. Missed: real-time prayer for Ren when Ron shared the update.",
+                "Leader Development (N/A): Solo lead; no mentor or apprentice present. Cameron’s Big Ideas recap role is a natural development pathway (explore deliberately next session). N/A reduces Building Ministry max proportionally per v3 spec."
+              ]
+            }
+          ],
+          "docUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV",
+          "pdfUrl": "https://drive.google.com/drive/folders/1vvVpdPk2ARawV3wOM9LeXJ0BtpVJ2qjV"
+        }
+      ]
+    },
+    {
+      "id": "david-kartozia",
+      "name": "David Kartozia",
+      "email": "david-kartozia@needs-real-email.invalid",
+      "group": "Men’s Study",
+      "coachName": "Bryan Bailey",
+      "isCoach": true,
+      "zoomLink": "",
+      "reports": []
     }
   ]
 }


### PR DESCRIPTION
## What & why

`GET /coach/*` is served from the bundled `packages/backend-base/src/coach/coach.data.json`. This regenerates it so the Bible-Coach portal — previously live for **Bryan only** — now serves **every evaluated leader**, each keyed to their real VerseMate login email and carrying their full session history.

The coach module matches a signed-in account's email (lowercased, exact) against `coach.email`, so a leader signing into VerseMate now unlocks their own coach portal with no extra step.

## Changes

- **`packages/backend-base/src/coach/coach.data.json`** — regenerated by the `bible-study-coaching` portal exporter (see companion PR). **Data only, no code changes.** 6 → 16 coaches, 8 → 50 reports.
  - Placeholder `@example.com` addresses (which could never match a real login) replaced with real leader emails.
  - Leaders whose address isn't yet confirmed carry an unroutable `.invalid` placeholder — their history loads for the admin oversight view, but the portal never unlocks for the wrong account.

The coach plugin/service and the portal UI already render whatever coaches this dataset contains, so no code changes are required.

## Verification

- All 50 reports conform to `coach.schema.ts` `ReportSchema` required fields (12 dims, 4 clusters, score in range); 16 unique emails.
- `coach.service.test.ts`'s real-data assertions (jeff-ward exists with ≥1 report, latest = max date) still hold. (The test suite couldn't run in this container — `@sinclair/typebox` isn't installed here — but the change is data-only and the tolerant assertions are unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XXaGKjB79CYmJ21XVGePpo

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXaGKjB79CYmJ21XVGePpo)_