### PR TITLE
ci(backend): implement production deploy so merges actually roll out

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -12,6 +12,14 @@
 #   OBJECT_STORAGE_ENDPOINT          - Object storage endpoint URL
 #   OBJECT_STORAGE_BUCKET            - Object storage bucket name
 #   OBJECT_STORAGE_REGION            - Object storage region
+#
+# Optional GitHub Secrets (production deploy — see the deploy job):
+#   SSH_PRIVATE_KEY   - Private key authorized on the production host. When
+#                       unset, the deploy job skips (build + push still run),
+#                       so CI stays green until deploy is configured.
+#   DEPLOY_HOST       - Production host (default: app.versemate.org)
+#   DEPLOY_USER       - SSH user (default: root)
+#   DEPLOY_PATH       - Compose project dir on the host (default: ~/verse-mate)
 
 name: Backend CI/CD
 
@@ -321,21 +329,48 @@ jobs:
         run: docker push ${{ secrets.DO_REGISTRY }}/${{ secrets.DO_REGISTRY_IMAGE }}-backend:${{ github.ref_name }}
 
   # ============================================
-  # DEPLOY PLACEHOLDER JOB
-  # Placeholder for future SSH deployment automation
+  # DEPLOY JOB
+  # Rolls the freshly-pushed image onto the production host over SSH:
+  #   cd <path> && docker compose pull && docker compose up -d && docker system prune -a -f
   #
-  # Future deployment implementation (reference from .drone.yml):
-  # 1. Install SSH client: apk add openssh
-  # 2. Configure SSH key from secrets
-  # 3. SSH to server: ssh root@app.versemate.org
-  #    "cd ~/verse-mate && docker compose pull && docker compose up -d && docker system prune -a -f"
-  # Required secrets for future: SSH_PRIVATE_KEY
+  # Runs only on pushes to the main branch (not on version tags, whose image
+  # is pushed under a different tag than the server's compose references).
+  # Gated on SSH_PRIVATE_KEY: when the secret is absent the job logs a warning
+  # and succeeds without deploying, so the pipeline stays green until an
+  # operator configures the deploy secrets (see the header for the full list).
   # ============================================
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
     needs: [docker-push]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - name: Deploy placeholder
-        run: echo "TODO - Implement deployment"
+      - name: Check deploy configuration
+        id: cfg
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: |
+          if [ -n "$SSH_PRIVATE_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::SSH_PRIVATE_KEY is not set — skipping production deploy. Add the SSH_PRIVATE_KEY secret to enable automatic roll-out."
+          fi
+
+      - name: Deploy to production over SSH
+        if: steps.cfg.outputs.enabled == 'true'
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        run: |
+          set -euo pipefail
+          HOST="${DEPLOY_HOST:-app.versemate.org}"
+          USER="${DEPLOY_USER:-root}"
+          DIR="${DEPLOY_PATH:-~/verse-mate}"
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new "$USER@$HOST" \
+            "cd $DIR && docker compose pull && docker compose up -d && docker system prune -a -f"


### PR DESCRIPTION
## Problem

The coach **Monthly Summary** page shows *"Something went wrong loading your coaching data"* in production, even though `/coach/admin/monthly` is correct and green in CI. Root cause is **not** the endpoint — it's the deploy pipeline.

The backend `deploy` job in `.github/workflows/backend-ci.yml` was a placeholder:

```yaml
- name: Deploy placeholder
  run: echo "TODO - Implement deployment"
```

So every merge to `main`:
1. ✅ builds the backend image and **pushes it to the registry** (`docker-push` job), but
2. ❌ **never rolls that image onto the production host** — the deploy step did nothing.

That's why routes added after the last *manual* server roll-out are live in the registry but return 404 in prod:

| Route | Shipped | Live in prod? |
|---|---|---|
| `/coach/admin/coaches` (roster) | #273 · Jul 19 | ✅ from an already-deployed image |
| `/coach/admin/monthly` | #290 · Jul 21 | ❌ never rolled out |

Both live in the same file, so this is purely a deploy gap, not a code bug. (The Monthly Summary endpoint + `availableMonths` picker from #293/#261 are already merged and correct.)

## Change

Replace the placeholder with the SSH roll-out the workflow comment already documented:

```
cd <path> && docker compose pull && docker compose up -d && docker system prune -a -f
```

- **Main-only** — runs on push to `main`, not on version tags (whose image tag differs from what the server's compose references).
- **Safe by default** — gated on `SSH_PRIVATE_KEY`. When the secret is absent the job logs a `::warning::` and **succeeds without deploying**, so the currently-green pipeline is never broken; it activates automatically once the secret is configured.
- **Configurable** — `DEPLOY_HOST` / `DEPLOY_USER` / `DEPLOY_PATH` optional secrets, defaulting to `app.versemate.org` / `root` / `~/verse-mate`. New secrets documented in the workflow header.

## Follow-up required to actually go live

This PR makes deploys *possible*; an operator still needs to add the `SSH_PRIVATE_KEY` repo secret (a key authorized on the production host). Until then, the already-built image can be rolled out manually:

```bash
ssh root@app.versemate.org "cd ~/verse-mate && docker compose pull && docker compose up -d"
```

## Testing

- Workflow YAML validated (parses; `deploy` job gated on `push` + `refs/heads/main`, two steps).
- No application code changed — backend build/test/tsc/lint/stylelint jobs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcgRnLpiKNMr9YQ6Ju7iZ8)_