### PR TITLE
feat(coach): expose completed months in monthly rollup

### DIFF
--- a/packages/backend-base/src/coach/coach.schema.ts
+++ b/packages/backend-base/src/coach/coach.schema.ts
@@ -160,4 +160,7 @@ export const MonthlySchema = t.Object({
     delta: t.Union([t.Number(), t.Null()]),
   }),
   leaders: t.Array(MonthlyLeaderSchema),
+  // Months (YYYY-MM) that actually have reports, newest first — drives the
+  // portal's month picker so only completed months are selectable.
+  availableMonths: t.Array(t.String()),
 });

--- a/packages/backend-base/src/coach/coach.service.test.ts
+++ b/packages/backend-base/src/coach/coach.service.test.ts
@@ -246,6 +246,35 @@ describe("CoachService admin oversight", () => {
     expect(await adminSvc.getTrendsById("nope")).toBeNull();
     expect(await adminSvc.getProfileById("nope")).toBeNull();
   });
+
+  it("lists only months that actually have reports (newest first)", async () => {
+    const monthly = await adminSvc.getMonthly("2026-07");
+    // Every listed month must be present in the underlying dataset — a month
+    // with no reports must never appear in the picker.
+    const reportMonths = new Set<string>();
+    for (const c of await adminSvc.listCoaches()) {
+      const reps = (await adminSvc.getReportsById(c.id)) ?? [];
+      for (const r of reps) reportMonths.add(r.date.slice(0, 7));
+    }
+    expect(monthly.availableMonths.length).toBeGreaterThan(0);
+    for (const m of monthly.availableMonths)
+      expect(reportMonths.has(m)).toBe(true);
+    expect(
+      [...monthly.availableMonths].sort((a, b) => (a < b ? 1 : -1)),
+    ).toEqual(monthly.availableMonths);
+    // A month the dataset never covers is absent.
+    expect(monthly.availableMonths).not.toContain("2025-12");
+  });
+
+  it("carries the same availableMonths regardless of which month is queried", async () => {
+    const jul = await adminSvc.getMonthly("2026-07");
+    const jan = await adminSvc.getMonthly("2026-01");
+    expect(jan.availableMonths).toEqual(jul.availableMonths);
+    // An empty month still reports zero leaders but the full picker list.
+    const empty = await adminSvc.getMonthly("2030-01");
+    expect(empty.leaders).toHaveLength(0);
+    expect(empty.availableMonths).toEqual(jul.availableMonths);
+  });
 });
 
 describe("CoachService recording-link auto-attach", () => {

--- a/packages/backend-base/src/coach/coach.service.ts
+++ b/packages/backend-base/src/coach/coach.service.ts
@@ -220,6 +220,10 @@ export interface CoachMonthly {
     delta: number | null;
   };
   leaders: MonthlyLeader[];
+  /** Every YYYY-MM month that has at least one report across the program,
+   *  newest first. Drives the portal's month picker so only months that were
+   *  actually done are offered — empty months are never selectable. */
+  availableMonths: string[];
 }
 
 export class CoachService {
@@ -623,13 +627,18 @@ export class CoachService {
     const records = await this.allRecords();
     const prev = CoachService.prevMonth(month);
 
-    // Canonical n→name map for the 12-dimension heatmap columns.
+    // Canonical n→name map for the 12-dimension heatmap columns, plus the set
+    // of months that actually have reports (for the picker).
     const dimNames = new Map<number, string>();
+    const monthSet = new Set<string>();
     for (const c of records)
-      for (const r of c.reports)
+      for (const r of c.reports) {
+        monthSet.add(r.date.slice(0, 7));
         for (const d of r.dimensions)
           if (!dimNames.has(d.n)) dimNames.set(d.n, d.name);
+      }
     const dimList = [...dimNames.entries()].sort((a, b) => a[0] - b[0]);
+    const availableMonths = [...monthSet].sort((a, b) => (a < b ? 1 : -1));
 
     const leaders: MonthlyLeader[] = [];
     let programSessions = 0;
@@ -717,6 +726,7 @@ export class CoachService {
             : null,
       },
       leaders,
+      availableMonths,
     };
   }
 


### PR DESCRIPTION
## Summary

The coaching portal's **Monthly Summary** screen let program admins step through calendar months with blind prev/next arrows, so they could land on months with no sessions (rendering "No sessions recorded") — and the current month before its first session, which is what left the page looking empty.

This backend change adds **`availableMonths`** to the `GET /coach/admin/monthly` response: the distinct `YYYY-MM` months that actually have reports across the whole program, newest first. The portal (verse-mate-web companion PR) uses it to offer a picker of only completed months.

## Changes

- **`coach.service.ts`** — while building the 12-dimension heatmap map, also collect the set of months that have at least one report; return them sorted newest-first as `availableMonths` on `CoachMonthly`. The list is program-wide, so it's identical in every response regardless of which month is queried.
- **`coach.schema.ts`** — declare `availableMonths` on `MonthlySchema`. Elysia strips any response field not present in the schema, so this is required for the field to reach the client.
- **`coach.service.test.ts`** — new tests asserting: every listed month actually has reports; the list is newest-first; and it's identical across queried months, including an empty future month (which still returns zero leaders but the full picker list).

## Testing

- `bun test src/coach/coach.service.test.ts` — 20 pass
- `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcgRnLpiKNMr9YQ6Ju7iZ8)_