### PR TITLE
fix(coach): let admins set church affiliation + Bible coach

### DIFF
--- a/packages/backend-base/src/coach/coach.service.ts
+++ b/packages/backend-base/src/coach/coach.service.ts
@@ -394,9 +394,10 @@ export class CoachService {
     // Authenticated but neither a coachee nor an admin → not a coaching account.
     if (!record && !admin) return null;
 
-    const stored = record
-      ? await this.coachRepository.getSettings(userId)
-      : null;
+    // Church + Bible-coach settings apply to any portal member (coachee OR
+    // admin), so fetch the stored row for admins too — not just coachees.
+    const stored =
+      record || admin ? await this.coachRepository.getSettings(userId) : null;
     return {
       isCoach: !!record,
       isAdmin: admin,
@@ -784,12 +785,18 @@ export class CoachService {
     return this.coachRepository.setZoomLink(userId, zoomLink);
   }
 
+  /** True when the user belongs to the coach portal at all — a coachee OR a
+   *  program admin. Church + Bible-coach settings are writable by both. */
+  private async isPortalMember(userId: string): Promise<boolean> {
+    if (await this.recordFor(userId)) return true;
+    return this.isAdmin(userId);
+  }
+
   async setAffiliatedChurch(
     userId: string,
     affiliatedChurch: string,
   ): Promise<string | null> {
-    const record = await this.recordFor(userId);
-    if (!record) return null;
+    if (!(await this.isPortalMember(userId))) return null;
     return this.coachRepository.setAffiliatedChurch(userId, affiliatedChurch);
   }
 
@@ -797,8 +804,7 @@ export class CoachService {
     userId: string,
     bibleCoach: string,
   ): Promise<string | null> {
-    const record = await this.recordFor(userId);
-    if (!record) return null;
+    if (!(await this.isPortalMember(userId))) return null;
     return this.coachRepository.setBibleCoach(userId, bibleCoach);
   }
 


### PR DESCRIPTION
## What & why

The church-affiliation and Bible-coach settings are per-account fields that apply to any coach-portal member, but their setters were gated on the caller being a **coachee**. A program admin (`isAdmin`, not in the coachee roster — e.g. the program owner) got a 403 on save, and `getMe` never loaded their stored values. So on the Coach Settings page an admin saw only the profile, with Church affiliation and Bible coach missing.

## Changes

- `getMe()` now loads the stored settings row for **admins as well as coachees** (previously only coachees), so their saved church + Bible coach come back.
- `setAffiliatedChurch()` / `setBibleCoach()` accept any portal member via a new `isPortalMember()` guard (coachee OR admin) instead of requiring a coachee record.

Pairs with the verse-mate/verse-mate-web fix that ungates the same two sections on the Coach Settings page.

## Testing

- `bun tsc` — clean (also via the pre-commit hook).
- `bun test src/coach/coach.service.test.ts` — 20 pass.
- `biome check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7tuzvvzMwpK9RqG1ryYWc)_