### PR TITLE
feat(coach): persist and expose leader's Bible coach selection

### DIFF
--- a/packages/backend-base/src/coach/coach.plugin.ts
+++ b/packages/backend-base/src/coach/coach.plugin.ts
@@ -23,6 +23,7 @@ import {
   AddNoteDto,
   CoachClassDto,
   UpdateAffiliatedChurchDto,
+  UpdateBibleCoachDto,
   UpdateRecordingLinkDto,
   UpdateZoomLinkDto,
 } from "./dto/coach.dto";
@@ -55,6 +56,7 @@ const MeSchema = t.Object({
   ]),
   zoomLink: t.String(),
   affiliatedChurch: t.String(),
+  bibleCoach: t.String(),
   model: t.String(),
   clusters: t.Array(t.Object({ name: t.String(), weight: t.Number() })),
   statusBands: t.Array(
@@ -247,6 +249,28 @@ const plugin = new Elysia()
           body: UpdateAffiliatedChurchDto,
           response: {
             200: t.Object({ affiliatedChurch: t.String() }),
+            ...StandardErrorResponses,
+          },
+        },
+      )
+      .put(
+        "/bible-coach",
+        async ({ body, store: { coachService }, currentUserId }) => {
+          if (!currentUserId)
+            throw new UnauthorizedError("Authentication required");
+          const bibleCoach = body.bibleCoach.trim();
+          const saved = await coachService.setBibleCoach(
+            currentUserId,
+            bibleCoach,
+          );
+          if (saved === null)
+            throw new ForbiddenError("Not a coaching account");
+          return { bibleCoach: saved };
+        },
+        {
+          body: UpdateBibleCoachDto,
+          response: {
+            200: t.Object({ bibleCoach: t.String() }),
             ...StandardErrorResponses,
           },
         },

--- a/packages/backend-base/src/coach/coach.service.ts
+++ b/packages/backend-base/src/coach/coach.service.ts
@@ -396,6 +396,7 @@ export class CoachService {
         : null,
       zoomLink: stored?.zoomLink ?? record?.zoomLink ?? "",
       affiliatedChurch: stored?.affiliatedChurch ?? "",
+      bibleCoach: stored?.bibleCoach ?? "",
       model: coachData.model,
       clusters: coachData.clusters,
       statusBands: coachData.statusBands,
@@ -761,6 +762,15 @@ export class CoachService {
     const record = await this.recordFor(userId);
     if (!record) return null;
     return this.coachRepository.setAffiliatedChurch(userId, affiliatedChurch);
+  }
+
+  async setBibleCoach(
+    userId: string,
+    bibleCoach: string,
+  ): Promise<string | null> {
+    const record = await this.recordFor(userId);
+    if (!record) return null;
+    return this.coachRepository.setBibleCoach(userId, bibleCoach);
   }
 
   // ─── Classes (many per leader) ────────────────────────────────────────────

--- a/packages/backend-base/src/coach/dto/coach.dto.ts
+++ b/packages/backend-base/src/coach/dto/coach.dto.ts
@@ -16,6 +16,15 @@ export const UpdateAffiliatedChurchDto = t.Object({
 
 export type UpdateAffiliatedChurchDto = typeof UpdateAffiliatedChurchDto.static;
 
+/** Body for PUT /coach/bible-coach. Empty string clears the selection (the
+ *  portal then defaults to Bryan Bailey); any non-empty value is the chosen
+ *  coach's display name. */
+export const UpdateBibleCoachDto = t.Object({
+  bibleCoach: t.String({ maxLength: 200 }),
+});
+
+export type UpdateBibleCoachDto = typeof UpdateBibleCoachDto.static;
+
 /** Allowed recurrence keywords for a class. */
 export const CLASS_RECURRENCES = [
   "none",

--- a/packages/backend-base/src/coach/repository/coach.repository.ts
+++ b/packages/backend-base/src/coach/repository/coach.repository.ts
@@ -5,6 +5,7 @@ import type { db } from "../../shared/shared.plugin";
 export interface CoachSettings {
   zoomLink: string;
   affiliatedChurch: string;
+  bibleCoach: string;
 }
 
 /** A persisted class row as returned to the service layer (dates normalized
@@ -67,11 +68,15 @@ export class CoachRepository {
       .getOrCreateConnection()
       .selectFrom("coach_zoom_links")
       .where("user_id", "=", userId)
-      .select(["zoom_link", "affiliated_church"])
+      .select(["zoom_link", "affiliated_church", "bible_coach"])
       .executeTakeFirst();
 
     return row
-      ? { zoomLink: row.zoom_link, affiliatedChurch: row.affiliated_church }
+      ? {
+          zoomLink: row.zoom_link,
+          affiliatedChurch: row.affiliated_church,
+          bibleCoach: row.bible_coach,
+        }
       : null;
   }
 
@@ -110,6 +115,23 @@ export class CoachRepository {
       .execute();
 
     return affiliatedChurch;
+  }
+
+  /** Upserts the selected Bible coach for a user and returns the stored value. */
+  async setBibleCoach(userId: string, bibleCoach: string): Promise<string> {
+    await this.db
+      .getOrCreateConnection()
+      .insertInto("coach_zoom_links")
+      .values({ user_id: userId, bible_coach: bibleCoach })
+      .onConflict((oc) =>
+        oc.column("user_id").doUpdateSet({
+          bible_coach: bibleCoach,
+          updated_at: sql`NOW()`,
+        }),
+      )
+      .execute();
+
+    return bibleCoach;
   }
 
   // ─── Classes (many rows per user) ─────────────────────────────────────────

--- a/packages/database/migrations/20260721020000-add-coach-bible-coach.ts
+++ b/packages/database/migrations/20260721020000-add-coach-bible-coach.ts
@@ -1,0 +1,32 @@
+import type { Kysely } from "kysely";
+import type Database from "../src/models/Database";
+
+/**
+ * Bible-Coach portal: per-leader Bible coach selection.
+ *
+ * The leader's meeting link + affiliated church already live in
+ * coach_zoom_links (one row per user). Which coach mentors them is the third
+ * user-writable setup field, so it rides on the same row. Empty string means
+ * "unset" — the portal defaults the picker to Bryan Bailey in that case.
+ */
+export async function up(db: Kysely<Database>): Promise<void> {
+  console.log("Adding bible_coach to coach_zoom_links...");
+
+  await db.schema
+    .alterTable("coach_zoom_links")
+    .addColumn("bible_coach", "text", (col) => col.defaultTo("").notNull())
+    .execute();
+
+  console.log("bible_coach column added successfully");
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  console.log("Dropping bible_coach from coach_zoom_links...");
+
+  await db.schema
+    .alterTable("coach_zoom_links")
+    .dropColumn("bible_coach")
+    .execute();
+
+  console.log("bible_coach column dropped successfully");
+}

--- a/packages/database/src/models/public/CoachZoomLinks.ts
+++ b/packages/database/src/models/public/CoachZoomLinks.ts
@@ -16,6 +16,8 @@ export default interface CoachZoomLinksTable {
 
   affiliated_church: ColumnType<string, string | undefined, string>;
 
+  bible_coach: ColumnType<string, string | undefined, string>;
+
   updated_at: ColumnType<Date, Date | string | undefined, Date | string>;
 }
 


### PR DESCRIPTION
## What & why

Adds a third user-writable coach setup field alongside the meeting link and affiliated church: **which Bible coach mentors the leader**. This backs the new Bible-coach picker on the Coach Settings page (verse-mate/verse-mate-web companion PR).

The value rides on the existing `coach_zoom_links` row (one row per user). Empty string means "unset" — the portal defaults the picker to **Bryan Bailey**.

## Changes

- **Migration** `20260721020000-add-coach-bible-coach.ts` — adds `coach_zoom_links.bible_coach` (`text`, default `''`, not null) and the matching hand-authored Kanel model column.
- **Repository** — `getSettings()` now returns `bibleCoach`; adds `setBibleCoach()` (upsert, mirrors `setAffiliatedChurch`).
- **Service** — `getMe()` returns `bibleCoach`; adds `setBibleCoach()` gated on the coaching roster (403 for non-coaches).
- **Plugin** — new `PUT /coach/bible-coach` endpoint + `UpdateBibleCoachDto` (max 200 chars, empty clears); `bibleCoach` added to the `/coach/me` response schema.

## Testing

- `bun tsc` — clean (also enforced by the pre-commit hook).
- `bun test src/coach/coach.service.test.ts` — 15 pass.
- `biome check` — clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7tuzvvzMwpK9RqG1ryYWc)_