### PR TITLE
fix(admin): mount QueryClientProvider so admin tabs stop crashing

### DIFF
--- a/apps/frontend-next/src/app/layout.tsx
+++ b/apps/frontend-next/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import "frontend-base/styles/global.css";
-import { Notifications } from "frontend-base/admin";
+import { Notifications, QueryProvider } from "frontend-base/admin";
 import { $env, type Env, StoreInitializer } from "frontend-envs";
 import type { Metadata } from "next";
 
@@ -43,8 +43,10 @@ export default function RootLayout({
       </head>
       <StoreInitializer {...envValues} />
       <body>
-        {children}
-        <Notifications />
+        <QueryProvider>
+          {children}
+          <Notifications />
+        </QueryProvider>
       </body>
     </html>
   );

--- a/packages/frontend-base/admin/index.ts
+++ b/packages/frontend-base/admin/index.ts
@@ -16,6 +16,11 @@
 // Admin shell + dashboard
 export { AdminDashboard } from "../src/ui/admin/AdminDashboard/AdminDashboard";
 export { AdminGuard } from "../src/ui/AdminGuard/AdminGuard";
+// react-query provider every admin page needs (Audio, Daily Verses, Topics,
+// Notifications, Auto-Highlights all use useQuery/useMutation).
+// ponytail: still lives under src/Main (end-user tree) — move it out with the
+// rest of VERA-21 rather than duplicating a second QueryClient here.
+export { QueryProvider } from "../src/Main/Providers/useQueryProvider";
 
 // Admin feature modules
 export { BatchOperations } from "../src/ui/admin/BatchOperations/BatchOperations";


### PR DESCRIPTION
## Problem

Reported by Sebastian: clicking **Audio**, **Daily Verses**, **Notifications** or **Topics** in the admin dashboard blows up with

> Oops! Something went wrong — No QueryClient set, use QueryClientProvider to set one

## Root cause

`70950285` (VERA-22, "strip end-user routes; admin-only middleware") deleted `apps/frontend-next/src/app/components/MainPage.tsx`, which was the **only** place mounting `MainPage.QueryProvider`. The rewritten root layout renders `{children}` bare, so every admin tab that calls a react-query hook throws during render:

| Tab | Hook |
|---|---|
| Audio | `useAdminAudio` |
| Daily Verses | `useQuery`/`useMutation` |
| Topics | `useQuery`/`useMutation` |
| Notifications | `useQuery`/`useMutation` |
| Auto-Highlights | `useAutoHighlights` |

Batch Operations / Explanations / Prompts / Playground / User Management don't use react-query — which is why only *some* tabs broke.

## Fix

Mount the existing `frontend-base` `QueryProvider` once in the admin root layout (covers every current and future admin route, not just the four reported tabs), and export it from the `frontend-base/admin` barrel.

Reused the existing provider rather than newing up a `QueryClient` in the app so the PostHog query/mutation error tracking stays wired to a single client.

## Verification

Temporary throwaway route under `/auth/callback/*` (public per middleware) rendering all four react-query tabs through the real root layout, against `next dev`:

- **without** the wrapper → `HTTP 500`, body contains `No QueryClient set, use QueryClientProvider to set one` (reproduces the report exactly)
- **with** the wrapper → `HTTP 200`, all four render their loading states

Temp route deleted before commit. Also clean: `bunx tsc` (monorepo root), `biome check`, `next build` (all 5 routes prerender).

Not covered: a click-through of the live dashboard with a real admin session — the four tab components are the same ones exercised above.