### PR TITLE
coach: auto-attach the leader's saved meeting link as each session's recording link

### DIFF
--- a/packages/backend-base/src/coach/coach.service.test.ts
+++ b/packages/backend-base/src/coach/coach.service.test.ts
@@ -248,6 +248,77 @@ describe("CoachService admin oversight", () => {
   });
 });
 
+describe("CoachService recording-link auto-attach", () => {
+  // A table-aware query stub: coach_zoom_links terminal → the saved meeting
+  // link; coach_recording_links terminal → the seeded explicit links; all
+  // other terminals → empty.
+  function stubDbFor(opts: {
+    zoomLink?: string;
+    recordingLinks?: Record<string, string>;
+  }) {
+    const recordingRows = Object.entries(opts.recordingLinks ?? {}).map(
+      ([report_id, recording_url]) => ({ report_id, recording_url }),
+    );
+    const builderFor = (table: string) => {
+      const b: Record<string, unknown> = new Proxy(
+        {},
+        {
+          get(_t, prop) {
+            if (prop === "execute")
+              return async () =>
+                table === "coach_recording_links" ? recordingRows : [];
+            if (prop === "executeTakeFirst")
+              return async () =>
+                table === "coach_zoom_links" && opts.zoomLink
+                  ? { zoom_link: opts.zoomLink }
+                  : undefined;
+            return () => b;
+          },
+        },
+      );
+      return b;
+    };
+    return {
+      getOrCreateConnection: () => ({
+        selectFrom: (table: string) => builderFor(table),
+        insertInto: () => builderFor("_"),
+      }),
+    } as unknown as ConstructorParameters<typeof CoachService>[0];
+  }
+
+  it("auto-attaches the leader's saved meeting link when no explicit link is set", async () => {
+    const zoom = "https://zoom.us/j/555000111";
+    const svc = new CoachService(stubDbFor({ zoomLink: zoom }));
+    const reports = (await svc.getReportsById("jeff-ward")) ?? [];
+    expect(reports.length).toBeGreaterThan(0);
+    for (const r of reports) expect(r.recordingUrl).toBe(zoom);
+  });
+
+  it("lets an explicit recording link override the auto-attached meeting link", async () => {
+    const zoom = "https://zoom.us/j/555000111";
+    const explicit = "https://drive.google.com/file/session-1";
+    // Grab a real report id first, then seed an explicit link for it.
+    const ids =
+      (await new CoachService(stubDbFor({})).getReportsById("jeff-ward")) ?? [];
+    const targetId = ids[0]?.id ?? "";
+    const svc = new CoachService(
+      stubDbFor({ zoomLink: zoom, recordingLinks: { [targetId]: explicit } }),
+    );
+    const reports = (await svc.getReportsById("jeff-ward")) ?? [];
+    expect(reports.find((r) => r.id === targetId)?.recordingUrl).toBe(explicit);
+    // Every other session still gets the auto-attached meeting link.
+    for (const r of reports.filter((r) => r.id !== targetId)) {
+      expect(r.recordingUrl).toBe(zoom);
+    }
+  });
+
+  it("leaves the recording link empty when the leader has saved no meeting link", async () => {
+    const svc = new CoachService(stubDbFor({}));
+    const reports = (await svc.getReportsById("jeff-ward")) ?? [];
+    for (const r of reports) expect(r.recordingUrl).toBe("");
+  });
+});
+
 describe("Coach class schemas", () => {
   const validClass = {
     id: "c1",

--- a/packages/backend-base/src/coach/coach.service.ts
+++ b/packages/backend-base/src/coach/coach.service.ts
@@ -301,6 +301,7 @@ export class CoachService {
   private async overlayReports(
     coachId: string,
     reports: CoachReport[],
+    fallbackRecordingUrl = "",
   ): Promise<CoachReport[]> {
     if (reports.length === 0) return [];
     const [recMap, noteRows] = await Promise.all([
@@ -313,11 +314,21 @@ export class CoachService {
       list.push(n);
       notesByReport.set(n.reportId, list);
     }
-    return reports.map((r) => ({
-      ...r,
-      recordingUrl: recMap[r.id] ?? r.recordingUrl ?? "",
-      notes: (notesByReport.get(r.id) ?? []).map(CoachService.toNoteView),
-    }));
+    return reports.map((r) => {
+      // An explicit admin value (including an explicit clear to "") wins;
+      // otherwise fall back to any bundled URL, then to the leader's saved
+      // meeting link so every session auto-carries a recording link.
+      const explicit = recMap[r.id];
+      const recordingUrl =
+        explicit !== undefined
+          ? explicit
+          : r.recordingUrl || fallbackRecordingUrl || "";
+      return {
+        ...r,
+        recordingUrl,
+        notes: (notesByReport.get(r.id) ?? []).map(CoachService.toNoteView),
+      };
+    });
   }
 
   private static toNoteView(row: CoachNoteRow): CoachNoteView {
@@ -405,7 +416,9 @@ export class CoachService {
   async getReports(userId: string): Promise<CoachReport[] | null> {
     const record = await this.recordFor(userId);
     if (!record) return null;
-    return this.overlayReports(record.id, record.reports);
+    const stored = await this.coachRepository.getSettings(userId);
+    const fallback = stored?.zoomLink ?? record.zoomLink ?? "";
+    return this.overlayReports(record.id, record.reports, fallback);
   }
 
   async getTrends(userId: string): Promise<CoachTrends | null> {
@@ -447,7 +460,13 @@ export class CoachService {
   async getReportsById(coachId: string): Promise<CoachReport[] | null> {
     const record = await this.resolveById(coachId);
     if (!record) return null;
-    return this.overlayReports(record.id, record.reports);
+    // Auto-attach the leader's saved meeting link (looked up by their account
+    // email) so each session carries a recording link on the admin drill-in too.
+    const fallback =
+      (await this.coachRepository.getZoomLinkByEmail(record.email)) ||
+      record.zoomLink ||
+      "";
+    return this.overlayReports(record.id, record.reports, fallback);
   }
 
   /** A specific coach's trends by id (admin drill-in). null → unknown id. */

--- a/packages/backend-base/src/coach/repository/coach.repository.ts
+++ b/packages/backend-base/src/coach/repository/coach.repository.ts
@@ -75,6 +75,24 @@ export class CoachRepository {
       : null;
   }
 
+  /** The saved meeting link for the account whose email matches `email`
+   *  (case-insensitive), or "" when there is no matching account or no saved
+   *  link. Used to auto-attach a leader's recurring meeting link (where the
+   *  Fireflies Notetaker records) as the default recording link on each of
+   *  their sessions. */
+  async getZoomLinkByEmail(email: string): Promise<string> {
+    const target = email.trim().toLowerCase();
+    if (!target) return "";
+    const row = await this.db
+      .getOrCreateConnection()
+      .selectFrom("coach_zoom_links")
+      .innerJoin("user", "user.id", "coach_zoom_links.user_id")
+      .where(sql<boolean>`lower("user"."email") = ${target}`)
+      .select("coach_zoom_links.zoom_link")
+      .executeTakeFirst();
+    return row?.zoom_link ?? "";
+  }
+
   /** Upserts the link for a user and returns the stored value. */
   async setZoomLink(userId: string, zoomLink: string): Promise<string> {
     await this.db


### PR DESCRIPTION
Backend part of a three-item coach-portal batch (the frontend fixes are in `verse-mate/verse-mate-web` on the same branch).

## What
Sessions previously showed "No recording link yet" until an admin pasted a recording URL per session. Now each report falls back to the leader's saved Zoom/Fireflies meeting link (where the Notetaker records) when no explicit recording link is set, so every session auto-carries a link on both the leader dashboard and the admin drill-in.

## How
- `CoachRepository.getZoomLinkByEmail` — looks up a leader's saved meeting link by their account email (the admin path has the coach record but not the user id).
- `overlayReports` takes a `fallbackRecordingUrl`: an explicit admin value (including an explicit clear to `""`) still wins; otherwise a bundled URL, then the saved meeting link.
- `getReports` uses the signed-in user's stored settings; `getReportsById` resolves the leader's saved link by email.

No API/schema shape change — `recordingUrl` is already part of `ReportSchema`; this only changes how it's populated when otherwise empty.

## Testing
`bun test src/coach/coach.service.test.ts` — 18 passing, including 3 new cases (auto-attach when no explicit link; explicit link overrides; empty when the leader saved no link). `bun tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUygWrscmiBgWkCnfawEiw)_