### PR TITLE
fix(user): return is_admin from GET /user/me so admins can reach the admin app

### DIFF
--- a/packages/backend-base/src/user/user.service.ts
+++ b/packages/backend-base/src/user/user.service.ts
@@ -24,6 +24,10 @@ export class UserService {
       lastName: user.lastName,
       fullName: `${user.firstName} ${user.lastName}`,
       emailVerified: user.emailVerified,
+      // The admin app's middleware gates every route on GET /user/me
+      // returning is_admin — omitting it locked out every admin.
+      is_admin: user.is_admin,
+      preferred_language: user.preferred_language,
     };
   }
 


### PR DESCRIPTION
## Problem

`admin.versemate.org` rejects **every** admin with *"Admin access required. Sign in with an admin account."* — including accounts with `is_admin = true` in the production database. All three admin accounts are locked out. Reported today by two of them independently.

## Root cause

The admin middleware added in #231 (VERA-22) gates every non-public route on `GET ${API_URL}/user/me` returning `is_admin === true`:

```ts
const body = (await res.json()) as { is_admin?: boolean };
return body.is_admin === true;
```

`UserService.findOne()` — which backs that endpoint — does `selectAll()` and then builds its return literal **without `is_admin`**:

```ts
return {
  id: user.id, email: user.email, firstName: user.firstName,
  lastName: user.lastName, fullName: `…`, emailVerified: user.emailVerified,
};   // no is_admin
```

So `body.is_admin` is always `undefined`, `undefined === true` is `false`, and the middleware redirects to `/login?error=admin_required` **and deletes the access-token cookie** — which is why it also feels like the login "didn't take".

Why it slipped through review and CI: `user-response.schema.ts` declares `is_admin` as `t.Optional(t.Boolean())`, so omitting it is not a type error and `bun tsc` stays green. `GET /auth/session` (`AuthService.getUserById`) *does* select `is_admin`, so the flag looks present if you check from there. `findOne()` has not changed since 2025-10-20 — it never returned the field; the gate that depends on it landed 2026-05-12, and admin has been unreachable since.

## Fix

Return `is_admin` (and `preferred_language`, the same schema-declared omission) from `findOne()`.

## Testing

Local stack — postgres + valkey, backend on `:4000`, `frontend-next` on `:3000` with `API_URL=http://localhost:4000`; two seeded users, `is_admin` true and false. A/B by reverting only this change, same cookie, same URL:

| `GET /admin` | before | after |
|---|---|---|
| admin cookie | `307 → /login?error=admin_required` | **`200`** |
| non-admin cookie | `307 → /login?error=admin_required` | `307 → /login?error=admin_required` |
| no cookie | `307 → /login` | `307 → /login` |

Payload from `GET /user/me` for the `is_admin = true` user:

```
before: {"id":"…","email":"admintest@local.test",…,"emailVerified":true}
after:  {"id":"…","email":"admintest@local.test",…,"is_admin":true,"preferred_language":null}
```

Non-admins are still denied — the gate is fixed, not weakened.

- `bunx tsc --noEmit` clean
- `biome check` clean
- `bun test src/user/` → 23/23 pass

## Follow-ups (not in this PR)

- `AuthService.validateUser()` looks up the login email with an exact match and no `.toLowerCase().trim()`, while the SSO path normalizes. Against production, `sebastian.boghiu@gmail.com` returns 401 (found) but `Sebastian.boghiu@gmail.com` returns 404 *"User not found"*, which the UI renders as *"No account found with this email address"* — any autocapitalized input looks like a deleted account.
- `AuthLoginInput.password` is capped at `maxLength: 20`, so a longer password returns `422 VALIDATION_ERROR` before credentials are ever checked — a second failure mode that reads as a broken login.
- Consider making `is_admin` required in `user-response.schema.ts` so this class of omission fails typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)