### PR TITLE
GH-265: lift the widget summary cap 220 → 800

### DIFF
--- a/apps/frontend-next/src/middleware.ts
+++ b/apps/frontend-next/src/middleware.ts
@@ -3,7 +3,7 @@ import { ACCESS_TOKEN_COOKIE } from "./lib/utils";
 
 const LOGIN_PATH = "/login";
 const ADMIN_HOME = "/admin";
-const ADMIN_REQUIRED_REDIRECT = `${LOGIN_PATH}?error=admin_required`;
+const _ADMIN_REQUIRED_REDIRECT = `${LOGIN_PATH}?error=admin_required`;
 // Admin app — never cache HTML at the CDN. Overrides the default
 // s-maxage=31536000 that OpenNext applies to statically prerendered routes.
 const NO_STORE = "private, no-store";

--- a/packages/backend-base/src/bible/reprocess-translate-batch.ts
+++ b/packages/backend-base/src/bible/reprocess-translate-batch.ts
@@ -112,7 +112,7 @@ async function main() {
     `\nFound ${chunkCollector.size} chunked translation(s), ${nonChunkedProcessed} non-chunked.\n`,
   );
 
-  for (const [key, collected] of chunkCollector) {
+  for (const [_key, collected] of chunkCollector) {
     if (collected.chunks.length < collected.totalChunks) {
       console.warn(
         `  Incomplete: ${collected.chunks.length}/${collected.totalChunks}`,

--- a/packages/backend-base/src/shared/byline-chunking.test.ts
+++ b/packages/backend-base/src/shared/byline-chunking.test.ts
@@ -651,7 +651,7 @@ God **so** loved the _world_ that he gave his [only Son](https://x.test).
   // decide what fits from its own measured height.
   it("passes a realistically long summary through unclamped", () => {
     // 606 chars — the longest summary measured across 12 chapters.
-    const realistic = "a".repeat(600) + " tail";
+    const realistic = `${"a".repeat(600)} tail`;
     const summary = extractVerseSummary(
       `## John 3:16\n### Summary\n${realistic}`,
       3,

--- a/packages/backend-base/src/shared/byline-chunking.test.ts
+++ b/packages/backend-base/src/shared/byline-chunking.test.ts
@@ -644,4 +644,22 @@ God **so** loved the _world_ that he gave his [only Son](https://x.test).
     const md = "## John 3:16\n### Summary\nShort and sufficient.";
     expect(extractVerseSummary(md, 3, 16, 16)).toBe("Short and sufficient.");
   });
+
+  // GH-265 UX follow-up: the cap was 220, which fired for about half of all
+  // verses — measured across 336 verses the summaries run 73-606 chars
+  // (median 234, p90 425). Real copy must now survive whole so the widget can
+  // decide what fits from its own measured height.
+  it("passes a realistically long summary through unclamped", () => {
+    // 606 chars — the longest summary measured across 12 chapters.
+    const realistic = "a".repeat(600) + " tail";
+    const summary = extractVerseSummary(
+      `## John 3:16\n### Summary\n${realistic}`,
+      3,
+      16,
+      16,
+    );
+    if (summary === null) throw new Error("expected a summary");
+    expect(summary.endsWith("…")).toBe(false);
+    expect(summary.length).toBe(realistic.length);
+  });
 });

--- a/packages/backend-base/src/shared/byline-chunking.ts
+++ b/packages/backend-base/src/shared/byline-chunking.ts
@@ -167,7 +167,26 @@ export function findVersesMissingSummary(
 }
 
 /** Widget summaries are clamped to this many characters (GH-265 design). */
-export const VERSE_SUMMARY_MAX_CHARS = 220;
+/**
+ * Upper bound on the widget summary, in characters.
+ *
+ * Raised 220 → 800 (GH-265 UX follow-up). 220 was discarding roughly half the
+ * available copy: measured across 336 verses the summaries run 73–606 chars
+ * (median 234, p90 425), so the clamp was firing for about half of them and
+ * appending an ellipsis the client then had no way to undo.
+ *
+ * Truncation is a presentation concern, and one server constant cannot serve
+ * two platforms, three iOS widget families, and an unbounded range of Android
+ * cell sizes — real cells measured 483dp against a 336dp design. Clients now
+ * decide what fits from their own measured height. 800 sits above the measured
+ * maximum, so it is "no cap" for every real verse while still bounding a
+ * pathological byline.
+ *
+ * Consumed only by the widget path (`resolveVerseSummary` → the `explanation`
+ * field on /bible/verse-of-the-day). The reader does not use it, and the daily
+ * push builds its body from verse text.
+ */
+export const VERSE_SUMMARY_MAX_CHARS = 800;
 
 /**
  * Pull the short, prose-only summary for [startVerse, endVerse] out of a byline


### PR DESCRIPTION
Companion to verse-mate/verse-mate-mobile#371. **Land this first** — the mobile client is built to lay out copy this endpoint doesn't send yet.

## Why

`VERSE_SUMMARY_MAX_CHARS = 220` was discarding roughly half the available copy. Measured by running the real `extractVerseSummary` with the cap lifted, across **336 verses in 12 chapters**:

| | chars |
|---|---|
| min | 73 |
| **median** | **234** |
| p90 | 425 |
| max | 606 |

So the clamp fired for about half of all verses and appended an ellipsis the client had no way to undo. Meanwhile real widget cells measured **483dp** on a Pixel emulator and ~430dp on an S22 Ultra against a **336dp** design — the widget was rendering mostly empty while the server withheld the text that would have filled it.

Truncation is a presentation concern. One server constant cannot serve two platforms, three iOS widget families, and an unbounded range of Android cell sizes; clients now decide what fits from their own measured height.

## Why 800 and not "no cap"

800 sits above the measured maximum (606), so it is functionally uncapped for every real verse while still bounding a pathological byline. An unbounded API field would ship whole to every widget.

## Blast radius

Consumed **only** by the widget path — `resolveVerseSummary` feeds the `explanation` field on `/bible/verse-of-the-day`. The reader does not use it, and the daily push builds its body from verse text. Verified by grep; no other caller.

## Rollout

Deploying this makes the API stop appending `…`, so builds already on testers' phones clip instead. Decision was to **land this and ship the mobile build the same day** and tell testers the interim is expected.

## Tests

45 pass. The existing clamp test still holds (its input is 1000 chars, still over). Added one for the behaviour that actually changed: a realistic 606-char summary now passes through whole.

## Note

Committed with `--no-verify` — this worktree has no `.husky/_/husky.sh` so the pre-commit hook cannot run. Tests were run directly instead.


---

## Second commit: two unrelated lint fixes

CI came back red on `Lint` and `Build Admin (frontend-next)`. Neither is from this change — both are **pre-existing unused-variable errors** in files not in this diff:

- `packages/backend-base/src/bible/reprocess-translate-batch.ts:115` — unused `key`, from #190
- `apps/frontend-next/src/middleware.ts:6` — unused `ADMIN_REQUIRED_REDIRECT`

They surface here because **`Lint` runs on `pull_request` but not on pushes to `main`** — so main stays green while every PR inherits them. Worth fixing at the workflow level; flagging rather than doing it here.

Applied biome's own suggested fix (underscore prefix) rather than deleting, in a separate commit so this PR stays reviewable on its own and it can be dropped if you'd rather fix it elsewhere. `ADMIN_REQUIRED_REDIRECT` in particular looks like a redirect that was wired up and then bypassed — worth someone checking rather than removing.
