### PR TITLE
feat(coach): persist and expose leader affiliated church

### DIFF
--- a/packages/backend-base/src/coach/coach.plugin.ts
+++ b/packages/backend-base/src/coach/coach.plugin.ts
@@ -10,7 +10,7 @@ import { StandardErrorResponses } from "../common/response-schemas";
 import shared from "../shared/shared.plugin";
 import { ReportSchema } from "./coach.schema";
 import { CoachService } from "./coach.service";
-import { UpdateZoomLinkDto } from "./dto/coach.dto";
+import { UpdateAffiliatedChurchDto, UpdateZoomLinkDto } from "./dto/coach.dto";
 
 // ─── Response schemas ──────────────────────────────────────────────────────
 // ReportSchema (and its parts) live in coach.schema.ts — a side-effect-free
@@ -32,6 +32,7 @@ const MeSchema = t.Object({
     t.Null(),
   ]),
   zoomLink: t.String(),
+  affiliatedChurch: t.String(),
   model: t.String(),
   clusters: t.Array(t.Object({ name: t.String(), weight: t.Number() })),
   statusBands: t.Array(
@@ -167,6 +168,28 @@ const plugin = new Elysia()
           body: UpdateZoomLinkDto,
           response: {
             200: t.Object({ zoomLink: t.String() }),
+            ...StandardErrorResponses,
+          },
+        },
+      )
+      .put(
+        "/affiliated-church",
+        async ({ body, store: { coachService }, currentUserId }) => {
+          if (!currentUserId)
+            throw new UnauthorizedError("Authentication required");
+          const affiliatedChurch = body.affiliatedChurch.trim();
+          const saved = await coachService.setAffiliatedChurch(
+            currentUserId,
+            affiliatedChurch,
+          );
+          if (saved === null)
+            throw new ForbiddenError("Not a coaching account");
+          return { affiliatedChurch: saved };
+        },
+        {
+          body: UpdateAffiliatedChurchDto,
+          response: {
+            200: t.Object({ affiliatedChurch: t.String() }),
             ...StandardErrorResponses,
           },
         },

--- a/packages/backend-base/src/coach/coach.service.ts
+++ b/packages/backend-base/src/coach/coach.service.ts
@@ -208,7 +208,7 @@ export class CoachService {
     if (!record && !admin) return null;
 
     const stored = record
-      ? await this.coachRepository.getZoomLink(userId)
+      ? await this.coachRepository.getSettings(userId)
       : null;
     return {
       isCoach: !!record,
@@ -222,7 +222,8 @@ export class CoachService {
             coachName: record.coachName,
           }
         : null,
-      zoomLink: stored ?? record?.zoomLink ?? "",
+      zoomLink: stored?.zoomLink ?? record?.zoomLink ?? "",
+      affiliatedChurch: stored?.affiliatedChurch ?? "",
       model: coachData.model,
       clusters: coachData.clusters,
       statusBands: coachData.statusBands,
@@ -296,6 +297,15 @@ export class CoachService {
     const record = await this.recordFor(userId);
     if (!record) return null;
     return this.coachRepository.setZoomLink(userId, zoomLink);
+  }
+
+  async setAffiliatedChurch(
+    userId: string,
+    affiliatedChurch: string,
+  ): Promise<string | null> {
+    const record = await this.recordFor(userId);
+    if (!record) return null;
+    return this.coachRepository.setAffiliatedChurch(userId, affiliatedChurch);
   }
 
   /** Derive the chart series from a coach's reports. Pure — exported shape

--- a/packages/backend-base/src/coach/dto/coach.dto.ts
+++ b/packages/backend-base/src/coach/dto/coach.dto.ts
@@ -7,3 +7,11 @@ export const UpdateZoomLinkDto = t.Object({
 });
 
 export type UpdateZoomLinkDto = typeof UpdateZoomLinkDto.static;
+
+/** Body for PUT /coach/affiliated-church. Empty string clears the value; any
+ *  non-empty value is a free-form church name. */
+export const UpdateAffiliatedChurchDto = t.Object({
+  affiliatedChurch: t.String({ maxLength: 200 }),
+});
+
+export type UpdateAffiliatedChurchDto = typeof UpdateAffiliatedChurchDto.static;

--- a/packages/backend-base/src/coach/repository/coach.repository.ts
+++ b/packages/backend-base/src/coach/repository/coach.repository.ts
@@ -1,25 +1,33 @@
 import { sql } from "kysely";
 import type { db } from "../../shared/shared.plugin";
 
+/** The coach portal's user-writable setup fields (one row per user). */
+export interface CoachSettings {
+  zoomLink: string;
+  affiliatedChurch: string;
+}
+
 /**
- * Persistence for the coach portal's one mutable field: the leader's meeting
- * (Zoom / Meet / Teams) link. Reports + trends come from the bundled dataset;
- * only this link is user-writable, so it lives in coach_zoom_links (one row
- * per user).
+ * Persistence for the coach portal's mutable setup fields: the leader's
+ * meeting (Zoom / Meet / Teams) link and their affiliated church. Reports +
+ * trends come from the bundled dataset; only these fields are user-writable,
+ * so they live in coach_zoom_links (one row per user).
  */
 export class CoachRepository {
   constructor(private readonly db: db) {}
 
-  /** Returns the saved link, or null when the user has never set one. */
-  async getZoomLink(userId: string): Promise<string | null> {
+  /** Returns the saved setup fields, or null when the user has no row yet. */
+  async getSettings(userId: string): Promise<CoachSettings | null> {
     const row = await this.db
       .getOrCreateConnection()
       .selectFrom("coach_zoom_links")
       .where("user_id", "=", userId)
-      .select(["zoom_link"])
+      .select(["zoom_link", "affiliated_church"])
       .executeTakeFirst();
 
-    return row ? row.zoom_link : null;
+    return row
+      ? { zoomLink: row.zoom_link, affiliatedChurch: row.affiliated_church }
+      : null;
   }
 
   /** Upserts the link for a user and returns the stored value. */
@@ -37,5 +45,25 @@ export class CoachRepository {
       .execute();
 
     return zoomLink;
+  }
+
+  /** Upserts the affiliated church for a user and returns the stored value. */
+  async setAffiliatedChurch(
+    userId: string,
+    affiliatedChurch: string,
+  ): Promise<string> {
+    await this.db
+      .getOrCreateConnection()
+      .insertInto("coach_zoom_links")
+      .values({ user_id: userId, affiliated_church: affiliatedChurch })
+      .onConflict((oc) =>
+        oc.column("user_id").doUpdateSet({
+          affiliated_church: affiliatedChurch,
+          updated_at: sql`NOW()`,
+        }),
+      )
+      .execute();
+
+    return affiliatedChurch;
   }
 }

--- a/packages/database/migrations/20260721000000-add-coach-affiliated-church.ts
+++ b/packages/database/migrations/20260721000000-add-coach-affiliated-church.ts
@@ -1,0 +1,35 @@
+import type { Kysely } from "kysely";
+import type Database from "../src/models/Database";
+
+/**
+ * Bible-Coach portal: per-leader affiliated church.
+ *
+ * The coach portal's reports + trends are served from the coaching-pipeline
+ * dataset (backend-base/src/coach/coach.data.json); the leader's meeting link
+ * already lives in coach_zoom_links (one row per user). The affiliated church
+ * is the second user-writable setup field, so it rides on the same row rather
+ * than a new table.
+ */
+export async function up(db: Kysely<Database>): Promise<void> {
+  console.log("Adding affiliated_church to coach_zoom_links...");
+
+  await db.schema
+    .alterTable("coach_zoom_links")
+    .addColumn("affiliated_church", "text", (col) =>
+      col.defaultTo("").notNull(),
+    )
+    .execute();
+
+  console.log("affiliated_church column added successfully");
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  console.log("Dropping affiliated_church from coach_zoom_links...");
+
+  await db.schema
+    .alterTable("coach_zoom_links")
+    .dropColumn("affiliated_church")
+    .execute();
+
+  console.log("affiliated_church column dropped successfully");
+}

--- a/packages/database/src/models/public/CoachZoomLinks.ts
+++ b/packages/database/src/models/public/CoachZoomLinks.ts
@@ -14,6 +14,8 @@ export default interface CoachZoomLinksTable {
 
   zoom_link: ColumnType<string, string | undefined, string>;
 
+  affiliated_church: ColumnType<string, string | undefined, string>;
+
   updated_at: ColumnType<Date, Date | string | undefined, Date | string>;
 }
 


### PR DESCRIPTION
## What & why

Adds a second user-writable coach setup field alongside the meeting link: the leader's **affiliated church**. This backs the new "Affiliated church" field on the coach setup page in the web portal (verse-mate/verse-mate-web companion PR).

The value rides on the existing `coach_zoom_links` row (one row per user) rather than introducing a new table — reports + trends still come from the bundled dataset; only these setup fields are user-writable.

## Changes

- **Migration** `20260721000000-add-coach-affiliated-church.ts` — adds `coach_zoom_links.affiliated_church` (`text`, default `''`, not null) and the matching hand-authored Kanel model column.
- **Repository** — replaces `getZoomLink()` with `getSettings()` returning `{ zoomLink, affiliatedChurch }`; adds `setAffiliatedChurch()` (upsert, mirrors `setZoomLink`).
- **Service** — `getMe()` now returns `affiliatedChurch`; adds `setAffiliatedChurch()` gated on the coaching roster (403 for non-coaches).
- **Plugin** — new `PUT /coach/affiliated-church` endpoint + `UpdateAffiliatedChurchDto` (max 200 chars, empty clears); `affiliatedChurch` added to the `/coach/me` response schema.

## Testing

- `bun tsc` — clean (also enforced by the pre-commit hook).
- `bun test src/coach/coach.service.test.ts` — 11 pass.
- `biome check` — clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7tuzvvzMwpK9RqG1ryYWc)_